### PR TITLE
Add gcc scan step for module interfaces

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -228,8 +228,23 @@ jobs:
       - name: Install libc++ for `import std;` (Linux)
         if: runner.os == 'Linux'
         run: sudo apt-get install -y libc++-18-dev libc++abi-18-dev
+      - name: Install gcc-15 (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+          
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update
+
+          sudo apt-get install -y gcc-15 g++-15
+
+          sudo update-alternatives --install /usr/bin/gcc gcc \
+            /usr/bin/gcc-15 100
+          sudo update-alternatives --install /usr/bin/g++ g++ \
+            /usr/bin/g++-15 100
       - name: Run C++20 modules example tests
-        run: uv run pytest tests/test_examples.py --cov=pcons --cov-report=xml -k "29_cxx_modules or 30_cxx_partitions or 31_cxx_modules_optin or 32_cxx_import_std" -v
+        run: uv run pytest tests/test_examples.py --cov=pcons --cov-report=xml -k "29_cxx_modules or 30_cxx_partitions or 31_cxx_modules_optin or 32_cxx_import_std or 35_cxx_modules_deps" -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/examples/35_cxx_modules_deps/pcons-build.py
+++ b/examples/35_cxx_modules_deps/pcons-build.py
@@ -11,11 +11,17 @@ Demonstrates:
 from pcons import Project, get_var
 from pcons.toolchains import find_c_toolchain
 
+toolchain = find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"])
 project = Project("cxx_modules")
-env = project.Environment(
-    toolchain=find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"])
-)
-env.cxx.flags.append("-std=c++20")
+env = project.Environment(toolchain=toolchain)
+
+if toolchain.name == "msvc":
+    env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
+elif toolchain.name == "llvm":
+    env.cxx.flags.extend(["-std=c++20", "-stdlib=libc++"])
+    env.link.libs.append("c++")
+else:
+    env.cxx.flags.append("-std=c++20")
 
 hello = project.Program(
     "hello",

--- a/examples/35_cxx_modules_deps/pcons-build.py
+++ b/examples/35_cxx_modules_deps/pcons-build.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build script for a C++20 modules example.
+
+Demonstrates:
+- Using find_c_toolchain() to select LLVM/Clang
+- C++20 named module interface units (.cppm)
+- Ninja dyndep for correct module dependency ordering
+"""
+
+from pcons import Project, get_var
+from pcons.toolchains import find_c_toolchain
+
+project = Project("cxx_modules")
+env = project.Environment(
+    toolchain=find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"])
+)
+env.cxx.flags.append("-std=c++20")
+
+hello = project.Program(
+    "hello",
+    env,
+    sources=[
+        "src/mod1.cppm",
+        "src/mod2.cppm",
+        "src/main.cpp",
+    ],
+)
+hello.private.include_dirs.append("src")
+
+project.generate()

--- a/examples/35_cxx_modules_deps/src/MyHeader.hpp
+++ b/examples/35_cxx_modules_deps/src/MyHeader.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+inline int get_answer() {
+    return 42;
+}

--- a/examples/35_cxx_modules_deps/src/main.cpp
+++ b/examples/35_cxx_modules_deps/src/main.cpp
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// C++20 consumer: imports MyMod
+import Mod1;
+import Mod2;
+
+int main() {
+  return mod1::answer() == mod2::answer() && mod1::answer() == 42 ? 0 : 1;
+}

--- a/examples/35_cxx_modules_deps/src/mod1.cppm
+++ b/examples/35_cxx_modules_deps/src/mod1.cppm
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// C++20 module interface unit: defines module MyMod
+module;
+
+#include <MyHeader.hpp>
+
+export module Mod1;
+
+export namespace mod1 {
+int answer() { return get_answer(); }
+} // namespace mod1

--- a/examples/35_cxx_modules_deps/src/mod2.cppm
+++ b/examples/35_cxx_modules_deps/src/mod2.cppm
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+// C++20 module interface unit: defines module MyMod
+module;
+
+#include <MyHeader.hpp>
+
+export module Mod2;
+
+export namespace mod2 {
+int answer() { return get_answer(); }
+} // namespace mod2

--- a/examples/35_cxx_modules_deps/test.toml
+++ b/examples/35_cxx_modules_deps/test.toml
@@ -1,0 +1,52 @@
+# Test configuration for the cxx_modules example
+
+[test]
+description = "Demonstrates C++20 named modules with Ninja dyndep ordering"
+
+expected_outputs = [
+    "build/obj.hello/src/mod1.cppm.o",
+    "build/obj.hello/src/mod2.cppm.o",
+    "build/obj.hello/src/main.cpp.o",
+    "build/hello",
+]
+
+[toolchains]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+windows = ["msvc"]
+
+[verify]
+commands = [{ run = "./build/hello", expect_exit_code = 0 }]
+
+
+[[rebuild]]
+description = "Touching mod1.cppm triggers rebuild of mod1, main, and the final executable"
+touch = "src/mod1.cppm"
+expect_rebuild = [
+    "obj.hello/src/mod1.cppm.o",
+    "obj.hello/src/main.cpp.o",
+    "hello",
+]
+
+[[rebuild]]
+description = "Touching mod2.cppm triggers rebuild of mod2, main, and the final executable"
+touch = "src/mod2.cppm"
+expect_rebuild = [
+    "obj.hello/src/mod2.cppm.o",
+    "obj.hello/src/main.cpp.o",
+    "hello",
+]
+
+[[rebuild]]
+description = "Touching MyHeader.hpp triggers rebuild of mod1, mod2, main, and the final executable"
+touch = "src/MyHeader.hpp"
+expect_rebuild = [
+    "obj.hello/src/mod1.cppm.o",
+    "obj.hello/src/mod2.cppm.o",
+    "obj.hello/src/main.cpp.o",
+    "hello",
+]
+
+[skip]
+requires = ["clang-scan-deps", "clang++"]
+generators = ["xcode", "make"]

--- a/examples/35_cxx_modules_deps/test.toml
+++ b/examples/35_cxx_modules_deps/test.toml
@@ -47,6 +47,10 @@ expect_rebuild = [
     "hello",
 ]
 
+[[rebuild]]
+description = "No rebuild when nothing changed"
+expect_no_work = true
+
 [skip]
 requires = ["clang-scan-deps", "clang++"]
 generators = ["xcode", "make"]

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -497,7 +497,6 @@ def _build_scan_node(
     # Paths for command execution
     scan_rel = str(scan_path.relative_to(build_dir)).replace("\\", "/")
     depfile_rel = str(depfile_path.relative_to(build_dir)).replace("\\", "/")
-    depfile_dir = str(Path(depfile_rel).parent)
     rel_src = src
     if hasattr(project, "_path_resolver"):
         rel_src = project._path_resolver.make_project_relative(src)
@@ -506,14 +505,10 @@ def _build_scan_node(
 
     # Build scan command
     scan_cmd = (
-        # create the output directory
-        f"mkdir -p {depfile_dir}"
         # generate the depfile
-        f" && {compiler_cmd} -E -MD -MT {scan_rel} -MF {depfile_rel} "
+        f"{compiler_cmd} -MM -MT {scan_rel} -MF {depfile_rel} "
         + " ".join(normalized_flags)
-        + f" {rel_src} >/dev/null"
-        # create/update stamp file
-        f" && touch {scan_rel}"
+        + f" {rel_src} && touch {scan_rel}"
     )
 
     from pcons.core.node import BuildInfo

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -17,7 +17,8 @@ from typing import TYPE_CHECKING, Any
 
 from pcons.configure.platform import get_platform
 from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
-from pcons.core.subst import SourcePath, TargetPath
+from pcons.core.node import FileNode
+from pcons.core.subst import PathToken, SourcePath, TargetPath
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 
@@ -454,6 +455,81 @@ class GccLinker(BaseTool):
         return ToolConfig("link", cmd=str(gcc.path))
 
 
+def _build_scan_node(
+    project: Project,
+    src: Path,
+    obj_node: FileNode,
+    compile_flags: list[str],
+    compiler_cmd: str,
+    build_dir: Path,
+    modules_flag: str,
+) -> FileNode:
+    """Generate the scan target and its build information."""
+    obj_path = obj_node.path
+    scan_path = obj_path.with_suffix(obj_path.suffix + ".scan")
+    depfile_path = scan_path.with_suffix(scan_path.suffix + ".d")
+    scan_node = FileNode(str(scan_path), defined_at=obj_node.defined_at)
+
+    # Filter out -fmodules from scan (GCC emits extra make-rules that Ninja rejects)
+    scan_flags = [f for f in compile_flags if f != modules_flag]
+
+    def ninja_relativize(path: str) -> str:
+        """Convert project-relative path to topdir-relative."""
+        return f"$topdir/{path}"
+
+    normalized_flags: list[str] = []
+    for f in scan_flags:
+        if f.startswith("-I") and len(f) > 2:
+            inc = f[2:]
+            if not inc.startswith("$"):
+                inc_path = project._path_resolver.make_project_relative(Path(inc))
+                token = PathToken(
+                    prefix="-I",
+                    path=str(inc_path),
+                    path_type="project",
+                )
+                normalized_flags.append(token.relativize(ninja_relativize))
+            else:
+                normalized_flags.append(f)
+        else:
+            normalized_flags.append(f)
+
+    # Paths for command execution
+    scan_rel = str(scan_path.relative_to(build_dir)).replace("\\", "/")
+    depfile_rel = str(depfile_path.relative_to(build_dir)).replace("\\", "/")
+    depfile_dir = str(Path(depfile_rel).parent)
+    rel_src = src
+    if hasattr(project, "_path_resolver"):
+        rel_src = project._path_resolver.make_project_relative(src)
+        if not rel_src.startswith("../") and not rel_src.startswith("./"):
+            rel_src = f"$topdir/{rel_src}"
+
+    # Build scan command
+    scan_cmd = (
+        # create the output directory
+        f"mkdir -p {depfile_dir}"
+        # generate the depfile
+        f" && {compiler_cmd} -E -MD -MT {scan_rel} -MF {depfile_rel} "
+        + " ".join(normalized_flags)
+        + f" {rel_src} >/dev/null"
+        # create/update stamp file
+        f" && touch {scan_rel}"
+    )
+
+    from pcons.core.node import BuildInfo
+
+    scan_node._build_info = BuildInfo(
+        tool="cxx_scan",
+        command=scan_cmd,
+        sources=[project.node(src)],
+        depfile=PathToken(suffix=".d"),
+        deps_style="gcc",
+        description=f"SCAN {src}",
+    )
+
+    return scan_node
+
+
 class GccToolchain(UnixToolchain):
     """GCC toolchain for C and C++ development.
 
@@ -560,6 +636,8 @@ class GccToolchain(UnixToolchain):
         # Build per-TU scan specs and run GCC p1689 scanning.
         specs: list[TuScanSpec] = []
         spec_to_obj: dict[int, FileNode] = {}
+        module_src_paths = {src for src, _ in cxx_module_pairs}
+
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
@@ -577,6 +655,24 @@ class GccToolchain(UnixToolchain):
                     compile_flags.append(f"-I{inc}")
                 for d in context.defines:
                     compile_flags.append(f"-D{d}")
+
+            # For module interfaces, insert a scan step to generate the depfile.
+            if src in module_src_paths:
+                scan_node = _build_scan_node(
+                    project,
+                    src,
+                    obj_node,
+                    compile_flags,
+                    compiler_cmd,
+                    build_dir,
+                    modules_flag,
+                )
+
+                if hasattr(project, "intermediate_nodes"):
+                    project.intermediate_nodes.append(scan_node)
+                if first_env is not None:
+                    first_env.register_node(scan_node)
+                obj_node.implicit_deps.append(scan_node)
 
             spec = TuScanSpec(
                 src=src.resolve(),

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -668,8 +668,6 @@ class GccToolchain(UnixToolchain):
                     modules_flag,
                 )
 
-                if hasattr(project, "intermediate_nodes"):
-                    project.intermediate_nodes.append(scan_node)
                 if first_env is not None:
                     first_env.register_node(scan_node)
                 obj_node.implicit_deps.append(scan_node)

--- a/pcons/toolchains/msvc.py
+++ b/pcons/toolchains/msvc.py
@@ -674,8 +674,14 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         from pcons.tools.toolchain import SourceHandler
 
         if suffix in CXX_MODULE_INTERFACE_SUFFIXES:
-            # No depfile for module interfaces: module deps are handled by dyndep.
-            return SourceHandler("cxx", "cxx_module", ".obj", None, None)
+            # No depfile (cl.exe doesn't produce make-style depfiles), but
+            # do enable `deps = msvc` so ninja parses /showIncludes output —
+            # otherwise #includes inside the module's global module fragment
+            # (e.g. legacy headers a .cppm pulls in) aren't tracked and
+            # touching one of those headers won't trigger a rebuild.
+            # The cxx_modules.dyndep file handles inter-module ordering;
+            # /showIncludes handles header deps. They're complementary.
+            return SourceHandler("cxx", "cxx_module", ".obj", None, "msvc")
         return super().get_source_handler(suffix)
 
     def after_resolve(

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -406,9 +406,12 @@ class TestMsvcSourceHandlers:
         assert handler.tool_name == "cxx"
         assert handler.language == "cxx_module"
         assert handler.object_suffix == ".obj"
-        # Module interfaces use dyndep, not per-source depfiles
+        # No make-style depfile (cl.exe doesn't emit one) — but deps_style is
+        # "msvc" so ninja still parses /showIncludes to track #includes inside
+        # the module's global module fragment. Inter-module ordering is
+        # handled by the cxx_modules.dyndep file.
         assert handler.depfile is None
-        assert handler.deps_style is None
+        assert handler.deps_style == "msvc"
 
 
 class TestMsvcLinkerAcceptsRes:


### PR DESCRIPTION
### Summary :memo:

This PR introduces a small GCC scan step used to produce depfiles for C++ module
interfaces and adds a test that exercises module dependency behavior.

### Details
- first commit adds `examples/35_cxx_modules_deps` (test + sources). Marks expected GCC
  failure due to missing dependency scanning.
- second one implements `_build_scan_node()` and wire a `cxx_scan` rule in
  `pcons/toolchains/gcc.py` to emit depfiles and a scan stamp per TU.

> NOTE: we mimic CMake behaviour.

### Bugfixes :bug:
- touching a module interface dependency does not trigger rebuild (gcc only).

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
