### PR TITLE
Fix CXX modules always re-built after generate

### DIFF
--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -72,6 +72,17 @@ class CxxModuleScannerNotFound(RuntimeError):
     """
 
 
+def _write_text_if_changed(path: Path, text: str) -> None:
+    """Write *text* to *path* only when content differs.
+
+    This keeps file mtimes stable across no-op configure runs so Ninja
+    doesn't treat unchanged dyndep files as freshly updated inputs.
+    """
+    if path.exists() and path.read_text(encoding="utf-8") == text:
+        return
+    path.write_text(text, encoding="utf-8")
+
+
 def run_scan_deps(
     scanner: str,
     compiler: str,
@@ -657,7 +668,7 @@ def write_dyndep_from_results(
             provides_pcms.append(module_to_pcm[r.logical_name])
 
         requires_pcms: list[str] = []
-        for ln in r.required_logical_names:
+        for ln in sorted(set(r.required_logical_names)):
             if ln in module_to_pcm:
                 requires_pcms.append(module_to_pcm[ln])
 
@@ -666,7 +677,8 @@ def write_dyndep_from_results(
         lines.append(f"build {r.spec.obj_rel}{implicit_out}: dyndep{implicit_in}")
         lines.append("")
 
-    Path(out_path).write_text("\n".join(lines), encoding="utf-8")
+    dyndep_text = "\n".join(lines)
+    _write_text_if_changed(Path(out_path), dyndep_text)
 
 
 def write_dyndep(
@@ -809,7 +821,7 @@ def write_dyndep(
         lines.append("")
 
     dyndep_text = "\n".join(lines)
-    Path(out_path).write_text(dyndep_text, encoding="utf-8")
+    _write_text_if_changed(Path(out_path), dyndep_text)
 
 
 def main() -> int:

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -159,6 +159,23 @@ class TestWriteDyndep:
         write_dyndep_from_results(results, m, out)
         assert "std" not in out.read_text()
 
+    def test_write_if_unchanged_keeps_mtime(self, tmp_path: Path) -> None:
+        results = [
+            _result("Calc.o", provides_name="Calc", requires=["Calc:Constants"]),
+            _result("Constants.o", provides_name="Calc:Constants"),
+        ]
+        m = build_module_map(results, "mods", ".pcm")
+        out = tmp_path / "deps.dyndep"
+
+        write_dyndep_from_results(results, m, out)
+        first_mtime = out.stat().st_mtime_ns
+
+        # Re-emitting identical content must not rewrite the file.
+        write_dyndep_from_results(results, m, out)
+        second_mtime = out.stat().st_mtime_ns
+
+        assert first_mtime == second_mtime
+
 
 class _FakeCxxNamespace:
     """Stand-in for env.cxx with just the `modules` attribute the helper reads."""


### PR DESCRIPTION
### Summary :memo:
CXX modules are always re-built after generate.
Since dyndep file is always created it breaks ninja timestamp-based dependency tracking.

### Details

Before:
```
$ pcons --debug all generate TOOLCHAIN=gcc
$ ninja -C build
[... normal build output ...]
$ pcons --debug all generate TOOLCHAIN=gcc
$ ninja -C build -d explain
ninja: Entering directory `build'
ninja explain: output cxx_modules/std.o older than most recent input cxx_modules.dyndep (1779006961776932443 vs 1779007050362319827)
[0/4] CXX std module
ninja explain: output cxx_modules/std.o older than most recent input cxx_modules.dyndep (1779006961776932443 vs 1779007050362319827)
[1/4] CXX std module
ninja explain: gcm.cache/std.gcm is dirty
[1/4] CXX obj.hello/src/Greet.cppm.o
ninja explain: gcm.cache/std.gcm is dirty
[2/4] CXX obj.hello/src/Greet.cppm.o
ninja explain: gcm.cache/Greet.gcm is dirty
ninja explain: gcm.cache/std.gcm is dirty
[2/4] CXX obj.hello/src/main.cpp.o
ninja explain: gcm.cache/Greet.gcm is dirty
ninja explain: gcm.cache/std.gcm is dirty
[3/4] CXX obj.hello/src/main.cpp.o
ninja explain: obj.hello/src/Greet.cppm.o is dirty
ninja explain: obj.hello/src/main.cpp.o is dirty
ninja explain: cxx_modules/std.o is dirty
[3/4] LINK hello
ninja explain: obj.hello/src/Greet.cppm.o is dirty
ninja explain: obj.hello/src/main.cpp.o is dirty
ninja explain: cxx_modules/std.o is dirty
[4/4] LINK hello
```

After:
```$ pcons --debug all generate TOOLCHAIN=gcc
$ ninja -C build
[... normal build output ...]
$ pcons --debug all generate TOOLCHAIN=gcc
$ ninja -C build -d explain
ninja: Entering directory `build'
ninja: no work to do.
```

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
