### PR TITLE
Plan: Integrate msvcup into pcons as a contrib module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         run: uv sync
       - name: Run tests
-        run: uv run pytest --cov=pcons --cov-report=xml
+        run: uv run pytest --cov=pcons --cov-report=xml -k "not 21_msvcup_hello"
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.11'
         uses: codecov/codecov-action@v4
@@ -63,9 +63,26 @@ jobs:
           file: coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-msvcup:
+    name: "test msvcup (windows, no VS)"
+    needs: lint
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      # No MSVC setup - msvcup installs its own toolchain
+      - name: Set Python version
+        run: uv python install 3.14
+      - name: Install dependencies
+        run: uv sync
+      - name: Run msvcup example tests
+        run: uv run pytest tests/test_examples.py -k "21_msvcup_hello" tests/contrib/test_msvcup.py -v
+
   release:
     name: Create Release & Publish
-    needs: test
+    needs: [test, test-msvcup]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:

--- a/examples/21_msvcup_hello/pcons-build.py
+++ b/examples/21_msvcup_hello/pcons-build.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: MIT
+"""Example: Building with msvcup-managed MSVC toolchain.
+
+This example downloads and installs the MSVC compiler via msvcup,
+then builds a simple C program. No Visual Studio installation required.
+Works on both x64 and ARM64 Windows machines -- target_cpu is auto-detected.
+"""
+
+import os
+import sys
+
+from pcons import Generator, Project, find_c_toolchain
+
+if sys.platform == "win32":
+    from pcons.contrib.windows.msvcup import ensure_msvc
+
+    # target_cpu auto-detected: x64 on x86_64, arm64 on ARM64
+    ensure_msvc("14.44.17.14", "10.0.22621.7")
+
+project = Project("hello", build_dir=os.environ.get("PCONS_BUILD_DIR", "build"))
+env = project.Environment(toolchain=find_c_toolchain())
+project.Program("hello", env, sources=["src/hello.c"])
+Generator().generate(project)

--- a/examples/21_msvcup_hello/src/hello.c
+++ b/examples/21_msvcup_hello/src/hello.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+
+int main(void) {
+#ifdef _MSC_VER
+    printf("Hello from MSVC %d (full: %d)\n", _MSC_VER, _MSC_FULL_VER);
+#else
+    printf("Hello (not MSVC)\n");
+#endif
+    return 0;
+}

--- a/examples/21_msvcup_hello/test.toml
+++ b/examples/21_msvcup_hello/test.toml
@@ -1,0 +1,24 @@
+# Test configuration for the msvcup_hello example
+
+[test]
+description = "Demonstrates building with msvcup-managed MSVC (no Visual Studio required)"
+# msvcup downloads MSVC + SDK on first run, which can take a while
+timeout = 300
+
+# Files that should exist after the build
+expected_outputs = [
+    "build/obj.hello/hello.obj",
+    "build/hello.exe",
+]
+
+[verify]
+# Run the built program and check output
+commands = [
+    { run = "./build/hello.exe", expect_stdout = "Hello from MSVC" },
+]
+
+[skip]
+# Only run on Windows -- msvcup is Windows-only
+platforms = ["linux", "darwin"]
+# Xcode and Make generators not applicable
+generators = ["xcode", "make"]

--- a/pcons/contrib/windows/__init__.py
+++ b/pcons/contrib/windows/__init__.py
@@ -3,6 +3,7 @@
 
 This package provides helpers for Windows development:
 - manifest: Windows SxS manifest generation (app and assembly manifests)
+- msvcup: MSVC toolchain installation via msvcup (no Visual Studio required)
 
 Usage:
     from pcons.contrib.windows import manifest
@@ -19,8 +20,13 @@ Usage:
     app = project.Program("myapp", env)
     app.add_sources(["src/main.c", app_manifest])
 
+    # Install MSVC without Visual Studio (call before find_c_toolchain)
+    from pcons.contrib.windows.msvcup import ensure_msvc
+    ensure_msvc("14.44.17.14", "10.0.22621.7")
+
 Available modules:
     - manifest: Windows SxS manifest generation
+    - msvcup: MSVC toolchain installation via msvcup
 """
 
 from __future__ import annotations
@@ -32,4 +38,4 @@ def list_modules() -> list[str]:
     Returns:
         List of module names in the windows package.
     """
-    return ["manifest"]
+    return ["manifest", "msvcup"]

