### PR TITLE
Add `import std;` support for GCC

### DIFF
--- a/examples/32_cxx_import_std/pcons-build.py
+++ b/examples/32_cxx_import_std/pcons-build.py
@@ -8,25 +8,37 @@ This exercises pcons's standard-library module support across toolchains:
   - On clang/libc++, pcons consults `libc++.modules.json` (queried via
     `clang++ -stdlib=libc++ -print-file-name=c++/libc++.modules.json`),
     locates `std.cppm`, builds it, and links the resulting `.o`.
+  - On GCC/libstdc++ (>= 14), pcons probes `#include <bits/std.cc>` via
+    `-E -x c++ - -H`, compiles the discovered source with `-fmodules`,
+    and links the resulting `.o`. GCC writes `gcm.cache/std.gcm` next to
+    the build directory automatically.
 
 The user code itself is portable: a single-module library that exposes
 `greet()`, and a `main` that uses `std::println` (C++23). Both files use
 `import std;` — pcons + the toolchain do the rest.
 """
 
-from pcons import Project
+from pcons import Project, get_var
 from pcons.toolchains import find_c_toolchain
 
 project = Project("cxx_import_std")
-# Prefer MSVC on Windows (its `import std;` lives in std.ixx and works
-# out of the box). Elsewhere, prefer LLVM/Clang with libc++.
-toolchain = find_c_toolchain(prefer=["msvc", "llvm"])
+
+# Optional override: pcons build TOOLCHAIN=gcc|llvm|msvc
+toolchain_override = get_var("TOOLCHAIN")
+if toolchain_override:
+    toolchain = find_c_toolchain(prefer=[toolchain_override])
+else:
+    # Prefer MSVC on Windows (its `import std;` lives in std.ixx and works
+    # out of the box). Elsewhere, prefer LLVM/Clang with libc++, then GCC.
+    toolchain = find_c_toolchain(prefer=["msvc", "llvm", "gcc"])
 env = project.Environment(toolchain=toolchain)
 
 if toolchain.name == "msvc":
     env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
-else:
+elif toolchain.name == "llvm":
     env.cxx.flags.extend(["-std=c++23", "-stdlib=libc++"])
+else:
+    env.cxx.flags.append("-std=c++23")
 
 project.Program(
     "hello",

--- a/examples/32_cxx_import_std/pcons-build.py
+++ b/examples/32_cxx_import_std/pcons-build.py
@@ -37,6 +37,7 @@ if toolchain.name == "msvc":
     env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
 elif toolchain.name == "llvm":
     env.cxx.flags.extend(["-std=c++23", "-stdlib=libc++"])
+    env.link.libs.append("c++")
 else:
     env.cxx.flags.append("-std=c++23")
 

--- a/examples/32_cxx_import_std/pcons-build.py
+++ b/examples/32_cxx_import_std/pcons-build.py
@@ -8,7 +8,7 @@ This exercises pcons's standard-library module support across toolchains:
   - On clang/libc++, pcons consults `libc++.modules.json` (queried via
     `clang++ -stdlib=libc++ -print-file-name=c++/libc++.modules.json`),
     locates `std.cppm`, builds it, and links the resulting `.o`.
-  - On GCC/libstdc++ (>= 14), pcons probes `#include <bits/std.cc>` via
+  - On GCC/libstdc++ (>= 15), pcons probes `#include <bits/std.cc>` via
     `-E -x c++ - -H`, compiles the discovered source with `-fmodules`,
     and links the resulting `.o`. GCC writes `gcm.cache/std.gcm` next to
     the build directory automatically.

--- a/examples/32_cxx_import_std/test.toml
+++ b/examples/32_cxx_import_std/test.toml
@@ -1,7 +1,7 @@
 # Test configuration for the cxx_import_std example
 
 [test]
-description = "C++23 import std; — clang+libc++ and MSVC paths"
+description = "C++23 import std; — multi-toolchain support (clang, gcc, msvc)"
 
 expected_outputs = [
     "build/obj.hello/src/Greet.cppm.o",
@@ -9,15 +9,16 @@ expected_outputs = [
     "build/hello",
 ]
 
+[toolchains]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+windows = ["msvc"]
+
 [verify]
 commands = [
     { run = "./build/hello", expect_exit_code = 0, expect_output_contains = "Hello, modules!" },
 ]
 
 [skip]
-requires = ["clang-scan-deps", "clang++"]
-# clang `import std;` needs libc++.modules.json — Apple Clang doesn't ship it.
-# On macOS this means brew LLVM; on Linux a recent libc++. The custom check
-# probes the available clang and skips when the manifest can't be located.
-requires_libcxx_std_module = true
 generators = ["xcode", "make"]
+requires_cxx_std_module = true

--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: MIT
 """C++20 module dependency scanner for Ninja dyndep.
 
-Supports two scanner styles:
+Supports three scanner styles:
 - "clang": uses clang-scan-deps (P1689R5 format); manifest uses "pcm" key
 - "msvc":  uses cl.exe /scanDependencies <file> (P1689R5 format); manifest uses "ifc" key
+- "gcc":   uses g++ with -fdeps-format=p1689r5 and reads a deps JSON file
 
 Run as:
     python -m pcons.toolchains.cxx_module_scanner \\
@@ -181,6 +182,92 @@ def run_scan_deps_msvc(
         ) from e
     finally:
         Path(tmp_path).unlink(missing_ok=True)
