### PR TITLE
Add metadata generator

### DIFF
--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -27,6 +27,7 @@ from pcons.core.flags import FlagPair  # noqa: E402
 from pcons.core.project import Project  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
 from pcons.generators.makefile import MakefileGenerator  # noqa: E402
+from pcons.generators.metadata import MetadataGenerator  # noqa: E402
 from pcons.generators.ninja import NinjaGenerator  # noqa: E402
 from pcons.generators.xcode import XcodeGenerator  # noqa: E402
 from pcons.packages.description import PackageDescription  # noqa: E402
@@ -147,13 +148,14 @@ GENERATORS = {
     "ninja": NinjaGenerator,
     "make": MakefileGenerator,
     "makefile": MakefileGenerator,  # Alias
+    "metadata": MetadataGenerator,
     "xcode": XcodeGenerator,
 }
 
 
 def Generator(
     default: str = "ninja",
-) -> NinjaGenerator | MakefileGenerator | XcodeGenerator:
+) -> NinjaGenerator | MakefileGenerator | MetadataGenerator | XcodeGenerator:
     """Get a generator instance based on CLI option or environment.
 
     The generator can be set with:
@@ -170,10 +172,11 @@ def Generator(
         3. default parameter
 
     Args:
-        default: Default generator name if not set ("ninja", "make", or "xcode").
+        default: Default generator name if not set ("ninja", "make", "metadata", or "xcode").
 
     Returns:
-        A generator instance (NinjaGenerator, MakefileGenerator, or XcodeGenerator).
+        A generator instance (NinjaGenerator, MakefileGenerator,
+        MetadataGenerator, or XcodeGenerator).
 
     Raises:
         ValueError: If the generator name is not recognized.

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -223,6 +223,7 @@ __all__ = [
     "Generator",
     "NinjaGenerator",
     "MakefileGenerator",
+    "MetadataGenerator",
     "XcodeGenerator",
     # Toolchain discovery
     "find_c_toolchain",

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -977,8 +977,8 @@ def add_generate_args(parser: argparse.ArgumentParser) -> None:
         "-G",
         "--generator",
         metavar="NAME",
-        choices=["ninja", "make", "makefile", "xcode"],
-        help="Generator to use (ninja, make, xcode). Default: ninja",
+        choices=["ninja", "make", "makefile", "metadata", "xcode"],
+        help="Generator to use (ninja, make, metadata, xcode). Default: ninja",
     )
     parser.add_argument(
         "--reconfigure",

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -304,11 +304,16 @@ class Project:
             else:
                 flat.append(t)
         for t in flat:
-            if isinstance(t, Target):
-                # Defer resolution: output_nodes may not be populated until resolve()
-                alias.add_deferred_target(t)
-            else:
-                alias.add_target(t)
+            match t:
+                case Target():
+                    # Defer resolution: output_nodes may not be populated until resolve()
+                    alias.add_deferred_target(t)
+                case Node():
+                    alias.add_target(t)
+                case _:
+                    raise TypeError(
+                        f"Alias targets must be Target, Node, or list of them, got {type(t)}"
+                    )
 
         return alias
 

--- a/pcons/generators/__init__.py
+++ b/pcons/generators/__init__.py
@@ -6,6 +6,7 @@ from pcons.generators.dot import DotGenerator
 from pcons.generators.generator import BaseGenerator, Generator
 from pcons.generators.makefile import MakefileGenerator
 from pcons.generators.mermaid import MermaidGenerator
+from pcons.generators.metadata import MetadataGenerator
 from pcons.generators.ninja import NinjaGenerator
 from pcons.generators.xcode import XcodeGenerator
 
@@ -15,6 +16,7 @@ __all__ = [
     "DotGenerator",
     "Generator",
     "MakefileGenerator",
+    "MetadataGenerator",
     "MermaidGenerator",
     "NinjaGenerator",
     "XcodeGenerator",

--- a/pcons/generators/metadata.py
+++ b/pcons/generators/metadata.py
@@ -44,8 +44,10 @@ class MetadataGenerator(BaseGenerator):
             "generator": self.name,
             "project": {
                 "name": project.name,
-                "root_dir": self._normalize_path(project.root_dir, project),
-                "build_dir": str(project.build_dir).replace("\\", "/"),
+                "root_dir": project._path_resolver.make_project_relative(
+                    project.root_dir
+                ),
+                "build_dir": project.build_dir.as_posix(),
             },
             "targets": [
                 self._serialize_target(target, project, default_target_names)
@@ -68,19 +70,21 @@ class MetadataGenerator(BaseGenerator):
     ) -> dict[str, Any]:
         """Serialize one target to metadata."""
         outputs = [
-            self._normalize_path(node.path, project)
+            project._path_resolver.make_project_relative(node.path)
             for node in target.output_nodes
             if isinstance(node, FileNode)
         ]
         sources = [
-            self._normalize_path(node.path, project)
+            project._path_resolver.make_project_relative(node.path)
             for node in target.sources
             if isinstance(node, FileNode)
         ]
         dependencies = sorted({dep.name for dep in target.dependencies})
 
         location: dict[str, Any] = {
-            "file": self._normalize_path(Path(target.defined_at.filename), project),
+            "file": project._path_resolver.make_project_relative(
+                Path(target.defined_at.filename)
+            ),
             "line": target.defined_at.lineno,
         }
         if target.defined_at.function is not None:
@@ -102,7 +106,7 @@ class MetadataGenerator(BaseGenerator):
         entries: list[str] = []
         for node in alias.targets:
             if isinstance(node, FileNode):
-                entries.append(self._normalize_path(node.path, project))
+                entries.append(project._path_resolver.make_project_relative(node.path))
             else:
                 entries.append(node.name)
 
@@ -110,16 +114,3 @@ class MetadataGenerator(BaseGenerator):
             "name": alias_name,
             "entries": entries,
         }
-
-    def _normalize_path(self, path: Path, project: Project) -> str:
-        """Normalize paths for cross-platform JSON metadata.
-
-        Paths under the project root are stored as project-relative paths.
-        External paths remain absolute.
-        """
-        if path.is_absolute():
-            try:
-                path = path.relative_to(project.root_dir)
-            except ValueError:
-                pass
-        return str(path).replace("\\", "/")

--- a/pcons/generators/metadata.py
+++ b/pcons/generators/metadata.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+"""JSON metadata generator for IDE integration.
+
+Generates structured metadata about project targets (programs, libraries,
+and other target kinds) so IDE plugins can query available targets and
+their relationships.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pcons.core.node import FileNode
+from pcons.generators.generator import BaseGenerator
+
+if TYPE_CHECKING:
+    from pcons.core.project import Project
+    from pcons.core.target import Target
+
+
+class MetadataGenerator(BaseGenerator):
+    """Generator that writes IDE-friendly target metadata as JSON."""
+
+    def __init__(self, *, output_filename: str = "pcons_metadata.json") -> None:
+        super().__init__("metadata")
+        self._output_filename = output_filename
+
+    def _generate_impl(self, project: Project, output_dir: Path) -> None:
+        """Generate metadata JSON file.
+
+        Args:
+            project: Configured project to introspect.
+            output_dir: Directory to write metadata file to.
+        """
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / self._output_filename
+
+        default_target_names = {target.name for target in project.default_targets}
+
+        metadata: dict[str, Any] = {
+            "schema_version": 1,
+            "generator": self.name,
+            "project": {
+                "name": project.name,
+                "root_dir": self._normalize_path(project.root_dir, project),
+                "build_dir": str(project.build_dir).replace("\\", "/"),
+            },
+            "targets": [
+                self._serialize_target(target, project, default_target_names)
+                for target in sorted(project.targets, key=lambda t: t.name)
+            ],
+            "aliases": [
+                self._serialize_alias(name, project) for name in sorted(project.aliases)
+            ],
+        }
+
+        with open(output_file, "w") as f:
+            json.dump(metadata, f, indent=2)
+            f.write("\n")
+
+    def _serialize_target(
+        self,
+        target: Target,
+        project: Project,
+        default_target_names: set[str],
+    ) -> dict[str, Any]:
+        """Serialize one target to metadata."""
+        outputs = [
+            self._normalize_path(node.path, project)
+            for node in target.output_nodes
+            if isinstance(node, FileNode)
+        ]
+        sources = [
+            self._normalize_path(node.path, project)
+            for node in target.sources
+            if isinstance(node, FileNode)
+        ]
+        dependencies = sorted({dep.name for dep in target.dependencies})
+
+        location: dict[str, Any] = {
+            "file": self._normalize_path(Path(target.defined_at.filename), project),
+            "line": target.defined_at.lineno,
+        }
+        if target.defined_at.function is not None:
+            location["function"] = target.defined_at.function
+
+        return {
+            "name": target.name,
+            "type": target.target_type or "other",
+            "is_default": target.name in default_target_names,
+            "dependencies": dependencies,
+            "sources": sources,
+            "outputs": outputs,
+            "defined_at": location,
+        }
+
+    def _serialize_alias(self, alias_name: str, project: Project) -> dict[str, Any]:
+        """Serialize one alias to metadata."""
+        alias = project.aliases[alias_name]
+        entries: list[str] = []
+        for node in alias.targets:
+            if isinstance(node, FileNode):
+                entries.append(self._normalize_path(node.path, project))
+            else:
+                entries.append(node.name)
+
+        return {
+            "name": alias_name,
+            "entries": entries,
+        }
+
+    def _normalize_path(self, path: Path, project: Project) -> str:
+        """Normalize paths for cross-platform JSON metadata.
+
+        Paths under the project root are stored as project-relative paths.
+        External paths remain absolute.
+        """
+        if path.is_absolute():
+            try:
+                path = path.relative_to(project.root_dir)
+            except ValueError:
+                pass
+        return str(path).replace("\\", "/")