--- a/pcons/contrib/windows/msvcup.py
+++ b/pcons/contrib/windows/msvcup.py
@@ -1,0 +1,275 @@
+# SPDX-License-Identifier: MIT
+"""MSVC toolchain installation via msvcup.
+
+Downloads and installs the MSVC compiler and Windows SDK without
+requiring Visual Studio. Uses msvcup's autoenv to generate standalone
+wrapper executables (cl.exe, link.exe, etc.) that work from any prompt.
+
+Usage:
+    from pcons.contrib.windows.msvcup import ensure_msvc
+
+    # In pcons-build.py, before find_c_toolchain():
+    ensure_msvc("14.44.17.14", "10.0.22621.7")
+    toolchain = find_c_toolchain()  # Finds cl.exe from msvcup
+
+See https://github.com/marler8997/msvcup for more information.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import sys
+import urllib.request
+import zipfile
+from pathlib import Path
+
+from pcons.configure.platform import get_platform
+
+logger = logging.getLogger(__name__)
+
+
+class MsvcUp:
+    """Manage MSVC toolchain installation via msvcup.
+
+    Downloads and installs the MSVC compiler and Windows SDK
+    without requiring Visual Studio. Uses autoenv to make tools
+    available in PATH.
+
+    Example::
+
+        from pcons.contrib.windows.msvcup import ensure_msvc
+
+        # In pcons-build.py, before find_c_toolchain():
+        ensure_msvc("14.44.17.14", "10.0.22621.7")
+        toolchain = find_c_toolchain()  # Finds cl.exe from msvcup
+    """
+
+    # msvcup hardcodes C:\msvcup as its install directory (no override flag).
+    # We use the same path for bootstrap (storing msvcup.exe itself) and for
+    # knowing where autoenv output goes.
+    MSVCUP_DIR = r"C:\msvcup"
+    RELEASE_URL = (
+        "https://github.com/marler8997/msvcup/releases/download"
+        "/{version}/msvcup-{host_arch}-windows.zip"
+    )
+
+    # Map pcons platform.arch -> msvcup host arch for download URL
+    _HOST_ARCH_MAP: dict[str, str] = {
+        "x86_64": "x86_64",
+        "arm64": "aarch64",
+    }
+
+    # Map pcons platform.arch -> msvcup --target-cpu value
+    _TARGET_CPU_MAP: dict[str, str] = {
+        "x86_64": "x64",
+        "arm64": "arm64",
+    }
+
+    _MANIFEST_UPDATE_VALUES = ("off", "daily", "always")
+
+    def __init__(
+        self,
+        msvc_version: str,
+        sdk_version: str,
+        *,
+        target_cpu: str | None = None,
+        msvcup_version: str = "v2026_02_07",
+        lock_file: str | Path | None = None,
+        manifest_update: str = "off",
+    ) -> None:
+        if manifest_update not in self._MANIFEST_UPDATE_VALUES:
+            msg = (
+                f"manifest_update must be one of {self._MANIFEST_UPDATE_VALUES}, "
+                f"got {manifest_update!r}"
+            )
+            raise ValueError(msg)
+        self._msvc_version = msvc_version
+        self._sdk_version = sdk_version
+        self._target_cpu = target_cpu
+        self._msvcup_version = msvcup_version
+        self._lock_file = Path(lock_file) if lock_file is not None else None
+        self._manifest_update = manifest_update
+
+    def ensure_installed(self) -> Path:
+        """Ensure msvcup and the specified toolchain are installed.
+
+        Returns the autoenv directory (containing cl.exe, link.exe, etc.).
+        Also prepends it to PATH so ``find_c_toolchain()`` discovers the tools.
+        """
+        msvcup_exe = self._bootstrap_msvcup()
+        self._run_install(msvcup_exe)
+        autoenv_dir = self._run_autoenv(msvcup_exe)
+        self._add_to_path(autoenv_dir)
+        return autoenv_dir
+
+    # -- Architecture helpers -------------------------------------------------
+
+    def _resolve_target_cpu(self) -> str:
+        """Resolve target_cpu from host architecture if not explicitly set."""
+        if self._target_cpu is not None:
+            return self._target_cpu
+        arch = get_platform().arch
+        cpu = self._TARGET_CPU_MAP.get(arch)
+        if cpu is None:
+            msg = f"Unsupported host architecture for msvcup: {arch}"
+            raise RuntimeError(msg)
+        return cpu
+
+    def _resolve_host_arch(self) -> str:
+        """Resolve host architecture for the msvcup download URL."""
+        arch = get_platform().arch
+        host_arch = self._HOST_ARCH_MAP.get(arch)
+        if host_arch is None:
+            msg = f"No msvcup binary available for architecture: {arch}"
+            raise RuntimeError(msg)
+        return host_arch
+
+    # -- Bootstrap ------------------------------------------------------------
+
+    def _bootstrap_msvcup(self) -> Path:
+        """Download msvcup.exe if not already present."""
+        msvcup_dir = Path(self.MSVCUP_DIR)
+        msvcup_exe = msvcup_dir / "bin" / "msvcup.exe"
+        if msvcup_exe.exists():
+            return msvcup_exe
+
+        host_arch = self._resolve_host_arch()
+        zip_url = self.RELEASE_URL.format(
+            version=self._msvcup_version,
+            host_arch=host_arch,
+        )
+        cache_dir = msvcup_dir / "cache"
+        zip_path = cache_dir / f"msvcup-{self._msvcup_version}.zip"
+
+        try:
+            zip_path.parent.mkdir(parents=True, exist_ok=True)
+        except PermissionError:
+            msg = (
+                f"Cannot create {msvcup_dir}. msvcup requires write access "
+                r"to C:\msvcup. You may need to run once with admin privileges, "
+                r"or pre-create C:\msvcup with appropriate permissions."
+            )
+            raise PermissionError(msg) from None
+
+        logger.info("Downloading msvcup %s for %s...", self._msvcup_version, host_arch)
+        urllib.request.urlretrieve(zip_url, zip_path)  # noqa: S310
+
+        msvcup_exe.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(zip_path) as zf:
+            # The zip contains msvcup.exe at the top level
+            for name in zf.namelist():
+                if name.endswith("msvcup.exe"):
+                    with zf.open(name) as src, open(msvcup_exe, "wb") as dst:
+                        dst.write(src.read())
+                    break
+            else:
+                msg = f"msvcup.exe not found in {zip_path}"
+                raise FileNotFoundError(msg)
+
+        logger.info("Installed msvcup to %s", msvcup_exe)
+        return msvcup_exe
+
+    # -- Install + autoenv ----------------------------------------------------
+
+    def _run_install(self, msvcup_exe: Path) -> None:
+        """Run msvcup install with specified versions."""
+        lock_file = self._lock_file or Path(self.MSVCUP_DIR) / "msvcup.lock"
+        cmd = [
+            str(msvcup_exe),
+            "install",
+            "--lock-file",
+            str(lock_file),
+            f"--manifest-update-{self._manifest_update}",
+        ]
+        cmd.extend(
+            [
+                f"msvc-{self._msvc_version}",
+                f"sdk-{self._sdk_version}",
+            ]
+        )
+        logger.info(
+            "Installing MSVC %s + SDK %s...", self._msvc_version, self._sdk_version
+        )
+        subprocess.run(cmd, check=True)
+
+    def _run_autoenv(self, msvcup_exe: Path) -> Path:
+        """Run msvcup autoenv to generate wrapper executables."""
+        target_cpu = self._resolve_target_cpu()
+        msvcup_dir = Path(self.MSVCUP_DIR)
+        autoenv_dir = msvcup_dir / f"autoenv-{target_cpu}"
+        cmd = [
+            str(msvcup_exe),
+            "autoenv",
+            "--target-cpu",
+            target_cpu,
+            "--out-dir",
+            str(autoenv_dir),
+            f"msvc-{self._msvc_version}",
+            f"sdk-{self._sdk_version}",
+        ]
+        logger.info("Setting up autoenv for %s...", target_cpu)
+        subprocess.run(cmd, check=True)
+        return autoenv_dir
+
+    # -- PATH -----------------------------------------------------------------
+
+    def _add_to_path(self, autoenv_dir: Path) -> None:
+        """Prepend autoenv directory to PATH."""
+        current_path = os.environ.get("PATH", "")
+        autoenv_str = str(autoenv_dir)
+        if autoenv_str not in current_path:
+            os.environ["PATH"] = autoenv_str + os.pathsep + current_path
+            logger.info("Added %s to PATH", autoenv_dir)
+
+
+def ensure_msvc(
+    msvc_version: str,
+    sdk_version: str,
+    *,
+    target_cpu: str | None = None,
+    msvcup_version: str = "v2026_02_07",
+    lock_file: str | Path | None = None,
+    manifest_update: str = "off",
+) -> Path:
+    r"""Ensure MSVC toolchain is installed and in PATH.
+
+    Call this before ``find_c_toolchain()`` in your ``pcons-build.py``.
+
+    Note: msvcup installs to ``C:\msvcup`` (hardcoded in msvcup itself).
+    On most Windows systems this is writable by regular users, since the
+    default ACLs on ``C:\`` allow authenticated users to create new
+    directories.  In restricted environments, admin access may be needed
+    for the first run.
+
+    Args:
+        msvc_version: MSVC version (e.g., ``"14.44.17.14"``).
+        sdk_version: Windows SDK version (e.g., ``"10.0.22621.7"``).
+        target_cpu: Target CPU architecture.  Auto-detected from host
+            if not specified (x64 on x86_64, arm64 on arm64).
+            Can be set explicitly for cross-compilation.
+        msvcup_version: msvcup release tag (default: latest known).
+        lock_file: Path to lock file for reproducible installs.
+        manifest_update: Manifest update policy: ``"off"`` (default),
+            ``"daily"``, or ``"always"``.
+
+    Returns:
+        Path to autoenv directory containing wrapper executables.
+
+    Raises:
+        PermissionError: If ``C:\msvcup`` cannot be created.
+    """
+    if sys.platform != "win32":
+        logger.debug("msvcup: not on Windows, skipping")
+        return Path()
+
+    up = MsvcUp(
+        msvc_version,
+        sdk_version,
+        target_cpu=target_cpu,
+        msvcup_version=msvcup_version,
+        lock_file=lock_file,
+        manifest_update=manifest_update,
+    )
+    return up.ensure_installed()

--- a/tests/contrib/test_msvcup.py
+++ b/tests/contrib/test_msvcup.py
@@ -1,0 +1,282 @@
+# SPDX-License-Identifier: MIT
+"""Tests for pcons.contrib.windows.msvcup."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from pcons.contrib.windows.msvcup import MsvcUp, ensure_msvc
+
+
+class TestMsvcUpInit:
+    """Tests for MsvcUp construction."""
+
+    def test_basic_init(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        assert up._msvc_version == "14.44.17.14"
+        assert up._sdk_version == "10.0.22621.7"
+        assert up._target_cpu is None
+        assert up._msvcup_version == "v2026_02_07"
+        assert up._lock_file is None
+
+    def test_init_with_all_options(self):
+        up = MsvcUp(
+            "14.44.17.14",
+            "10.0.22621.7",
+            target_cpu="arm64",
+            msvcup_version="v2025_09_04",
+            lock_file="msvcup.lock",
+        )
+        assert up._target_cpu == "arm64"
+        assert up._msvcup_version == "v2025_09_04"
+        assert up._lock_file == Path("msvcup.lock")
+
+
+class TestArchDetection:
+    """Tests for architecture auto-detection."""
+
+    def test_resolve_target_cpu_x86_64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="x86_64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            assert up._resolve_target_cpu() == "x64"
+
+    def test_resolve_target_cpu_arm64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="arm64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            assert up._resolve_target_cpu() == "arm64"
+
+    def test_resolve_target_cpu_explicit_override(self):
+        """Explicit target_cpu bypasses auto-detection."""
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", target_cpu="arm64")
+        # Should return "arm64" without calling get_platform at all
+        assert up._resolve_target_cpu() == "arm64"
+
+    def test_resolve_target_cpu_cross_compile(self):
+        """x86_64 host targeting arm64."""
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", target_cpu="arm64")
+        mock_platform = MagicMock(arch="x86_64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            assert up._resolve_target_cpu() == "arm64"
+
+    def test_resolve_target_cpu_unsupported_arch(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="riscv64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            with pytest.raises(RuntimeError, match="Unsupported host architecture"):
+                up._resolve_target_cpu()
+
+    def test_resolve_host_arch_x86_64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="x86_64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            assert up._resolve_host_arch() == "x86_64"
+
+    def test_resolve_host_arch_arm64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="arm64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            assert up._resolve_host_arch() == "aarch64"
+
+    def test_resolve_host_arch_unsupported(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        mock_platform = MagicMock(arch="riscv64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            with pytest.raises(RuntimeError, match="No msvcup binary available"):
+                up._resolve_host_arch()
+
+
+class TestDownloadUrl:
+    """Tests for download URL construction."""
+
+    def test_url_x86_64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v2026_02_07")
+        mock_platform = MagicMock(arch="x86_64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            host_arch = up._resolve_host_arch()
+            url = up.RELEASE_URL.format(version=up._msvcup_version, host_arch=host_arch)
+            assert url == (
+                "https://github.com/marler8997/msvcup/releases/download"
+                "/v2026_02_07/msvcup-x86_64-windows.zip"
+            )
+
+    def test_url_arm64(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v2026_02_07")
+        mock_platform = MagicMock(arch="arm64")
+        with patch(
+            "pcons.contrib.windows.msvcup.get_platform", return_value=mock_platform
+        ):
+            host_arch = up._resolve_host_arch()
+            url = up.RELEASE_URL.format(version=up._msvcup_version, host_arch=host_arch)
+            assert url == (
+                "https://github.com/marler8997/msvcup/releases/download"
+                "/v2026_02_07/msvcup-aarch64-windows.zip"
+            )
+
+
+class TestCommandConstruction:
+    """Tests for subprocess command construction."""
+
+    @patch("subprocess.run")
+    def test_install_command(self, mock_run: MagicMock):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        msvcup_exe = Path(r"C:\msvcup\bin\msvcup.exe")
+        up._run_install(msvcup_exe)
+        default_lock = str(Path(MsvcUp.MSVCUP_DIR) / "msvcup.lock")
+        mock_run.assert_called_once_with(
+            [
+                str(msvcup_exe),
+                "install",
+                "--lock-file",
+                default_lock,
+                "--manifest-update-off",
+                "msvc-14.44.17.14",
+                "sdk-10.0.22621.7",
+            ],
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_install_command_with_lock_file(self, mock_run: MagicMock):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", lock_file="msvcup.lock")
+        msvcup_exe = Path(r"C:\msvcup\bin\msvcup.exe")
+        up._run_install(msvcup_exe)
+        mock_run.assert_called_once_with(
+            [
+                str(msvcup_exe),
+                "install",
+                "--lock-file",
+                "msvcup.lock",
+                "--manifest-update-off",
+                "msvc-14.44.17.14",
+                "sdk-10.0.22621.7",
+            ],
+            check=True,
+        )
+
+    @patch("subprocess.run")
+    def test_autoenv_command_x64(self, mock_run: MagicMock):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", target_cpu="x64")
+        msvcup_exe = Path(r"C:\msvcup\bin\msvcup.exe")
+        autoenv_dir = up._run_autoenv(msvcup_exe)
+        # Compare as strings: on Linux, Path("C:\msvcup") / "autoenv-x64"
+        # uses forward slashes; on Windows it uses backslashes. Both are fine.
+        assert str(autoenv_dir).endswith("autoenv-x64")
+        assert "msvcup" in str(autoenv_dir)
+        args = mock_run.call_args[0][0]
+        assert args[0] == str(msvcup_exe)
+        assert args[1:3] == ["autoenv", "--target-cpu"]
+        assert args[3] == "x64"
+        assert args[4] == "--out-dir"
+        assert args[5] == str(autoenv_dir)
+        assert args[6:] == ["msvc-14.44.17.14", "sdk-10.0.22621.7"]
+
+    @patch("subprocess.run")
+    def test_autoenv_command_arm64(self, mock_run: MagicMock):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", target_cpu="arm64")
+        msvcup_exe = Path(r"C:\msvcup\bin\msvcup.exe")
+        autoenv_dir = up._run_autoenv(msvcup_exe)
+        assert str(autoenv_dir).endswith("autoenv-arm64")
+        args = mock_run.call_args[0][0]
+        assert args[3] == "arm64"
+        assert args[6:] == ["msvc-14.44.17.14", "sdk-10.0.22621.7"]
+
+
+class TestPathModification:
+    """Tests for PATH environment variable modification."""
+
+    def test_add_to_path_prepends(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        autoenv_dir = Path(r"C:\msvcup\autoenv-x64")
+        original_path = os.environ.get("PATH", "")
+        try:
+            os.environ["PATH"] = r"C:\Windows\system32"
+            up._add_to_path(autoenv_dir)
+            assert os.environ["PATH"].startswith(str(autoenv_dir))
+            assert os.environ["PATH"].endswith(r"C:\Windows\system32")
+        finally:
+            os.environ["PATH"] = original_path
+
+    def test_add_to_path_idempotent(self):
+        up = MsvcUp("14.44.17.14", "10.0.22621.7")
+        autoenv_dir = Path(r"C:\msvcup\autoenv-x64")
+        original_path = os.environ.get("PATH", "")
+        try:
+            os.environ["PATH"] = str(autoenv_dir) + os.pathsep + r"C:\Windows\system32"
+            up._add_to_path(autoenv_dir)
+            # Should not add a second copy
+            assert os.environ["PATH"].count(str(autoenv_dir)) == 1
+        finally:
+            os.environ["PATH"] = original_path
+
+
+class TestEnsureMsvc:
+    """Tests for the ensure_msvc convenience function."""
+
+    def test_non_windows_returns_empty_path(self):
+        """On non-Windows, ensure_msvc is a no-op."""
+        with patch("pcons.contrib.windows.msvcup.sys") as mock_sys:
+            mock_sys.platform = "linux"
+            result = ensure_msvc("14.44.17.14", "10.0.22621.7")
+            assert result == Path()
+
+    def test_non_windows_skips_on_real_platform(self):
+        """On the actual non-Windows test platform, ensure_msvc skips."""
+        if sys.platform == "win32":
+            pytest.skip("Test only applicable on non-Windows")
+        result = ensure_msvc("14.44.17.14", "10.0.22621.7")
+        assert result == Path()
+
+    @patch.object(MsvcUp, "ensure_installed")
+    def test_windows_delegates_to_msvcup(self, mock_ensure: MagicMock):
+        """On Windows, ensure_msvc delegates to MsvcUp.ensure_installed."""
+        mock_ensure.return_value = Path(r"C:\msvcup\autoenv-x64")
+        with patch("pcons.contrib.windows.msvcup.sys") as mock_sys:
+            mock_sys.platform = "win32"
+            result = ensure_msvc(
+                "14.44.17.14",
+                "10.0.22621.7",
+                target_cpu="x64",
+                msvcup_version="v2025_09_04",
+            )
+            assert result == Path(r"C:\msvcup\autoenv-x64")
+            mock_ensure.assert_called_once()
+
+
+class TestModuleImport:
+    """Tests for module importability."""
+
+    def test_importable_on_all_platforms(self):
+        """Module should be importable regardless of platform."""
+        from pcons.contrib.windows import msvcup  # noqa: F811
+
+        assert hasattr(msvcup, "ensure_msvc")
+        assert hasattr(msvcup, "MsvcUp")
+
+    def test_listed_in_windows_modules(self):
+        """msvcup should be listed in the windows contrib package."""
+        from pcons.contrib.windows import list_modules
+
+        assert "msvcup" in list_modules()

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -443,12 +443,13 @@ def run_example(
         "PCONS_GENERATOR": generator,
     }
 
+    timeout = test_config.get("timeout", 60)
     result = subprocess.run(
         cmd,
         cwd=work_dir,
         capture_output=True,
         text=True,
-        timeout=60,
+        timeout=timeout,
         env=env,
     )
 


### PR DESCRIPTION
## Summary

Add `pcons.contrib.windows.msvcup` module that downloads and installs the MSVC compiler and Windows SDK via [msvcup](https://github.com/marler8997/msvcup), without requiring a Visual Studio installation.

- `MsvcUp` class and `ensure_msvc()` convenience function
- Auto-detection of host/target architecture (x64/arm64)
- Bootstrap: downloads `msvcup.exe` from GitHub releases
- Autoenv: generates wrapper executables (`cl.exe`, `link.exe`, etc.)
- PATH integration for seamless `find_c_toolchain()` discovery
- Lock file and manifest update policy support (`--lock-file`, `--manifest-update-off`)
- Example project (`examples/21_msvcup_hello/`)
- Comprehensive unit tests (23 tests)
- Dedicated CI job ("test msvcup (windows, no VS)") that runs without Visual Studio
- Configurable `timeout` field in `test.toml` for example tests
- User guide documentation (usage, version pinning, lock files, cross-compilation, CI)

## Test plan

- [x] Unit tests pass on all platforms (23 tests in `tests/contrib/test_msvcup.py`)
- [x] Integration test passes on Windows CI without Visual Studio pre-installed
- [x] Main test matrix excludes msvcup example (skipped via `-k` filter)
- [x] All existing tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)