+
+
+def run_scan_deps_gcc(
+    compiler: str,
+    compile_flags: list[str],
+    src: str,
+    obj: str,
+) -> dict[str, Any] | None:
+    """Run GCC p1689 scan and return parsed JSON.
+
+    Args:
+        compiler: Path/name of g++.
+        compile_flags: List of compiler flags (e.g. ["-std=c++23"]).
+        src: Absolute path to the source file.
+        obj: Object file path relative to the build directory.
+
+    Returns:
+        Parsed P1689R5 JSON dict, or None on failure.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f_deps:
+        deps_json = f_deps.name
+    with tempfile.NamedTemporaryFile(suffix=".d", delete=False) as f_depfile:
+        depfile = f_depfile.name
+    with tempfile.NamedTemporaryFile(suffix=".ii", delete=False) as f_pp:
+        preprocessed = f_pp.name
+
+    try:
+        cmd = [compiler]
+        cmd += compile_flags
+        cmd += [
+            "-E",
+            "-x",
+            "c++",
+            src,
+            "-MT",
+            obj,
+            "-MD",
+            "-MF",
+            depfile,
+            "-fmodules",
+            f"-fdeps-file={deps_json}",
+            f"-fdeps-target={obj}",
+            "-fdeps-format=p1689r5",
+            "-o",
+            preprocessed,
+        ]
+
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            print(
+                f"Warning: GCC p1689 scan failed for {src}: {result.stderr}",
+                file=sys.stderr,
+            )
+            return None
+
+        try:
+            return json.loads(Path(deps_json).read_text(encoding="utf-8"))
+        except json.JSONDecodeError as e:
+            print(
+                f"Warning: could not parse GCC p1689 output for {src}: {e}",
+                file=sys.stderr,
+            )
+            return None
+        except OSError as e:
+            print(
+                f"Warning: could not read GCC p1689 output for {src}: {e}",
+                file=sys.stderr,
+            )
+            return None
+    except FileNotFoundError as e:
+        raise CxxModuleScannerNotFound(
+            f"GCC compiler '{compiler}' not found on PATH.\n"
+            "  C++20 module scanning needs g++ with p1689 support.\n"
+            "  Install hints:\n"
+            "    Ubuntu/Deb:   apt install g++\n"
+            "    Fedora/RHEL:  dnf install gcc-c++\n"
+            "    macOS:        brew install gcc"
+        ) from e
+    finally:
+        Path(deps_json).unlink(missing_ok=True)
+        Path(depfile).unlink(missing_ok=True)
+        Path(preprocessed).unlink(missing_ok=True)
 
 
 # =============================================================================
@@ -410,6 +497,13 @@ def scan_translation_units(
     for spec in specs:
         if scanner_style == "msvc":
             p1689 = run_scan_deps_msvc(spec.compiler, spec.compile_flags, str(spec.src))
+        elif scanner_style == "gcc":
+            p1689 = run_scan_deps_gcc(
+                spec.compiler,
+                spec.compile_flags,
+                str(spec.src),
+                spec.obj_rel,
+            )
         else:
             p1689 = run_scan_deps(
                 scanner,
@@ -746,8 +840,8 @@ def main() -> int:
     parser.add_argument(
         "--scanner-style",
         default="clang",
-        choices=["clang", "msvc"],
-        help="Scanner style: 'clang' (clang-scan-deps) or 'msvc' (cl.exe) (default: clang)",
+        choices=["clang", "msvc", "gcc"],
+        help="Scanner style: 'clang' (clang-scan-deps), 'msvc' (cl.exe), or 'gcc' (default: clang)",
     )
     args = parser.parse_args()
 

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -426,7 +426,7 @@ class GccToolchain(UnixToolchain):
     def __init__(self) -> None:
         super().__init__("gcc")
 
-    def get_source_handler(self, suffix: str) -> Any:
+    def get_source_handler(self, suffix: str) -> SourceHandler | None:
         """Return handler for source file suffix, including C++20 module interfaces."""
         from pcons.tools.toolchain import CXX_MODULE_INTERFACE_SUFFIXES
 
@@ -435,8 +435,6 @@ class GccToolchain(UnixToolchain):
             return handler
 
         if suffix in CXX_MODULE_INTERFACE_SUFFIXES:
-            from pcons.tools.toolchain import SourceHandler
-
             return SourceHandler(
                 "cxx", "cxx_module", ".o", TargetPath(suffix=".d"), "gcc"
             )
@@ -467,7 +465,7 @@ class GccToolchain(UnixToolchain):
                 all module-participating object nodes.
             6. Wires the std object into link inputs of importing targets.
 
-        Requires GCC 14+ (which ships ``bits/std.cc`` as part of libstdc++).
+        Requires GCC 15+ (which ships ``bits/std.cc`` as part of libstdc++).
         """
         from pcons.toolchains.cxx_module_scanner import (
             TuScanSpec,
@@ -568,7 +566,7 @@ class GccToolchain(UnixToolchain):
         # std/std.compat provides/requires relationships accurately.
         if std_obj_nodes:
             std_specs: list[TuScanSpec] = []
-            for logical, std_obj_node in std_obj_nodes.items():
+            for _logical, std_obj_node in std_obj_nodes.items():
                 std_bi = std_obj_node._build_info
                 assert std_bi is not None
                 std_src = std_bi["sources"][0].path
@@ -665,8 +663,8 @@ class GccToolchain(UnixToolchain):
                     f"'bits/{'std.cc' if logical == 'std' else 'std.compat.cc'}' "
                     f"via GCC include tracing:\n"
                     f"    {compiler_cmd} ... -E -x c++ - -H  (with #include <bits/...>)\n"
-                    f"Requires GCC 14+ with libstdc++ headers installed. "
-                    f"On Ubuntu/Debian: apt install gcc g++ libstdc++-14-dev"
+                    f"Requires GCC 15+ with libstdc++ headers installed. "
+                    f"On Ubuntu/Debian: apt install gcc g++ libstdc++-15-dev"
                 )
 
             obj_rel = f"{moddir}/{logical}.o"
@@ -726,7 +724,7 @@ class GccToolchain(UnixToolchain):
 # Registration
 # =============================================================================
 