--- a/pcons/generators/metadata.py
+++ b/pcons/generators/metadata.py
@@ -102,13 +102,14 @@ class MetadataGenerator(BaseGenerator):
 
     def _serialize_alias(self, alias_name: str, project: Project) -> dict[str, Any]:
         """Serialize one alias to metadata."""
+
         alias = project.aliases[alias_name]
         entries: list[str] = []
         for node in alias.targets:
             if isinstance(node, FileNode):
                 entries.append(project._path_resolver.make_project_relative(node.path))
             else:
-                entries.append(node.name)
+                pass  # Ignore for now
 
         return {
             "name": alias_name,

--- a/pcons/generators/metadata.py
+++ b/pcons/generators/metadata.py
@@ -58,7 +58,7 @@ class MetadataGenerator(BaseGenerator):
             ],
         }
 
-        with open(output_file, "w") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             json.dump(metadata, f, indent=2)
             f.write("\n")
 

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -427,3 +427,11 @@ class TestAlias:
 
         alias = project.Alias("install", t1, t2)
         assert len(alias._target_refs) == 2
+
+    def test_alias_raises_type_error_for_invalid_target(self, tmp_path):
+        """Alias() should raise TypeError for invalid targets."""
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        invalid_target = 42
+
+        with pytest.raises(TypeError):
+            project.Alias("install", invalid_target)

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -2,9 +2,8 @@
 """Tests for pcons.generators.metadata."""
 
 import json
