### PR TITLE
Fix/cxx modules deterministic dyndep

### DIFF
--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -662,6 +662,7 @@ def write_dyndep_from_results(
       - implicit inputs are the IFC/PCM files this TU imports
     """
     lines = ["ninja_dyndep_version = 1", ""]
+    entries: list[tuple[str, list[str], list[str]]] = []
     for r in results:
         provides_pcms: list[str] = []
         if r.is_module_provider and r.logical_name in module_to_pcm:
@@ -672,9 +673,18 @@ def write_dyndep_from_results(
             if ln in module_to_pcm:
                 requires_pcms.append(module_to_pcm[ln])
 
+        entries.append(
+            (
+                r.spec.obj_rel,
+                sorted(set(provides_pcms)),
+                sorted(set(requires_pcms)),
+            )
+        )
+
+    for obj_rel, provides_pcms, requires_pcms in sorted(entries, key=lambda e: e[0]):
         implicit_out = " | " + " ".join(provides_pcms) if provides_pcms else ""
         implicit_in = " | " + " ".join(requires_pcms) if requires_pcms else ""
-        lines.append(f"build {r.spec.obj_rel}{implicit_out}: dyndep{implicit_in}")
+        lines.append(f"build {obj_rel}{implicit_out}: dyndep{implicit_in}")
         lines.append("")
 
     dyndep_text = "\n".join(lines)
@@ -800,11 +810,17 @@ def write_dyndep(
         if is_interface and not provides_pcms and mod_key in item:
             provides_pcms = [str(item[mod_key])]
 
-        entries.append((obj, provides_pcms, requires_pcms))
+        entries.append(
+            (
+                obj,
+                sorted(set(provides_pcms)),
+                sorted(set(requires_pcms)),
+            )
+        )
 
     # Write dyndep file
     lines = ["ninja_dyndep_version = 1", ""]
-    for obj, provides_pcms, requires_pcms in entries:
+    for obj, provides_pcms, requires_pcms in sorted(entries, key=lambda e: e[0]):
         # Implicit outputs: PCM files produced by this compilation
         if provides_pcms:
             implicit_out = " | " + " ".join(provides_pcms)

--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -53,6 +53,7 @@ All paths in the output are relative to the build directory (where Ninja runs).
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
@@ -75,12 +76,24 @@ class CxxModuleScannerNotFound(RuntimeError):
 def _write_text_if_changed(path: Path, text: str) -> None:
     """Write *text* to *path* only when content differs.
 
-    This keeps file mtimes stable across no-op configure runs so Ninja
-    doesn't treat unchanged dyndep files as freshly updated inputs.
+    Fast-path no-op uses a matching ``<path>.sha256`` digest file.
+    If the digest file is missing or stale, use a size check first and
+    only fall back to a byte-for-byte compare for equal-size candidates.
     """
-    if path.exists() and path.read_text(encoding="utf-8") == text:
-        return
-    path.write_text(text, encoding="utf-8")
+    data = text.encode("utf-8")
+    digest = hashlib.sha256(data).digest()
+    digest_file = path.with_suffix(path.suffix + ".sha256")
+
+    if path.exists():
+        if (
+            path.stat().st_size == len(data)
+            and digest_file.exists()
+            and digest_file.read_bytes() == digest
+        ):
+            return
+
+    path.write_bytes(data)
+    digest_file.write_bytes(digest)
 
 
 def run_scan_deps(

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -25,6 +25,7 @@ from pcons.toolchains.cxx_module_scanner import (
     select_modules_scope,
     select_std_module_flags,
     wire_std_into_targets,
+    write_dyndep,
     write_dyndep_from_results,
 )
 
@@ -238,6 +239,41 @@ class TestWriteDyndep:
         write_dyndep_from_results(list(reversed(base_results)), module_map, out_b)
 
         assert out_a.read_text(encoding="utf-8") == out_b.read_text(encoding="utf-8")
+
+    def test_fallback_to_manifest_mod_file(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate scanner failure for an interface TU: write_dyndep should
+        # still emit the manifest-provided module file as an implicit output.
+        def _scan_fail(
+            scanner: str,
+            compiler: str,
+            compile_flags: list[str],
+            src: str,
+            obj: str,
+        ) -> None:
+            return None
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.run_scan_deps", _scan_fail
+        )
+
+        out = tmp_path / "deps.dyndep"
+        manifest = [
+            {
+                "src": str(tmp_path / "MyMod.cppm"),
+                "obj": "obj/MyMod.o",
+                "is_module_interface": True,
+                "pcm": "mods/MyMod.pcm",
+                "compiler": "clang++",
+                "compile_flags": ["-std=c++20"],
+            }
+        ]
+
+        write_dyndep(manifest, "mods", str(out), "clang-scan-deps", "clang")
+        text = out.read_text(encoding="utf-8")
+        assert "ninja_dyndep_version = 1" in text
+        assert "build obj/MyMod.o | mods/MyMod.pcm: dyndep" in text
 
 
 class _FakeCxxNamespace:

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -176,6 +176,53 @@ class TestWriteDyndep:
 
         assert first_mtime == second_mtime
 
+    def test_write_creates_digest_file(self, tmp_path: Path) -> None:
+        results = [
+            _result("Calc.o", provides_name="Calc"),
+        ]
+        m = build_module_map(results, "mods", ".pcm")
+        out = tmp_path / "deps.dyndep"
+
+        write_dyndep_from_results(results, m, out)
+
+        digest_file = tmp_path / "deps.dyndep.sha256"
+        assert digest_file.exists()
+        assert len(digest_file.read_bytes()) == 32
+
+    def test_stale_digest_same_content_rewrites(self, tmp_path: Path) -> None:
+        results = [
+            _result("Calc.o", provides_name="Calc"),
+        ]
+        m = build_module_map(results, "mods", ".pcm")
+        out = tmp_path / "deps.dyndep"
+        digest_file = tmp_path / "deps.dyndep.sha256"
+
+        write_dyndep_from_results(results, m, out)
+        first_content = out.read_text(encoding="utf-8")
+
+        digest_file.write_bytes(b"\x00" * 32)
+        write_dyndep_from_results(results, m, out)
+
+        assert out.read_text(encoding="utf-8") == first_content
+        assert digest_file.read_bytes() != b"\x00" * 32
+
+    def test_stale_digest_different_size_rewrites(self, tmp_path: Path) -> None:
+        results = [
+            _result("Calc.o", provides_name="Calc"),
+        ]
+        m = build_module_map(results, "mods", ".pcm")
+        out = tmp_path / "deps.dyndep"
+        digest_file = tmp_path / "deps.dyndep.sha256"
+
+        write_dyndep_from_results(results, m, out)
+        out.write_text("x\n", encoding="utf-8")
+        digest_file.write_bytes(b"bad\n")
+
+        write_dyndep_from_results(results, m, out)
+
+        assert out.read_text(encoding="utf-8").startswith("ninja_dyndep_version = 1")
+        assert len(digest_file.read_bytes()) == 32
+
     def test_deterministic_output_with_result_reordering(self, tmp_path: Path) -> None:
         base_results = [
             _result("Calc.o", provides_name="Calc", requires=["Calc:Constants"]),

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -176,6 +176,22 @@ class TestWriteDyndep:
 
         assert first_mtime == second_mtime
 
+    def test_deterministic_output_with_result_reordering(self, tmp_path: Path) -> None:
+        base_results = [
+            _result("Calc.o", provides_name="Calc", requires=["Calc:Constants"]),
+            _result("Constants.o", provides_name="Calc:Constants"),
+            _result("main.o", requires=["Calc"]),
+        ]
+        module_map = build_module_map(base_results, "mods", ".pcm")
+
+        out_a = tmp_path / "a.dyndep"
+        out_b = tmp_path / "b.dyndep"
+
+        write_dyndep_from_results(base_results, module_map, out_a)
+        write_dyndep_from_results(list(reversed(base_results)), module_map, out_b)
+
+        assert out_a.read_text(encoding="utf-8") == out_b.read_text(encoding="utf-8")
+
 
 class _FakeCxxNamespace:
     """Stand-in for env.cxx with just the `modules` attribute the helper reads."""


### PR DESCRIPTION
### Summary :memo:
The current way to generate `cxx_modules.dyndep` is not deterministic which could make ninja trigger unexpected rebuilds on complex projects.

### Details
1. make write_dyndep functions and write_dyndep_from_results by sorting entries and sorting every inputs/outputs in each entry.
2. improve outdated dyndep detection by adding a `cxx_modules.dyndep.sha256` alongside, then using it to detect changed content rather than the previous naive "compare-whole-text" method.

I cannot find any example that spot the problem right now, we may need more complex examples involving subdirectories/subprojects handling to spot it, I used my own project [here](https://github.com/Garcia6l20/reflex/tree/feature/pcons) which use a custom (temporary) implementation of subdirs management to validate the improvement.
Basically the generated dyndep ordering was not kept across `generate`s that was triggering many rebuild.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