-from pcons.tools.toolchain import toolchain_registry  # noqa: E402
+from pcons.tools.toolchain import SourceHandler, toolchain_registry  # noqa: E402
 
 toolchain_registry.register(
     GccToolchain,

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -10,7 +10,10 @@ Provides GCC-based C and C++ compilation toolchain including:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import logging
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from pcons.configure.platform import get_platform
 from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
@@ -20,7 +23,92 @@ from pcons.tools.tool import BaseTool
 
 if TYPE_CHECKING:
     from pcons.core.builder import Builder
+    from pcons.core.environment import Environment
+    from pcons.core.node import FileNode
+    from pcons.core.project import Project
     from pcons.core.toolconfig import ToolConfig
+
+logger = logging.getLogger(__name__)
+
+
+def _gcc_std_module_flag_spec() -> Any:
+    """Build the GCC/libstdc++ flag-passthrough spec for std-module compiles.
+
+    ABI-affecting flags that must match between the std-module compile and
+    the user TUs that import it. Mirrors the clang spec but without
+    -stdlib= (not a GCC flag) and with GCC-specific ABI knobs.
+    """
+    from pcons.toolchains.cxx_module_scanner import StdModuleFlagSpec
+
+    return StdModuleFlagSpec(
+        exact=frozenset(
+            {
+                "-fexceptions",
+                "-fno-exceptions",
+                "-frtti",
+                "-fno-rtti",
+                "-pthread",
+                "-fopenmp",
+                "-m32",
+                "-m64",
+            }
+        ),
+        prefixes=(
+            "-std=",
+            "--target=",
+            "--sysroot=",
+            "-march=",
+            "-mcpu=",
+            "-mtune=",
+        ),
+        paired=frozenset({"-target", "--sysroot"}),
+        # Pass user -D_GLIBCXX_* / -D__GLIBCXX_* defines: libstdc++ uses
+        # these for hardening, debug modes, etc. that affect module ABI.
+        define_prefix="-D",
+        define_glob_prefixes=("_GLIBCXX_", "__GLIBCXX_"),
+    )
+
+
+def _find_gcc_std_module_source(
+    compiler_cmd: str,
+    logical: str,
+    base_flags: list[str],
+) -> Path | None:
+    """Locate bits/std.cc (or bits/std.compat.cc) from GCC include tracing.
+
+    GCC's p1689 scan output does not carry the standard-library source path.
+    Probe the active C++ include root using ``-E -x c++ - -H`` and derive the
+    module source from that include root.
+    """
+
+    source_name = "std.cc" if logical == "std" else "std.compat.cc"
+    filename = f"bits/{source_name}"
+
+    try:
+        proc = subprocess.run(
+            [
+                compiler_cmd,
+                *base_flags,
+                "-E",
+                "-x",
+                "c++",
+                "-",
+                "-H",
+            ],
+            input=f"#include <{filename}>\n",
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return None
+
+    for line in proc.stderr.splitlines():
+        line = line.strip()
+        if not line.startswith(". "):
+            continue
+        return Path(line[2:])
+    return None
 
 
 class GccCCompiler(BaseTool):
@@ -337,6 +425,278 @@ class GccToolchain(UnixToolchain):
 
     def __init__(self) -> None:
         super().__init__("gcc")
+
+    def get_source_handler(self, suffix: str) -> Any:
+        """Return handler for source file suffix, including C++20 module interfaces."""
+        from pcons.tools.toolchain import CXX_MODULE_INTERFACE_SUFFIXES
+
+        handler = super().get_source_handler(suffix)
+        if handler is not None:
+            return handler
+
+        if suffix in CXX_MODULE_INTERFACE_SUFFIXES:
+            from pcons.tools.toolchain import SourceHandler
+
+            return SourceHandler(
+                "cxx", "cxx_module", ".o", TargetPath(suffix=".d"), "gcc"
+            )
+
+        return None
+
+    def after_resolve(
+        self,
+        project: Project,
+        source_obj_by_language: dict[str, list[tuple[Path, FileNode]]],
+    ) -> None:
+        """Configure `import std;` / `import std.compat;` support for GCC.
+
+        Triggered when module scanning is enabled — either implicitly (the
+        env has a C++ module-interface source such as ``.cppm``) or
+        explicitly (``env.cxx.modules = True``). The method:
+
+            1. Uses GCC's p1689 scanner mode (``-fdeps-format=p1689r5``)
+                to discover module provides/requires for each TU.
+            2. Locates the corresponding ``bits/std.cc`` /
+                ``bits/std.compat.cc`` source via the preprocessor.
+            3. Synthesizes a build node that compiles the std module with
+                ``-fmodules``.  GCC automatically places the resulting
+                ``std.gcm`` in ``gcm.cache/`` relative to the build dir,
+                where Ninja runs.
+            4. Adds ``-fmodules`` to every qualifying C++ TU.
+            5. Writes Ninja dyndep from the scan results and attaches it to
+                all module-participating object nodes.
+            6. Wires the std object into link inputs of importing targets.
+
+        Requires GCC 14+ (which ships ``bits/std.cc`` as part of libstdc++).
+        """
+        from pcons.toolchains.cxx_module_scanner import (
+            TuScanSpec,
+            build_module_map,
+            scan_translation_units,
+            select_modules_scope,
+            wire_std_into_targets,
+            write_dyndep_from_results,
+        )
+
+        cxx_module_pairs, cxx_pairs = select_modules_scope(source_obj_by_language)
+        all_cxx_pairs = cxx_module_pairs + cxx_pairs
+        if not all_cxx_pairs:
+            return
+
+        build_dir = project.build_dir
+        moddir = "cxx_modules"
+        dyndep_path = build_dir / "cxx_modules.dyndep"
+        dyndep_rel = "cxx_modules.dyndep"
+        (build_dir / moddir).mkdir(parents=True, exist_ok=True)
+
+        first_env = None
+        _, first_obj = all_cxx_pairs[0]
+        build_info = getattr(first_obj, "_build_info", None)
+        if build_info:
+            first_env = build_info.get("env")
+
+        cxx_tool = getattr(first_env, "cxx", None) if first_env else None
+        compiler_cmd = str(getattr(cxx_tool, "cmd", "g++") or "g++")
+        base_flags = list(getattr(cxx_tool, "flags", None) or [])
+
+        # Enable modules for all participating C++ TUs.
+        modules_flag = "-fmodules"
+        for _, obj_node in all_cxx_pairs:
+            bi = getattr(obj_node, "_build_info", None)
+            if bi is None:
+                continue
+            context = bi.get("context")
+            if context is not None and hasattr(context, "flags"):
+                if modules_flag not in context.flags:
+                    context.flags.append(modules_flag)
+            # Let dyndep drive module dependencies for these TUs. GCC depfiles
+            # conflict with module implicit outputs on Ninja for these edges.
+            bi["deps_style"] = None
+            bi["depfile"] = None
+
+        # Build per-TU scan specs and run GCC p1689 scanning.
+        specs: list[TuScanSpec] = []
+        spec_to_obj: dict[int, FileNode] = {}
+        for src, obj_node in all_cxx_pairs:
+            bi = getattr(obj_node, "_build_info", None)
+            context = bi.get("context") if bi else None
+            seen: set[str] = set(base_flags)
+            compile_flags = list(base_flags)
+            if modules_flag not in seen:
+                compile_flags.append(modules_flag)
+                seen.add(modules_flag)
+            if context:
+                for f in context.flags:
+                    if f not in seen:
+                        compile_flags.append(f)
+                        seen.add(f)
+                for inc in context.includes:
+                    compile_flags.append(f"-I{inc}")
+                for d in context.defines:
+                    compile_flags.append(f"-D{d}")
+
+            spec = TuScanSpec(
+                src=src.resolve(),
+                obj_rel=str(obj_node.path.relative_to(build_dir)).replace("\\", "/"),
+                compiler=compiler_cmd,
+                compile_flags=compile_flags,
+            )
+            specs.append(spec)
+            spec_to_obj[id(spec)] = obj_node
+
+        results = scan_translation_units(
+            specs, scanner=compiler_cmd, scanner_style="gcc"
+        )
+
+        required_logical_names: set[str] = set()
+        for r in results:
+            required_logical_names.update(r.required_logical_names)
+        std_wanted = required_logical_names & {"std", "std.compat"}
+
+        std_obj_nodes = self._inject_gcc_std_module_builds(
+            project,
+            build_dir,
+            moddir,
+            compiler_cmd,
+            base_flags,
+            std_wanted,
+            first_env,
+            cxx_tool,
+        )
+
+        # Scan synthesized std module sources too, so dyndep can capture
+        # std/std.compat provides/requires relationships accurately.
+        if std_obj_nodes:
+            std_specs: list[TuScanSpec] = []
+            for logical, std_obj_node in std_obj_nodes.items():
+                std_bi = std_obj_node._build_info
+                assert std_bi is not None
+                std_src = std_bi["sources"][0].path
+                std_obj_rel = str(std_obj_node.path.relative_to(build_dir)).replace(
+                    "\\", "/"
+                )
+                std_spec = TuScanSpec(
+                    src=std_src,
+                    obj_rel=std_obj_rel,
+                    compiler=compiler_cmd,
+                    compile_flags=[*base_flags, modules_flag],
+                )
+                std_specs.append(std_spec)
+                spec_to_obj[id(std_spec)] = std_obj_node
+
+            results.extend(
+                scan_translation_units(
+                    std_specs,
+                    scanner=compiler_cmd,
+                    scanner_style="gcc",
+                )
+            )
+
+        module_to_gcm = build_module_map(results, "gcm.cache", ".gcm")
+        write_dyndep_from_results(results, module_to_gcm, dyndep_path)
+        logger.debug("Wrote GCC C++ module dyndep to %s", dyndep_path)
+
+        dyndep_node = project.node(dyndep_path)
+        for _, obj_node in all_cxx_pairs:
+            bi = getattr(obj_node, "_build_info", None)
+            if bi is not None:
+                bi["dyndep"] = dyndep_rel
+            if dyndep_node not in obj_node.implicit_deps:
+                obj_node.implicit_deps.append(dyndep_node)
+        for std_obj_node in std_obj_nodes.values():
+            std_bi = std_obj_node._build_info
+            assert std_bi is not None
+            std_bi["dyndep"] = dyndep_rel
+            if dyndep_node not in std_obj_node.implicit_deps:
+                std_obj_node.implicit_deps.append(dyndep_node)
+
+        if std_obj_nodes:
+            wire_std_into_targets(project, results, spec_to_obj, std_obj_nodes)
+
+    def _inject_gcc_std_module_builds(
+        self,
+        project: Project,
+        build_dir: Path,
+        moddir: str,
+        compiler_cmd: str,
+        base_flags: list[str],
+        wanted: set[str],
+        first_env: Environment | None,
+        cxx_tool: Any,
+    ) -> dict[str, FileNode]:
+        """Synthesize build nodes for ``import std;`` / ``import std.compat;`` (GCC).
+
+        For each logical module name in *wanted* (``"std"`` or
+        ``"std.compat"``):
+
+        * Locates the corresponding libstdc++ source via the preprocessor.
+        * Creates a build node that compiles it with ``-fmodules`` and the
+          user's ABI-affecting flags.  GCC automatically writes
+          ``gcm.cache/<logical>.gcm`` next to the build directory CWD.
+
+        Returns a ``{logical_name: obj_node}`` dict for the modules that
+        were successfully synthesized.
+        """
+        from pcons.toolchains.cxx_module_scanner import (
+            select_std_module_flags,
+        )
+
+        if not wanted:
+            return {}
+
+        # Carry ABI-affecting flags onto the std-module compile.
+        env_defines = list(getattr(cxx_tool, "defines", None) or [])
+        dprefix = str(getattr(cxx_tool, "dprefix", "-D") or "-D")
+        all_user_flags = list(base_flags) + [f"{dprefix}{d}" for d in env_defines]
+
+        passthrough = select_std_module_flags(
+            all_user_flags, _gcc_std_module_flag_spec()
+        )
+        if not any(f.startswith("-std=") for f in passthrough):
+            passthrough.insert(0, "-std=c++23")
+
+        std_obj_nodes: dict[str, FileNode] = {}
+        for logical in sorted(wanted):
+            src_path = _find_gcc_std_module_source(compiler_cmd, logical, base_flags)
+            if src_path is None:
+                raise RuntimeError(
+                    f"`import {logical};` was used, but pcons could not locate "
+                    f"the GCC standard-library module source. Tried resolving "
+                    f"'bits/{'std.cc' if logical == 'std' else 'std.compat.cc'}' "
+                    f"via GCC include tracing:\n"
+                    f"    {compiler_cmd} ... -E -x c++ - -H  (with #include <bits/...>)\n"
+                    f"Requires GCC 14+ with libstdc++ headers installed. "
+                    f"On Ubuntu/Debian: apt install gcc g++ libstdc++-14-dev"
+                )
+
+            obj_rel = f"{moddir}/{logical}.o"
+            obj_path = build_dir / obj_rel
+
+            std_obj_node = project.node(obj_path)
+            cmd_list: list[str] = [
+                compiler_cmd,
+                *passthrough,
+                "-fmodules",
+                "-x",
+                "c++",
+                str(src_path),
+                "-c",
+                "-o",
+                obj_rel,
+            ]
+            std_obj_node._build_info = {
+                "tool": "cxx",
+                "command_var": "stdmodcmd",
+                "description": f"CXX {logical} module",
+                "sources": [project.node(src_path)],
+                "command": cmd_list,
+            }
+            if first_env is not None:
+                first_env.register_node(std_obj_node)
+
+            std_obj_nodes[logical] = std_obj_node
+
+        return std_obj_nodes
 
     def _configure_tools(self, config: object) -> bool:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -43,23 +43,63 @@ def _gcc_std_module_flag_spec() -> Any:
     return StdModuleFlagSpec(
         exact=frozenset(
             {
+                # Exceptions / RTTI
                 "-fexceptions",
                 "-fno-exceptions",
                 "-frtti",
                 "-fno-rtti",
+                # Threading / parallelism
                 "-pthread",
                 "-fopenmp",
+                # Data model / ABI width
                 "-m32",
                 "-m64",
+                # Layout / type ABI
+                "-fshort-enums",
+                "-fshort-wchar",
+                "-fpack-struct",
+                "-funsigned-char",
+                "-fsigned-char",
+                "-funsigned-bitfields",
+                "-mms-bitfields",
+                # Visibility / symbol ABI
+                "-fvisibility-inlines-hidden",
+                # Floating point ABI
+                "-msoft-float",
+                "-mhard-float",
+                # Experimental language features
+                "-fimplicit-constexpr",
+                "-freflection",
+                "-fcontracts",
+                # Debug / sanitizer ABI modifiers
+                "-fno-semantic-interposition",
+                "-flto",
             }
         ),
         prefixes=(
+            # Language / dialect
             "-std=",
+            # Target / sysroot
             "--target=",
             "--sysroot=",
+            # CPU / architecture / ABI
             "-march=",
             "-mcpu=",
             "-mtune=",
+            "-mabi=",
+            "-mfpmath=",
+            "-mfloat-abi=",
+            # C++ ABI
+            "-fabi-version=",
+            "-fabi-compat-version=",
+            # Visibility
+            "-fvisibility=",
+            # TLS ABI
+            "-ftls-model=",
+            # Warnings affecting ABI diagnostics
+            "-Wabi=",
+            # Sanitizers
+            "-fsanitize=",
         ),
         paired=frozenset({"-target", "--sysroot"}),
         # Pass user -D_GLIBCXX_* / -D__GLIBCXX_* defines: libstdc++ uses
@@ -100,15 +140,20 @@ def _find_gcc_std_module_source(
             text=True,
             check=True,
         )
-    except (FileNotFoundError, subprocess.CalledProcessError):
+        lines = proc.stderr.splitlines()
+        line = lines[0] if lines else ""
+    except FileNotFoundError:
         return None
+    except subprocess.CalledProcessError as e:
+        # note: the command may fail, with an error looking like 'module control-line cannot be in included file'
+        #       but we still have the resolution at the first line
+        lines = e.stderr.splitlines()
+        line = lines[0] if lines else ""
 
-    for line in proc.stderr.splitlines():
-        line = line.strip()
-        if not line.startswith(". "):
-            continue
-        return Path(line[2:])
-    return None
+    line = line.strip()
+    if not line.startswith(". "):
+        return None
+    return Path(line[2:])
 
 
 class GccCCompiler(BaseTool):

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -47,19 +47,27 @@ def _find_libcxx_modules_manifest(
         cmd.extend(user_stdlib_flags)
     else:
         cmd.append("-stdlib=libc++")
-    cmd.append("-print-file-name=c++/libc++.modules.json")
-    try:
-        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
-    except FileNotFoundError:
-        return None
-    if proc.returncode != 0:
-        return None
-    out = proc.stdout.strip()
-    # When the file isn't found, clang echoes the query string back unchanged.
-    if not out or out == "c++/libc++.modules.json":
-        return None
-    p = Path(out)
-    return p if p.is_file() else None
+    candidates = (
+        "libc++.modules.json",
+        "c++/libc++.modules.json",
+    )
+    for candidate in candidates:
+        cmd_copy = list(cmd)
+        cmd_copy.append(f"-print-file-name={candidate}")
+        try:
+            proc = subprocess.run(cmd_copy, capture_output=True, text=True, check=False)
+        except FileNotFoundError:
+            continue
+        if proc.returncode != 0:
+            continue
+        out = proc.stdout.strip()
+        # When the file isn't found, clang echoes the query string back unchanged.
+        if not out or out == candidate:
+            continue
+        p = Path(out)
+        if p.is_file():
+            return p.resolve()
+    return None
 
 
 def _parse_libcxx_manifest(manifest: Path) -> dict[str, dict[str, Any]]:

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -781,7 +781,7 @@ class LlvmToolchain(UnixToolchain):
                 "(`brew install llvm`) — Apple Clang doesn't ship the std "
                 "module yet. On Linux, install a recent libc++ that includes "
                 "`libc++.modules.json` (LLVM ≥ 18). Alternatively use a "
-                "different toolchain (MSVC works on Windows, GCC ≥ 14 works on Linux)."
+                "different toolchain (MSVC works on Windows, GCC ≥ 15 works on Linux)."
             )
         modules = _parse_libcxx_manifest(manifest)
 

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -781,7 +781,7 @@ class LlvmToolchain(UnixToolchain):
                 "(`brew install llvm`) — Apple Clang doesn't ship the std "
                 "module yet. On Linux, install a recent libc++ that includes "
                 "`libc++.modules.json` (LLVM ≥ 18). Alternatively use a "
-                "different toolchain (MSVC works on Windows)."
+                "different toolchain (MSVC works on Windows, GCC ≥ 14 works on Linux)."
             )
         modules = _parse_libcxx_manifest(manifest)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -267,41 +267,113 @@ def should_skip(config: dict[str, Any]) -> str | None:
         if not os.environ.get(var):
             return f"Required environment variable '{var}' not set"
 
-    # Check whether `import std;` is supported by the toolchain pcons would
-    # pick. On Windows we expect MSVC (which has its own std-module path);
-    # there we just check that cl.exe is on PATH. On macOS/Linux we expect
-    # clang, and we probe for libc++.modules.json — Apple Clang and many
-    # libstdc++ installs don't ship it (skip), while brew LLVM and recent
-    # libc++ packages do.
-    if skip_config.get("requires_libcxx_std_module"):
-        if current_platform == "windows":
-            if shutil.which("cl.exe") is None and shutil.which("cl") is None:
-                return "cl.exe not on PATH — run vcvars64.bat first"
-        else:
-            clang = shutil.which("clang++") or shutil.which("clang")
-            if clang is None:
-                return "clang not found (needed for libc++ std module check)"
-            try:
-                proc = subprocess.run(
-                    [
-                        clang,
-                        "-stdlib=libc++",
-                        "-print-file-name=c++/libc++.modules.json",
-                    ],
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-            except OSError:
-                return "could not invoke clang to probe libc++ std module"
-            out = proc.stdout.strip()
-            if not out or out == "c++/libc++.modules.json" or not Path(out).is_file():
-                return (
-                    "libc++.modules.json not available — `import std;` on clang "
-                    "needs Homebrew LLVM (macOS) or libc++-dev (Linux)"
-                )
+    def _check_msvc_module_support() -> bool | str:
+        """On Windows we expect MSVC (which has its own std-module path).
+        There we just check that cl.exe is on PATH.
+        """
+        if shutil.which("cl.exe") is None and shutil.which("cl") is None:
+            return "cl.exe not on PATH — run vcvars64.bat first"
 
-    return None
+    def _check_libcxx_std_module_support() -> bool | str:
+        """Check for libc++ std module support.
+        Check clang is on PATH and use internal manifest lookup
+        to check for libc++ std module support.
+        """
+        clang = shutil.which("clang++") or shutil.which("clang")
+        if clang is None:
+            return "clang not found (needed for libc++ std module check)"
+        from pcons.toolchains.llvm import _find_libcxx_modules_manifest
+
+        if _find_libcxx_modules_manifest(clang, []) is None:
+            return "libc++.modules.json not found - libc++ std module support requires Homebrew LLVM (macOS) or libc++-dev (Linux)"
+
+    def _check_gcc_std_module_support() -> bool | str:
+        """Check for GCC std module support.
+        Check g++ is on PATH and use internal source lookup
+        to check for GCC std module support.
+        """
+        gxx = shutil.which("g++")
+        if gxx is None:
+            return "g++ not found (needed for GCC std module check)"
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        if _find_gcc_std_module_source(gxx, "std", []) is None:
+            return "GCC std module support requires GCC 15+ with libstdc++"
+
+    # check for C++ std module support if required by the test config
+    if skip_config.get("requires_cxx_std_module"):
+        toolchain = config.get("toolchain")
+        if toolchain is None:
+            # toolchain not specified:
+            #   - On Windows, assume MSVC
+            #   - On MacOs, assume clang
+            #   - On Linux, check for gcc then clang
+            if current_platform == "windows":
+                if (check := _check_msvc_module_support()) is not None:
+                    return check
+            elif current_platform == "darwin":
+                if (check := _check_libcxx_std_module_support()) is not None:
+                    return check
+            else:  # assume linux
+                if (check := _check_gcc_std_module_support()) is not None:
+                    return check
+                if (check := _check_libcxx_std_module_support()) is not None:
+                    return check
+        else:
+            if toolchain == "msvc":
+                if (check := _check_msvc_module_support()) is not None:
+                    return check
+            elif toolchain == "llvm":
+                if (check := _check_libcxx_std_module_support()) is not None:
+                    return check
+            elif toolchain == "gcc":
+                if (check := _check_gcc_std_module_support()) is not None:
+                    return check
+    return None  # not skipped
+
+
+def _toolchain_is_available(toolchain: str, current_platform: str) -> bool:
+    """Check whether a requested toolchain is available on this host."""
+    if toolchain == "msvc":
+        return current_platform == "windows" and (
+            shutil.which("cl.exe") is not None or shutil.which("cl") is not None
+        )
+
+    if toolchain == "llvm":
+        clang = shutil.which("clang++") or shutil.which("clang")
+        if clang is None:
+            return False
+        return True
+
+    if toolchain == "gcc":
+        gxx = shutil.which("g++")
+        if gxx is None:
+            return False
+        return True
+
+    return False
+
+
+def get_requested_toolchains(config: dict[str, Any]) -> list[str | None]:
+    """Get requested toolchains for the current platform from test config."""
+    current_platform = platform.system().lower()
+    test_config = config.get("test", {})
+
+    toolchains_table = config.get("toolchains")
+    if isinstance(toolchains_table, dict):
+        requested_toolchains = toolchains_table.get(current_platform)
+    else:
+        requested_toolchains = get_platform_value(test_config, "toolchains")
+
+    # Backward-compatible fallback to toolchains_<platform> in [test]
+    if requested_toolchains is None:
+        requested_toolchains = get_platform_value(test_config, "toolchains")
+
+    if requested_toolchains is None:
+        single_toolchain = get_platform_value(test_config, "toolchain")
+        return [single_toolchain] if single_toolchain else [None]
+
+    return list(requested_toolchains)
 
 
 def adapt_outputs_for_generator(
@@ -441,6 +513,7 @@ def _run_generate(
     generator: str,
     test_config: dict[str, Any],
     variant: str | None = None,
+    variables: dict[str, str] | None = None,
 ) -> None:
     """Run the build script to generate build files.
 
@@ -451,6 +524,7 @@ def _run_generate(
         generator: Generator name.
         test_config: Test configuration dict.
         variant: Optional variant name (e.g., "debug", "release").
+        variables: Optional build variables (KEY=value) for the build script.
     """
     if invocation == "direct":
         from pcons.cli import run_script
@@ -458,7 +532,11 @@ def _run_generate(
         build_script = work_dir / "pcons-build.py"
         try:
             exit_code, _projects = run_script(
-                build_script, build_dir, generator=generator, variant=variant
+                build_script,
+                build_dir,
+                variables=variables,
+                generator=generator,
+                variant=variant,
             )
             if exit_code != 0:
                 variant_msg = f" (variant={variant})" if variant else ""
@@ -468,6 +546,8 @@ def _run_generate(
             pytest.fail(f"pcons-build.py raised {type(e).__name__}: {e}{variant_msg}")
     else:
         cmd = [sys.executable, "-m", "pcons"]
+        if variables:
+            cmd.extend([f"{k}={v}" for k, v in variables.items()])
         env = {
             **os.environ,
             "PCONS_BUILD_DIR": str(build_dir),
@@ -496,6 +576,7 @@ def run_example(
     tmp_path: Path,
     invocation: str = "direct",
     generator: str = "ninja",
+    toolchain: str | None = None,
 ) -> None:
     """Run a single example project.
 
@@ -508,8 +589,10 @@ def run_example(
         generator: Which generator to use:
             - "ninja": Generate build.ninja
             - "make": Generate Makefile
+        toolchain: Optional toolchain name to pass as TOOLCHAIN build variable.
     """
     config = load_test_config(example_dir)
+    config["toolchain"] = toolchain
     test_config = config.get("test", {})
 
     # Check skip conditions
@@ -541,9 +624,26 @@ def run_example(
 
     # Check for variants (CMake-style: run the script once per variant)
     variants = test_config.get("variants", [None])
+    current_platform = platform.system().lower()
+
+    if toolchain is not None and not _toolchain_is_available(
+        toolchain, current_platform
+    ):
+        pytest.skip(f"Requested toolchain '{toolchain}' is not available on this host")
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    tc_vars = {"TOOLCHAIN": toolchain} if toolchain else None
 
     for variant in variants:
-        _run_generate(work_dir, build_dir, invocation, generator, test_config, variant)
+        _run_generate(
+            work_dir,
+            build_dir,
+            invocation,
+            generator,
+            test_config,
+            variant,
+            variables=tc_vars,
+        )
 
     # For variant builds, collect all variant build dirs for the build step
     variant_build_dirs = (
@@ -797,27 +897,59 @@ EXAMPLES = discover_examples()
 INVOCATIONS = ["direct", "cli"]
 
 
-@pytest.mark.parametrize("generator", GENERATORS, ids=GENERATORS)
-@pytest.mark.parametrize("invocation", INVOCATIONS, ids=INVOCATIONS)
+def build_example_params() -> list[pytest.ParameterSet]:
+    """Build a complete pytest parameter matrix, including toolchains."""
+    params: list[pytest.ParameterSet] = []
+
+    for example_dir in EXAMPLES:
+        config = load_test_config(example_dir)
+        requested_toolchains = get_requested_toolchains(config)
+
+        for invocation in INVOCATIONS:
+            for generator in GENERATORS:
+                for toolchain in requested_toolchains:
+                    test_id = f"{example_dir.name}-{invocation}-{generator}"
+                    if toolchain:
+                        test_id = f"{test_id}-{toolchain}"
+                    params.append(
+                        pytest.param(
+                            example_dir,
+                            invocation,
+                            generator,
+                            toolchain,
+                            id=test_id,
+                        )
+                    )
+
+    return params
+
+
+EXAMPLE_PARAMS = build_example_params()
+
+
 @pytest.mark.parametrize(
-    "example_dir",
-    EXAMPLES,
-    ids=[e.name for e in EXAMPLES],
+    ("example_dir", "invocation", "generator", "toolchain"),
+    EXAMPLE_PARAMS,
 )
 def test_example(
-    example_dir: Path, tmp_path: Path, invocation: str, generator: str
+    example_dir: Path,
+    tmp_path: Path,
+    invocation: str,
+    generator: str,
+    toolchain: str | None,
 ) -> None:
     """Run an example project end-to-end.
 
     Tests combinations of:
     - Invocation methods: direct (python pcons-build.py), cli (python -m pcons)
-    - Generators: ninja (build.ninja), make (Makefile)
+    - Generators: ninja (build.ninja), make (Makefile), xcode
+    - Toolchains: from each example's test configuration
     """
-    run_example(example_dir, tmp_path, invocation, generator)
+    run_example(example_dir, tmp_path, invocation, generator, toolchain)
 
 
 # If no examples found, create a placeholder test
-if not EXAMPLES:
+if not EXAMPLE_PARAMS:
 
     def test_no_examples() -> None:
         """Placeholder when no examples are found."""

--- a/tests/toolchains/test_gcc.py
+++ b/tests/toolchains/test_gcc.py
@@ -1,6 +1,10 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.toolchains.gcc."""
 
+from pathlib import Path
+
+import pytest
+
 from pcons.configure.platform import Platform
 from pcons.toolchains.gcc import (
     GccArchiver,
@@ -298,3 +302,181 @@ class TestGccCompileFlagsForTargetType:
         tc = GccToolchain()
         flags = tc.get_compile_flags_for_target_type("interface")
         assert flags == []
+
+
+class TestGccModuleInterfaceSourceHandler:
+    """Tests for GccToolchain.get_source_handler with C++20 module interfaces."""
+
+    @pytest.mark.parametrize("suffix", [".cppm", ".ixx", ".cxxm", ".c++m"])
+    def test_module_interface_suffixes(self, suffix: str) -> None:
+        from pcons.core.subst import TargetPath
+
+        tc = GccToolchain()
+        handler = tc.get_source_handler(suffix)
+        assert handler is not None
+        assert handler.tool_name == "cxx"
+        assert handler.language == "cxx_module"
+        assert handler.object_suffix == ".o"
+        assert handler.depfile == TargetPath(suffix=".d")
+        assert handler.deps_style == "gcc"
+
+    def test_regular_cpp_not_cxx_module(self) -> None:
+        tc = GccToolchain()
+        handler = tc.get_source_handler(".cpp")
+        assert handler is not None
+        assert handler.language == "cxx"
+
+    def test_unknown_suffix_returns_none(self) -> None:
+        tc = GccToolchain()
+        assert tc.get_source_handler(".xyz") is None
+
+
+class TestFindGccStdModuleSource:
+    """Tests for _find_gcc_std_module_source."""
+
+    def test_resolves_std_cc_from_include_trace(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        std_cc = tmp_path / "usr" / "include" / "c++" / "16.1.1" / "bits" / "std.cc"
+        std_cc.parent.mkdir(parents=True)
+        std_cc.write_text("// std module\n", encoding="utf-8")
+
+        captured: dict[str, object] = {}
+
+        def _fake_run(cmd: list[str], **kw: object) -> object:
+            captured["cmd"] = cmd
+            captured["input"] = kw.get("input")
+            return type("R", (), {"stdout": "", "stderr": f". {std_cc}\n"})()
+
+        monkeypatch.setattr("pcons.toolchains.gcc.subprocess.run", _fake_run)
+        found = _find_gcc_std_module_source("g++", "std", [])
+        assert captured["input"] == "#include <bits/std.cc>\n"
+        assert captured["cmd"] == ["g++", "-E", "-x", "c++", "-", "-H"]
+        assert found == std_cc
+
+    def test_resolves_std_compat_cc_from_direct_include_probe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        compat_cc = (
+            tmp_path / "usr" / "include" / "c++" / "16.1.1" / "bits" / "std.compat.cc"
+        )
+        compat_cc.parent.mkdir(parents=True)
+        compat_cc.write_text("// std.compat module\n", encoding="utf-8")
+
+        def _fake_run(_cmd: list[str], **_kw: object) -> object:
+            return type("R", (), {"stdout": "", "stderr": f". {compat_cc}\n"})()
+
+        monkeypatch.setattr("pcons.toolchains.gcc.subprocess.run", _fake_run)
+        found = _find_gcc_std_module_source("g++", "std.compat", [])
+        assert found == compat_cc
+
+    def test_returns_none_when_compiler_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        def _fake_run(*_a: object, **_k: object) -> None:
+            raise FileNotFoundError(2, "No such file or directory")
+
+        monkeypatch.setattr("pcons.toolchains.gcc.subprocess.run", _fake_run)
+        assert _find_gcc_std_module_source("g++", "std", []) is None
+
+    def test_returns_none_when_path_not_in_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def _fake_run(cmd: list[str], **_kw: object) -> _Result:
+            return _Result()
+
+        monkeypatch.setattr("pcons.toolchains.gcc.subprocess.run", _fake_run)
+        assert _find_gcc_std_module_source("g++", "std", []) is None
+
+    def test_forwards_base_flags_to_direct_include_probe(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        from pcons.toolchains.gcc import _find_gcc_std_module_source
+
+        std_cc = tmp_path / "usr" / "include" / "c++" / "16.1.1" / "bits" / "std.cc"
+        std_cc.parent.mkdir(parents=True)
+        std_cc.write_text("// std module\n", encoding="utf-8")
+
+        captured: dict[str, object] = {}
+
+        def _fake_run(cmd: list[str], **_kw: object) -> object:
+            captured["cmd"] = cmd
+            return type("R", (), {"stdout": "", "stderr": f". {std_cc}\n"})()
+
+        monkeypatch.setattr("pcons.toolchains.gcc.subprocess.run", _fake_run)
+        found = _find_gcc_std_module_source(
+            "g++", "std", ["--sysroot=/x", "-std=c++23"]
+        )
+        assert found == std_cc
+        assert captured["cmd"] == [
+            "g++",
+            "--sysroot=/x",
+            "-std=c++23",
+            "-E",
+            "-x",
+            "c++",
+            "-",
+            "-H",
+        ]
+
+
+class TestGccStdModuleFlagSpec:
+    """Tests for _gcc_std_module_flag_spec and select_std_module_flags."""
+
+    def test_carries_std_flag(self) -> None:
+        from pcons.toolchains.cxx_module_scanner import select_std_module_flags
+        from pcons.toolchains.gcc import _gcc_std_module_flag_spec
+
+        flags = ["-std=c++23", "-O2", "-Wall"]
+        result = select_std_module_flags(flags, _gcc_std_module_flag_spec())
+        assert "-std=c++23" in result
+        assert "-O2" not in result
+        assert "-Wall" not in result
+
+    def test_carries_march(self) -> None:
+        from pcons.toolchains.cxx_module_scanner import select_std_module_flags
+        from pcons.toolchains.gcc import _gcc_std_module_flag_spec
+
+        flags = ["-std=c++20", "-march=native", "-Wextra"]
+        result = select_std_module_flags(flags, _gcc_std_module_flag_spec())
+        assert "-march=native" in result
+        assert "-Wextra" not in result
+
+    def test_carries_glibcxx_defines(self) -> None:
+        from pcons.toolchains.cxx_module_scanner import select_std_module_flags
+        from pcons.toolchains.gcc import _gcc_std_module_flag_spec
+
+        flags = [
+            "-std=c++23",
+            "-D_GLIBCXX_DEBUG=1",
+            "-DNDEBUG",
+            "-D__GLIBCXX_SOMETHING=1",
+        ]
+        result = select_std_module_flags(flags, _gcc_std_module_flag_spec())
+        assert "-D_GLIBCXX_DEBUG=1" in result
+        assert "-D__GLIBCXX_SOMETHING=1" in result
+        # NDEBUG is not a libstdc++ feature-test macro — don't carry it
+        assert "-DNDEBUG" not in result
+
+    def test_carries_exception_flags(self) -> None:
+        from pcons.toolchains.cxx_module_scanner import select_std_module_flags
+        from pcons.toolchains.gcc import _gcc_std_module_flag_spec
+
+        flags = ["-fno-exceptions", "-fno-rtti", "-pthread"]
+        result = select_std_module_flags(flags, _gcc_std_module_flag_spec())
+        assert "-fno-exceptions" in result
+        assert "-fno-rtti" in result
+        assert "-pthread" in result

--- a/tests/toolchains/test_llvm.py
+++ b/tests/toolchains/test_llvm.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.toolchains.llvm."""
 
+import re
 from pathlib import Path
 
 import pytest
@@ -417,7 +418,10 @@ class TestLibcxxModulesManifest:
         assert found == manifest
         # Must query with -stdlib=libc++ since user didn't pass one.
         assert "-stdlib=libc++" in captured["cmd"]
-        assert "-print-file-name=c++/libc++.modules.json" in captured["cmd"]
+        assert any(
+            re.search(r"-print-file-name=(c++/)?libc\+\+.modules.json", cmd)
+            for cmd in captured["cmd"]
+        )
 
     def test_returns_none_when_compiler_echoes_query(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
### Summary :memo:
Support for `import std;` with GCC toolchain.

### Details
 1. Add gcc scan deps (p1689r5)
 3. Use gcc include tracing to locate `std.cc` and `std.compat.cc`
 4. Inject std module(s) builds the same way llvm toolchain does
 5. Add tests:
   - TestGccModuleInterfaceSourceHandler
   - TestFindGccStdModuleSource
   - TestGccStdModuleFlagSpec
 6. Add `TOOLCHAIN` variable in 32_cxx_import_std example to enforce toolchain to use

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