-from pathlib import Path
 
-from pcons.core.node import FileNode
+from pcons.core.node import FileNode, Node
 from pcons.core.project import Project
 from pcons.core.target import Target
 from pcons.generators.metadata import MetadataGenerator
@@ -42,7 +41,7 @@ class TestMetadataGenerator:
 
         lib = Target("mylib", target_type="static_library")
         lib.output_nodes.append(FileNode("build/libmylib.a"))
-        lib._sources.append(FileNode("src/lib.c"))
+        lib.add_source("src/lib.c")
         project.add_target(lib)
 
         app = Target(
@@ -51,13 +50,18 @@ class TestMetadataGenerator:
             defined_at=SourceLocation(filename="build.py", lineno=10, function=None),
         )
         app.output_nodes.append(FileNode("build/app"))
-        app._sources.append(FileNode("src/main.c"))
+        app.add_source("src/main.c")
         app.dependencies.append(lib)
         project.add_target(app)
 
         project.Default(app)
         project.Alias("all", app)
-        project.Alias("all", Path("file.txt"))
+        project.Alias("all", FileNode("some/file.txt"))
+
+        class IgnoredNode(Node):
+            name = "ignored"
+
+        project.Alias("all", IgnoredNode())  # Should be ignored in metadata
 
         gen = MetadataGenerator()
         gen.generate(project)
@@ -83,5 +87,6 @@ class TestMetadataGenerator:
 
         aliases = {alias["name"]: alias for alias in content["aliases"]}
         assert "all" in aliases
+        assert len(aliases["all"]["entries"]) == 2
         assert "build/app" in aliases["all"]["entries"]
-        assert "file.txt" in aliases["all"]["entries"]
+        assert "some/file.txt" in aliases["all"]["entries"]

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -2,11 +2,13 @@
 """Tests for pcons.generators.metadata."""
 
 import json
+from pathlib import Path
 
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
 from pcons.generators.metadata import MetadataGenerator
+from pcons.util.source_location import SourceLocation
 
 
 def normalize_path(path: str) -> str:
@@ -43,7 +45,11 @@ class TestMetadataGenerator:
         lib._sources.append(FileNode("src/lib.c"))
         project.add_target(lib)
 
-        app = Target("app", target_type="program")
+        app = Target(
+            "app",
+            target_type="program",
+            defined_at=SourceLocation(filename="build.py", lineno=10, function=None),
+        )
         app.output_nodes.append(FileNode("build/app"))
         app._sources.append(FileNode("src/main.c"))
         app.dependencies.append(lib)
@@ -51,6 +57,7 @@ class TestMetadataGenerator:
 
         project.Default(app)
         project.Alias("all", app)
+        project.Alias("all", Path("file.txt"))
 
         gen = MetadataGenerator()
         gen.generate(project)
@@ -71,7 +78,10 @@ class TestMetadataGenerator:
         assert by_name["app"]["is_default"] is True
         assert normalize_path(by_name["app"]["sources"][0]) == "src/main.c"
         assert normalize_path(by_name["app"]["outputs"][0]) == "build/app"
+        assert by_name["app"]["defined_at"]["file"] == "build.py"
+        assert by_name["app"]["defined_at"]["line"] == 10
 
         aliases = {alias["name"]: alias for alias in content["aliases"]}
         assert "all" in aliases
-        assert normalize_path(aliases["all"]["entries"][0]) == "build/app"
+        assert "build/app" in aliases["all"]["entries"]
+        assert "file.txt" in aliases["all"]["entries"]

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: MIT
+"""Tests for pcons.generators.metadata."""
+
+import json
+
+from pcons.core.node import FileNode
+from pcons.core.project import Project
+from pcons.core.target import Target
+from pcons.generators.metadata import MetadataGenerator
+
+
+def normalize_path(path: str) -> str:
+    """Normalize path separators for cross-platform assertions."""
+    return path.replace("\\", "/")
+
+
+class TestMetadataGenerator:
+    def test_is_generator(self, tmp_path):
+        project = Project("test", root_dir=tmp_path, build_dir=".")
+        gen = MetadataGenerator()
+
+        gen.generate(project)
+
+        assert gen.name == "metadata"
+        assert (tmp_path / "pcons_metadata.json").exists()
+
+    def test_empty_project(self, tmp_path):
+        project = Project("test", root_dir=tmp_path, build_dir=".")
+        gen = MetadataGenerator()
+
+        gen.generate(project)
+
+        content = json.loads((tmp_path / "pcons_metadata.json").read_text())
+        assert content["schema_version"] == 1
+        assert content["targets"] == []
+        assert content["aliases"] == []
+
+    def test_includes_targets_dependencies_and_aliases(self, tmp_path):
+        project = Project("test", root_dir=tmp_path, build_dir="build")
+
+        lib = Target("mylib", target_type="static_library")
+        lib.output_nodes.append(FileNode("build/libmylib.a"))
+        lib._sources.append(FileNode("src/lib.c"))
+        project.add_target(lib)
+
+        app = Target("app", target_type="program")
+        app.output_nodes.append(FileNode("build/app"))
+        app._sources.append(FileNode("src/main.c"))
+        app.dependencies.append(lib)
+        project.add_target(app)
+
+        project.Default(app)
+        project.Alias("all", app)
+
+        gen = MetadataGenerator()
+        gen.generate(project)
+
+        content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
+
+        assert content["project"]["name"] == "test"
+        assert content["project"]["build_dir"] == "build"
+
+        by_name = {target["name"]: target for target in content["targets"]}
+
+        assert by_name["mylib"]["type"] == "static_library"
+        assert normalize_path(by_name["mylib"]["sources"][0]) == "src/lib.c"
+        assert normalize_path(by_name["mylib"]["outputs"][0]) == "build/libmylib.a"
+
+        assert by_name["app"]["type"] == "program"
+        assert by_name["app"]["dependencies"] == ["mylib"]
+        assert by_name["app"]["is_default"] is True
+        assert normalize_path(by_name["app"]["sources"][0]) == "src/main.c"
+        assert normalize_path(by_name["app"]["outputs"][0]) == "build/app"
+
+        aliases = {alias["name"]: alias for alias in content["aliases"]}
+        assert "all" in aliases
+        assert normalize_path(aliases["all"]["entries"][0]) == "build/app"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,14 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pcons import Generator, MakefileGenerator, NinjaGenerator, get_var, get_variant
+from pcons import (
+    Generator,
+    MakefileGenerator,
+    MetadataGenerator,
+    NinjaGenerator,
+    get_var,
+    get_variant,
+)
 from pcons.cli import (
     find_command_in_argv,
     find_script,
@@ -193,6 +200,13 @@ class TestGenerator:
 
         gen = Generator()
         assert isinstance(gen, MakefileGenerator)
+
+    def test_generator_metadata(self, monkeypatch) -> None:
+        """Test Generator() supports metadata generator."""
+        monkeypatch.setenv("PCONS_GENERATOR", "metadata")
+
+        gen = Generator()
+        assert isinstance(gen, MetadataGenerator)
 
     def test_generator_case_insensitive(self, monkeypatch) -> None:
         """Test generator names are case-insensitive."""


### PR DESCRIPTION
### Summary :memo:
Add new "metadata" generator that exposes project outline as json.
Those metadata are intended to be used by IDEs to support pcons, in a language-agnostic way.

> see [vscode-pcons](https://github.com/Garcia6l20/vscode-pcons)

### Details
 - create a new "metadata" generator that exposes project outline as json that may be used by IDEs to support pcons
 - add dedicated "tests/generators/test_metadata.py" unit test.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
