### PR TITLE
Feature/add subdirectory

### DIFF
--- a/examples/05_multi_library/include/physics.h
+++ b/examples/05_multi_library/include/physics.h
@@ -2,13 +2,24 @@
 #ifndef PHYSICS_H
 #define PHYSICS_H
 
+/* Windows DLL export/import declaration */
+#ifdef _WIN32
+#ifdef PHYSICS_BUILDING_DLL
+#define PHYSICS_API __declspec(dllexport)
+#else
+#define PHYSICS_API __declspec(dllimport)
+#endif
+#else
+#define PHYSICS_API
+#endif
+
 typedef struct {
     double x, y, z;
     double vx, vy, vz;
     double mass;
 } Body;
 
-void body_update(Body* body, double dt);
-double body_kinetic_energy(const Body* body);
+PHYSICS_API void body_update(Body *body, double dt);
+PHYSICS_API double body_kinetic_energy(const Body *body);
 
 #endif

--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -21,19 +21,15 @@ from pcons.generators.mermaid import MermaidGenerator
 # =============================================================================
 
 project = Project("multi_library")
-
-src_dir = project.root_dir / "src"
-include_dir = project.root_dir / "include"
-build_dir = project.build_dir
 env = project.Environment(toolchain=find_c_toolchain())
 
 # -----------------------------------------------------------------------------
 # Library: libmath - low-level math utilities
 # -----------------------------------------------------------------------------
 libmath = project.StaticLibrary("math", env)
-libmath.add_sources([src_dir / "math_utils.c"])
+libmath.add_sources(["src/math_utils.c"])
 # Public includes propagate to consumers
-libmath.public.include_dirs.append(include_dir)
+libmath.public.include_dirs.append("include")
 # Link against libm for math functions (required on Linux, not needed on Windows)
 if sys.platform != "win32":
     libmath.public.link_libs.append("m")
@@ -41,23 +37,21 @@ if sys.platform != "win32":
 # -----------------------------------------------------------------------------
 # Library: libphysics - physics simulation, depends on libmath
 # -----------------------------------------------------------------------------
-libphysics = project.StaticLibrary("physics", env)
-libphysics.add_sources([src_dir / "physics.c"])
+libphysics = project.SharedLibrary("physics", env)
+libphysics.add_sources(["src/physics.c"])
 libphysics.link(libmath)  # Gets libmath's public includes transitively
 
 # -----------------------------------------------------------------------------
 # Program: simulator - main application
 # -----------------------------------------------------------------------------
 simulator = project.Program("simulator", env)
-simulator.add_sources([src_dir / "main.c"])
+simulator.add_sources(["src/main.c"])
 simulator.link(libphysics)  # Gets both libphysics and libmath includes
-
-project.generate()
 
 # Generate Mermaid dependency diagram (after generate, which auto-resolves)
 mermaid_gen = MermaidGenerator(direction="LR")
 mermaid_gen.generate(project)
 
-print(f"Generated {build_dir / 'build.ninja'}")
-print(f"Generated {build_dir / 'compile_commands.json'}")
-print(f"Generated {build_dir / 'deps.mmd'}")
+print("Generated 'build.ninja'")
+print("Generated 'compile_commands.json'")
+print("Generated 'deps.mmd'")

--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -39,6 +39,9 @@ if sys.platform != "win32":
 # -----------------------------------------------------------------------------
 libphysics = project.SharedLibrary("physics", env)
 libphysics.add_sources(["src/physics.c"])
+if sys.platform == "win32":
+    # export symbols on Windows
+    libphysics.private.defines.append("PHYSICS_BUILDING_DLL")
 libphysics.link(libmath)  # Gets libmath's public includes transitively
 
 # -----------------------------------------------------------------------------

--- a/examples/05_multi_library/test.toml
+++ b/examples/05_multi_library/test.toml
@@ -11,7 +11,7 @@ expected_outputs = [
     "build/compile_commands.json",
     "build/deps.mmd",
     "build/libmath.a",
-    "build/libphysics.a",
+    "build/libphysics.so",
     "build/simulator",
 ]
 
@@ -19,8 +19,8 @@ expected_outputs = [
 # Run the built program and check output
 # Commands are Unix-style; automatically adapted for Windows
 commands = [
-    { run = "./build/simulator", expect_stdout = "Kinetic energy:" },
-    { run = "./build/simulator", expect_stdout = "Final position:" },
+    { run = "LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Kinetic energy:" },
+    { run = "LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Final position:" },
 
     # Verify compile_commands.json has entries for all source files
     { run = "cat build/compile_commands.json", expect_stdout = "math_utils.c" },

--- a/examples/05_multi_library/test.toml
+++ b/examples/05_multi_library/test.toml
@@ -19,8 +19,8 @@ expected_outputs = [
 # Run the built program and check output
 # Commands are Unix-style; automatically adapted for Windows
 commands = [
-    { run = "LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Kinetic energy:" },
-    { run = "LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Final position:" },
+    { run = "DYLD_LIBRARY_PATH=./build LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Kinetic energy:" },
+    { run = "DYLD_LIBRARY_PATH=./build LD_LIBRARY_PATH=./build ./build/simulator", expect_stdout = "Final position:" },
 
     # Verify compile_commands.json has entries for all source files
     { run = "cat build/compile_commands.json", expect_stdout = "math_utils.c" },

--- a/examples/13_subdirs/app/pcons-build.py
+++ b/examples/13_subdirs/app/pcons-build.py
@@ -11,7 +11,7 @@ from pcons import context
 project = context.current_project
 env = project.default_environment
 
-libfoo = project.get_target("foo")
+libfoo = project.get_target("libfoo::foo")
 assert libfoo is not None, (
     "libfoo target not found - ensure libfoo's pcons-build.py is run first"
 )

--- a/examples/13_subdirs/app/pcons-build.py
+++ b/examples/13_subdirs/app/pcons-build.py
@@ -6,11 +6,10 @@ This demonstrates a subdir that depends on another subdir (libfoo).
 Works both standalone and as part of the parent build.
 """
 
-from pcons import Project
+from pcons import context
 
-project = Project.current()
-assert project is not None
-env = project.environments[0]
+project = context.current_project
+env = project.default_environment
 
 libfoo = project.get_target("foo")
 assert libfoo is not None, (

--- a/examples/13_subdirs/app/pcons-build.py
+++ b/examples/13_subdirs/app/pcons-build.py
@@ -6,49 +6,17 @@ This demonstrates a subdir that depends on another subdir (libfoo).
 Works both standalone and as part of the parent build.
 """
 
-import runpy
-from pathlib import Path
+from pcons import Project
 
-from pcons import Project, find_c_toolchain
+project = Project.current()
+assert project is not None
+env = project.environments[0]
 
-# Load libfoo's build script using runpy
-libfoo_script = Path(__file__).parent.parent / "libfoo" / "pcons-build.py"
-libfoo_module = runpy.run_path(str(libfoo_script))
-build_libfoo = libfoo_module["build_libfoo"]
+libfoo = project.get_target("foo")
+assert libfoo is not None, (
+    "libfoo target not found - ensure libfoo's pcons-build.py is run first"
+)
 
-
-def build_app(project: Project | None = None, build_dir: Path | None = None):
-    """Build app, optionally as part of a parent project.
-
-    Args:
-        project: Parent project, or None for standalone build
-        build_dir: Build output directory (unused, kept for API compat)
-    """
-    this_dir = Path(__file__).parent
-    src_dir = this_dir / "src"
-
-    # Create project if not provided (standalone mode)
-    standalone = project is None
-    if standalone:
-        project = Project("app")
-
-    assert project is not None  # For type checker - always true after above
-
-    # Build libfoo first to get its library target
-    libfoo = build_libfoo(project, build_dir)
-
-    env = project.Environment(toolchain=find_c_toolchain())
-
-    # Build app program, linking to libfoo (gets includes automatically)
-    app = project.Program("app", env)
-    app.add_sources([src_dir / "main.c"])
-    app.link(libfoo)  # Gets libfoo's public.include_dirs automatically
-
-    if standalone:
-        # Generate build file when running standalone
-        project.generate()
-        print(f"Generated {project.build_dir}")
-
-
-if __name__ == "__main__":
-    build_app()
+app = project.Program("app", env)
+app.add_sources(["src/main.c"])
+app.link(libfoo)

--- a/examples/13_subdirs/libfoo/pcons-build.py
+++ b/examples/13_subdirs/libfoo/pcons-build.py
@@ -19,6 +19,8 @@ else:
 
     env = project.Environment(toolchain=find_c_toolchain())
 
+# Assigning to a module-level name exports it: the parent can access this
+# target as `ns.libfoo` after `ns = add_subdirectory("libfoo")`.
 libfoo = project.StaticLibrary("foo", env)
 libfoo.add_sources(["src/foo.c"])
 libfoo.public.include_dirs.append("include")

--- a/examples/13_subdirs/libfoo/pcons-build.py
+++ b/examples/13_subdirs/libfoo/pcons-build.py
@@ -9,9 +9,16 @@ This demonstrates a subdir that works both:
 
 from pcons import Project
 
-project = Project.current()
+project = Project("libfoo")
 assert project is not None
-env = project.environments[0]
+
+if not project.is_top_level:
+    # take parent environment
+    env = project.parent.environments[-1]
+else:
+    from pcons import find_c_toolchain
+
+    env = project.Environment(toolchain=find_c_toolchain())
 
 libfoo = project.StaticLibrary("foo", env)
 libfoo.add_sources(["src/foo.c"])

--- a/examples/13_subdirs/libfoo/pcons-build.py
+++ b/examples/13_subdirs/libfoo/pcons-build.py
@@ -10,11 +10,10 @@ This demonstrates a subdir that works both:
 from pcons import Project
 
 project = Project("libfoo")
-assert project is not None
 
 if not project.is_top_level:
     # take parent environment
-    env = project.parent.environments[-1]
+    env = project.parent.default_environment
 else:
     from pcons import find_c_toolchain
 

--- a/examples/13_subdirs/libfoo/pcons-build.py
+++ b/examples/13_subdirs/libfoo/pcons-build.py
@@ -7,49 +7,12 @@ This demonstrates a subdir that works both:
 - As subdir: called from parent pcons-build.py
 """
 
-from pathlib import Path
+from pcons import Project
 
-from pcons import Project, find_c_toolchain
-from pcons.core.target import Target
+project = Project.current()
+assert project is not None
+env = project.environments[0]
 
-
-def build_libfoo(
-    project: Project | None = None, build_dir: Path | None = None
-) -> Target:
-    """Build libfoo, optionally as part of a parent project.
-
-    Args:
-        project: Parent project, or None for standalone build
-        build_dir: Build output directory (unused, kept for API compat)
-
-    Returns:
-        The libfoo static library target (with public.include_dirs set)
-    """
-    this_dir = Path(__file__).parent
-    src_dir = this_dir / "src"
-    include_dir = this_dir / "include"
-
-    # Create project if not provided (standalone mode)
-    standalone = project is None
-    if standalone:
-        project = Project("libfoo")
-
-    assert project is not None  # For type checker - always true after above
-
-    env = project.Environment(toolchain=find_c_toolchain())
-
-    # Build static library with public include directory
-    libfoo = project.StaticLibrary("foo", env)
-    libfoo.add_sources([src_dir / "foo.c"])
-    libfoo.public.include_dirs.append(include_dir)
-
-    if standalone:
-        # Generate build file when running standalone
-        project.generate()
-        print(f"Generated {project.build_dir}")
-
-    return libfoo
-
-
-if __name__ == "__main__":
-    build_libfoo()
+libfoo = project.StaticLibrary("foo", env)
+libfoo.add_sources(["src/foo.c"])
+libfoo.public.include_dirs.append("include")

--- a/examples/13_subdirs/pcons-build.py
+++ b/examples/13_subdirs/pcons-build.py
@@ -37,6 +37,10 @@ this_dir = Path(__file__).parent
 project = Project("subdirs_example")
 env = project.Environment(toolchain=find_c_toolchain())
 
-# add libfoo and app subdirectories
-add_subdirectory("libfoo")
+# add_subdirectory() returns a SimpleNamespace of all module-level names
+# defined in the subdir's pcons-build.py.  libfoo/pcons-build.py assigns
+# `libfoo = project.StaticLibrary(...)` at module scope, so it is exported.
+libfoo_ns = add_subdirectory("libfoo")
+# libfoo_ns.libfoo is the StaticLibrary target, pass it to dependents if needed.
+
 add_subdirectory("app")

--- a/examples/13_subdirs/pcons-build.py
+++ b/examples/13_subdirs/pcons-build.py
@@ -27,28 +27,18 @@ Usage:
   cd app && python pcons-build.py && ninja -C build
 """
 
-import runpy
 from pathlib import Path
 
-from pcons import Project, find_c_toolchain
+from pcons import Project, add_subdirectory, find_c_toolchain
 
 this_dir = Path(__file__).parent
 
 # Create the main project
 project = Project("subdirs_example")
-build_dir = project.build_dir
-
-# Load libfoo's build script using runpy (simpler than importlib.util)
-libfoo_module = runpy.run_path(str(this_dir / "libfoo" / "pcons-build.py"))
-libfoo = libfoo_module["build_libfoo"](project, build_dir)
-
-# Build the app, linking to libfoo (gets includes automatically)
-app_src_dir = this_dir / "app" / "src"
 env = project.Environment(toolchain=find_c_toolchain())
 
-app = project.Program("subdirs_demo", env)
-app.add_sources([app_src_dir / "main.c"])
-app.link(libfoo)  # Gets libfoo's public.include_dirs automatically
+# add libfoo and app subdirectories
+add_subdirectory("libfoo")
+add_subdirectory("app")
 
 project.generate()
-print(f"Generated {build_dir}")

--- a/examples/13_subdirs/pcons-build.py
+++ b/examples/13_subdirs/pcons-build.py
@@ -40,5 +40,3 @@ env = project.Environment(toolchain=find_c_toolchain())
 # add libfoo and app subdirectories
 add_subdirectory("libfoo")
 add_subdirectory("app")
-
-project.generate()

--- a/examples/15_custom_builder/pcons-build.py
+++ b/examples/15_custom_builder/pcons-build.py
@@ -91,7 +91,6 @@ class GenerateVersionBuilder:
             target_type="command",
             defined_at=get_caller_location(),
         )
-        target._project = project
         target._builder_name = "GenerateVersion"
 
         # Create the output node immediately (not using pending sources)

--- a/examples/15_custom_builder/pcons-build.py
+++ b/examples/15_custom_builder/pcons-build.py
@@ -119,7 +119,6 @@ class GenerateVersionBuilder:
         target.output_nodes.append(output_node)
         target.nodes.append(output_node)
 
-        project.add_target(target)
         return target
 
 

--- a/examples/36_cxx_modules_multi_level_subdirs/a/a.cppm
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/a.cppm
@@ -1,0 +1,7 @@
+export module a;
+
+export namespace a {
+    bool a() {
+        return true;
+    }
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/a/a_main.cpp
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/a_main.cpp
@@ -1,0 +1,6 @@
+import a;
+import aa;
+
+int main() {
+    return (a::a() and aa::aa()) ? 0 : 1;
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/a/aa/aa.cppm
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/aa/aa.cppm
@@ -1,0 +1,7 @@
+export module aa;
+
+export namespace aa {
+    bool aa() {
+        return true;
+    }
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
@@ -1,0 +1,3 @@
+from pcons import static_library
+
+static_library("aa", sources=["aa.cppm"])

--- a/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
@@ -1,3 +1,6 @@
-from pcons import static_library
+from pcons import context
 
-static_library("aa", sources=["aa.cppm"])
+project = context.current_project
+env = project.default_environment
+
+project.StaticLibrary("aa", env, sources=["aa.cppm"])

--- a/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/aa/pcons-build.py
@@ -3,4 +3,4 @@ from pcons import context
 project = context.current_project
 env = project.default_environment
 
-project.StaticLibrary("aa", env, sources=["aa.cppm"])
+aa = project.StaticLibrary("aa", env, sources=["aa.cppm"])

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -3,6 +3,8 @@ from pcons import add_subdirectory, context
 project = context.current_project
 env = project.default_environment
 a = project.StaticLibrary("a", env, sources=["a.cppm"])
-add_subdirectory("aa")
 
-project.Program("a_app", env, sources=["a_main.cpp"]).link(a, context.get_target("aa"))
+# pick "aa" variable ("libaa") from the subdirectory aa/pcons-build.py
+(aa,) = add_subdirectory("aa", pick=["aa"])
+
+project.Program("a_app", env, sources=["a_main.cpp"]).link(a, aa)

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -1,0 +1,6 @@
+from pcons import add_subdirectory, get_target, program, static_library
+
+a = static_library("a", sources=["a.cppm"])
+add_subdirectory("aa")
+
+program("a_app", sources=["a_main.cpp"]).link(a, get_target("aa"))

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -1,8 +1,8 @@
-from pcons import add_subdirectory, context, get_target
+from pcons import add_subdirectory, context
 
 project = context.current_project
 env = project.default_environment
 a = project.StaticLibrary("a", env, sources=["a.cppm"])
 add_subdirectory("aa")
 
-project.Program("a_app", env, sources=["a_main.cpp"]).link(a, get_target("aa"))
+project.Program("a_app", env, sources=["a_main.cpp"]).link(a, context.get_target("aa"))

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -1,6 +1,8 @@
-from pcons import add_subdirectory, get_target, program, static_library
+from pcons import add_subdirectory, context, get_target
 
-a = static_library("a", sources=["a.cppm"])
+project = context.current_project
+env = project.default_environment
+a = project.StaticLibrary("a", env, sources=["a.cppm"])
 add_subdirectory("aa")
 
-program("a_app", sources=["a_main.cpp"]).link(a, get_target("aa"))
+project.Program("a_app", env, sources=["a_main.cpp"]).link(a, get_target("aa"))

--- a/examples/36_cxx_modules_multi_level_subdirs/app/main.cpp
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/main.cpp
@@ -1,0 +1,8 @@
+import a;
+import aa;
+import b;
+import bb;
+
+int main(void) {
+    return (a::a() && aa::aa() && b::b() && bb::bb()) ? 0 : 1;
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
@@ -11,5 +11,5 @@ from pcons import context
 project = context.current_project
 env = project.default_environment
 project.Program("app", env).add_sources(["main.cpp"]).link(
-    *project.get_targets("a", "aa", "b", "bb")
+    *context.get_targets("a", "aa", "b", "bb")
 )

--- a/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
@@ -6,6 +6,10 @@ This demonstrates a subdir that depends on another subdir (libfoo).
 Works both standalone and as part of the parent build.
 """
 
-from pcons import get_targets, program
+from pcons import context
 
-program("app").add_sources(["main.cpp"]).link(*get_targets("a", "aa", "b", "bb"))
+project = context.current_project
+env = project.default_environment
+project.Program("app", env).add_sources(["main.cpp"]).link(
+    *project.get_targets("a", "aa", "b", "bb")
+)

--- a/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build script for app - can be built standalone or as part of parent project.
+
+This demonstrates a subdir that depends on another subdir (libfoo).
+Works both standalone and as part of the parent build.
+"""
+
+from pcons import get_targets, program
+
+program("app").add_sources(["main.cpp"]).link(*get_targets("a", "aa", "b", "bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/b/b.cppm
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/b.cppm
@@ -1,0 +1,7 @@
+export module b;
+
+export namespace b {
+    bool b() {
+        return true;
+    }
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/b/b_main.cpp
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/b_main.cpp
@@ -1,0 +1,6 @@
+import b;
+import bb;
+
+int main() {
+    return (b::b() and bb::bb()) ? 0 : 1;
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/b/bb/bb.cppm
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/bb/bb.cppm
@@ -1,0 +1,7 @@
+export module bb;
+
+export namespace bb {
+    bool bb() {
+        return true;
+    }
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/b/bb/bb_main.cpp
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/bb/bb_main.cpp
@@ -1,0 +1,5 @@
+import bb;
+
+int main() {
+    return bb::bb() ? 0 : 1;
+}

--- a/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
@@ -1,0 +1,5 @@
+from pcons import program, static_library
+
+bb = static_library("bb").add_sources(["bb.cppm"])
+
+program("bb_app").add_sources(["bb_main.cpp"]).link(bb)

--- a/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
@@ -1,5 +1,8 @@
-from pcons import program, static_library
+from pcons import context
 
-bb = static_library("bb").add_sources(["bb.cppm"])
+project = context.current_project
+env = project.default_environment
 
-program("bb_app").add_sources(["bb_main.cpp"]).link(bb)
+bb = project.StaticLibrary("bb", env, sources=["bb.cppm"])
+
+project.Program("bb_app", env, sources=["bb_main.cpp"]).link(bb)

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -1,0 +1,7 @@
+from pcons import add_subdirectory, get_target, program, static_library
+
+b = static_library("b").add_sources(["b.cppm"])
+
+add_subdirectory("bb")
+
+program("b_app").add_sources(["b_main.cpp"]).link(b, get_target("bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -4,6 +4,7 @@ project = context.current_project
 env = project.default_environment
 b = project.StaticLibrary("b", env, sources=["b.cppm"])
 
-add_subdirectory("bb")
+# load the subdirectory's pcons-build.py as SimpleNamespace (with all variables defined in it)
+s = add_subdirectory("bb")
 
-project.Program("b_app", env, sources=["b_main.cpp"]).link(b, context.get_target("bb"))
+project.Program("b_app", env, sources=["b_main.cpp"]).link(b, s.bb)

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -1,7 +1,9 @@
-from pcons import add_subdirectory, get_target, program, static_library
+from pcons import add_subdirectory, context, get_target
 
-b = static_library("b").add_sources(["b.cppm"])
+project = context.current_project
+env = project.default_environment
+b = project.StaticLibrary("b", env, sources=["b.cppm"])
 
 add_subdirectory("bb")
 
-program("b_app").add_sources(["b_main.cpp"]).link(b, get_target("bb"))
+project.Program("b_app", env, sources=["b_main.cpp"]).link(b, get_target("bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -1,4 +1,4 @@
-from pcons import add_subdirectory, context, get_target
+from pcons import add_subdirectory, context
 
 project = context.current_project
 env = project.default_environment
@@ -6,4 +6,4 @@ b = project.StaticLibrary("b", env, sources=["b.cppm"])
 
 add_subdirectory("bb")
 
-project.Program("b_app", env, sources=["b_main.cpp"]).link(b, get_target("bb"))
+project.Program("b_app", env, sources=["b_main.cpp"]).link(b, context.get_target("bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build script demonstrating multi-level subdirectory builds."""
+
+from pcons import Environment, Project, add_subdirectory, find_c_toolchain, get_var
+
+# Create the main project
+Project("subdirs_example")
+env = Environment(
+    toolchain=(toolchain := find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"]))
+)
+
+if toolchain.name == "msvc":
+    env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
+elif toolchain.name == "llvm":
+    env.cxx.flags.extend(["-std=c++20", "-stdlib=libc++"])
+    env.link.libs.append("c++")
+else:
+    env.cxx.flags.append("-std=c++20")
+
+add_subdirectory("a")
+add_subdirectory("b")
+add_subdirectory("app")

--- a/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 """Build script demonstrating multi-level subdirectory builds."""
 
-from pcons import Environment, Project, add_subdirectory, find_c_toolchain, get_var
+from pcons import Project, add_subdirectory, find_c_toolchain, get_var
 
 # Create the main project
-Project("subdirs_example")
-env = Environment(
+project = Project("subdirs_example")
+env = project.Environment(
     toolchain=(toolchain := find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"]))
 )
 

--- a/examples/36_cxx_modules_multi_level_subdirs/test.toml
+++ b/examples/36_cxx_modules_multi_level_subdirs/test.toml
@@ -13,6 +13,10 @@ expected_outputs = [
     "build/app/app",
 ]
 
+[toolchains]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+windows = ["msvc"]
 
 [verify]
 commands = [

--- a/examples/36_cxx_modules_multi_level_subdirs/test.toml
+++ b/examples/36_cxx_modules_multi_level_subdirs/test.toml
@@ -1,0 +1,26 @@
+# Test configuration for subdirs example
+
+[test]
+description = "Demonstrates multi-level subdirectories with C++20 named modules"
+
+expected_outputs = [
+    "build/a/aa/libaa.a",
+    "build/a/liba.a",
+    "build/a/a_app",
+    "build/b/bb/libbb.a",
+    "build/b/libb.a",
+    "build/b/b_app",
+    "build/app/app",
+]
+
+
+[verify]
+commands = [
+    { run = "./build/a/a_app", expect_stdout = "" },
+    { run = "./build/b/b_app", expect_stdout = "" },
+    { run = "./build/app/app", expect_stdout = "" },
+]
+
+[skip]
+requires = ["clang-scan-deps", "clang++"]
+generators = ["xcode", "make"]

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -41,6 +41,7 @@ from pcons.toolchains import (
     find_fortran_toolchain,
     find_wasi_toolchain,
 )  # noqa: E402
+from pcons.util.add_subdirectory import add_subdirectory  # noqa: E402
 
 register_builtin_builders()
 
@@ -238,4 +239,6 @@ __all__ = [
     "find_wasi_toolchain",
     # Module system
     "modules",
+    # Misc utilities
+    "add_subdirectory",
 ]

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -24,7 +24,7 @@ from pcons.configure.config import Configure  # noqa: E402
 from pcons.configure.config_file import configure_file  # noqa: E402
 from pcons.configure.platform import Platform, get_platform  # noqa: E402
 from pcons.core.flags import FlagPair  # noqa: E402
-from pcons.core.project import Project  # noqa: E402, F811
+from pcons.core.project import Project, get_target, get_targets  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
 from pcons.core.test import set_test_properties, set_test_property  # noqa: E402
 from pcons.generators.makefile import MakefileGenerator  # noqa: E402
@@ -241,4 +241,6 @@ __all__ = [
     "modules",
     # Misc utilities
     "add_subdirectory",
+    "get_target",
+    "get_targets",
 ]

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -23,6 +23,7 @@ from pcons.builders import register_builtin_builders  # noqa: E402
 from pcons.configure.config import Configure  # noqa: E402
 from pcons.configure.config_file import configure_file  # noqa: E402
 from pcons.configure.platform import Platform, get_platform  # noqa: E402
+from pcons.core.context import context  # noqa: E402
 from pcons.core.flags import FlagPair  # noqa: E402
 from pcons.core.project import Project, get_target, get_targets  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
@@ -240,6 +241,7 @@ __all__ = [
     # Module system
     "modules",
     # Misc utilities
+    "context",
     "add_subdirectory",
     "get_target",
     "get_targets",

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -25,7 +25,7 @@ from pcons.configure.config_file import configure_file  # noqa: E402
 from pcons.configure.platform import Platform, get_platform  # noqa: E402
 from pcons.core.context import context  # noqa: E402
 from pcons.core.flags import FlagPair  # noqa: E402
-from pcons.core.project import Project, get_target, get_targets  # noqa: E402, F811
+from pcons.core.project import Project  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
 from pcons.core.test import set_test_properties, set_test_property  # noqa: E402
 from pcons.generators.makefile import MakefileGenerator  # noqa: E402
@@ -243,6 +243,4 @@ __all__ = [
     # Misc utilities
     "context",
     "add_subdirectory",
-    "get_target",
-    "get_targets",
 ]

--- a/pcons/builders/compile.py
+++ b/pcons/builders/compile.py
@@ -70,8 +70,7 @@ class ProgramBuilder:
         target._builder_name = "Program"
 
         if sources:
-            source_nodes = _normalize_sources(project, sources)
-            target.add_sources(source_nodes)
+            target.add_sources(sources)
 
         project.add_target(target)
         return target
@@ -119,8 +118,7 @@ class StaticLibraryBuilder:
         target._builder_name = "StaticLibrary"
 
         if sources:
-            source_nodes = _normalize_sources(project, sources)
-            target.add_sources(source_nodes)
+            target.add_sources(sources)
 
         project.add_target(target)
         return target
@@ -168,8 +166,7 @@ class SharedLibraryBuilder:
         target._builder_name = "SharedLibrary"
 
         if sources:
-            source_nodes = _normalize_sources(project, sources)
-            target.add_sources(source_nodes)
+            target.add_sources(sources)
 
         project.add_target(target)
         return target
@@ -217,8 +214,7 @@ class ObjectLibraryBuilder:
         target._builder_name = "ObjectLibrary"
 
         if sources:
-            source_nodes = _normalize_sources(project, sources)
-            target.add_sources(source_nodes)
+            target.add_sources(sources)
 
         project.add_target(target)
         return target
@@ -315,38 +311,3 @@ def _validate_builder_name(name: object, builder_name: str) -> None:
             f"{builder_name}() first argument must be a name string, "
             f"got {type(name).__name__}."
         )
-
-
-def _normalize_sources(
-    project: Project,
-    sources: list[str | Path | Node],
-) -> list[Node]:
-    """Convert source paths/strings to nodes.
-
-    Uses project's node() for deduplication.
-
-    Args:
-        project: Project for node deduplication.
-        sources: List of source files.
-
-    Returns:
-        List of Node objects.
-
-    Raises:
-        TypeError: If sources is a string or bare Path instead of a list.
-    """
-    if isinstance(sources, str):
-        raise TypeError(
-            f'sources must be a list, got a string. Use sources=["{sources}"].'
-        )
-    if isinstance(sources, Path):
-        raise TypeError(
-            f"sources must be a list, got a Path. Use sources=[{sources!r}]."
-        )
-    result: list[Node] = []
-    for src in sources:
-        if isinstance(src, Node):
-            result.append(src)
-        else:
-            result.append(project.node(src))
-    return result

--- a/pcons/builders/compile.py
+++ b/pcons/builders/compile.py
@@ -67,7 +67,6 @@ class ProgramBuilder:
             defined_at=defined_at or get_caller_location(),
         )
         target._env = env
-        target._project = project
         target._builder_name = "Program"
 
         if sources:
@@ -117,7 +116,6 @@ class StaticLibraryBuilder:
             defined_at=defined_at or get_caller_location(),
         )
         target._env = env
-        target._project = project
         target._builder_name = "StaticLibrary"
 
         if sources:
@@ -167,7 +165,6 @@ class SharedLibraryBuilder:
             defined_at=defined_at or get_caller_location(),
         )
         target._env = env
-        target._project = project
         target._builder_name = "SharedLibrary"
 
         if sources:
@@ -217,7 +214,6 @@ class ObjectLibraryBuilder:
             defined_at=defined_at or get_caller_location(),
         )
         target._env = env
-        target._project = project
         target._builder_name = "ObjectLibrary"
 
         if sources:

--- a/pcons/builders/compile.py
+++ b/pcons/builders/compile.py
@@ -72,7 +72,6 @@ class ProgramBuilder:
         if sources:
             target.add_sources(sources)
 
-        project.add_target(target)
         return target
 
 
@@ -120,7 +119,6 @@ class StaticLibraryBuilder:
         if sources:
             target.add_sources(sources)
 
-        project.add_target(target)
         return target
 
 
@@ -168,7 +166,6 @@ class SharedLibraryBuilder:
         if sources:
             target.add_sources(sources)
 
-        project.add_target(target)
         return target
 
 
@@ -216,7 +213,6 @@ class ObjectLibraryBuilder:
         if sources:
             target.add_sources(sources)
 
-        project.add_target(target)
         return target
 
 
@@ -253,7 +249,6 @@ class HeaderOnlyLibraryBuilder:
             for inc_dir in include_dirs:
                 target.public.include_dirs.append(Path(inc_dir))
 
-        project.add_target(target)
         return target
 
 

--- a/pcons/builders/test.py
+++ b/pcons/builders/test.py
@@ -56,7 +56,7 @@ def _make_internal_target_name(project: Project, user_name: str) -> str:
     base_name = f"test_{sanitized}"
     target_name = base_name
     counter = 1
-    while project.get_target(target_name) is not None:
+    while project.get_target(target_name, raise_if_missing=False) is not None:
         target_name = f"{base_name}_{counter}"
         counter += 1
     return target_name
@@ -222,7 +222,6 @@ class TestBuilder:
             target_type="test",
             defined_at=defined_at or get_caller_location(),
         )
-        target._project = project
         target._builder_name = "Test"
 
         # Partial spec — the factory finalizes the program path during resolve.
@@ -251,5 +250,4 @@ class TestBuilder:
         if isinstance(program, Target):
             target.dependencies.append(program)
 
-        project.add_target(target)
         return target

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -223,7 +223,17 @@ def run_script(
         }
         exec(code, namespace)
 
-        return 0, pcons.get_registered_projects()
+        # generate
+        try:
+            from pcons import Project
+
+            top_level_project = Project.top_level()
+            top_level_project.generate()
+
+            return 0, pcons.get_registered_projects()
+        except ValueError:
+            logger.error("No Project created in build script")
+            return 1, []
 
     except SystemExit as e:
         # Script called sys.exit()
@@ -529,15 +539,7 @@ def cmd_generate(args: argparse.Namespace) -> tuple[int, Project | None]:
     if exit_code != 0:
         return exit_code, None
 
-    try:
-        from pcons import Project
-
-        top_level_project = Project.top_level()
-
-        return 0, top_level_project
-    except ValueError:
-        logger.error("No Project created in build script")
-        return 1, None
+    return 0, _projects[0] if _projects else None
 
 
 def _cmd_generate_wrapper(args: argparse.Namespace) -> int:

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -516,7 +516,7 @@ def cmd_generate(args: argparse.Namespace) -> tuple[int, Project | None]:
         extra_env["PCONS_MERMAID"] = mermaid
 
     # Run build script
-    exit_code, projects = run_script(
+    exit_code, _projects = run_script(
         script,
         build_dir,
         variables=variables,
@@ -529,14 +529,15 @@ def cmd_generate(args: argparse.Namespace) -> tuple[int, Project | None]:
     if exit_code != 0:
         return exit_code, None
 
-    if not projects:
-        logger.warning("No Project created in build script")
-        return 0, None
+    try:
+        from pcons import Project
 
-    if len(projects) > 1:
-        logger.warning("Multiple Projects created; using first one")
+        top_level_project = Project.top_level()
 
-    return 0, projects[0]
+        return 0, top_level_project
+    except ValueError:
+        logger.error("No Project created in build script")
+        return 1, None
 
 
 def _cmd_generate_wrapper(args: argparse.Namespace) -> int:

--- a/pcons/core/builder_registry.py
+++ b/pcons/core/builder_registry.py
@@ -212,7 +212,6 @@ def builder(
                 target = Target(...)
                 target._builder_name = "InstallSymlink"
                 target._builder_data = {"dest": dest, "source": source}
-                project.add_target(target)
                 return target
 
     Args:

--- a/pcons/core/context.py
+++ b/pcons/core/context.py
@@ -22,9 +22,9 @@ class Context:
         """Get a target by name from the current project."""
         return self.current_project.get_target(name)
 
-    def get_targets(self):
+    def get_targets(self, *names: str):
         """Get all targets from the current project."""
-        return self.current_project.get_targets()
+        return self.current_project.get_targets(*names)
 
 
 context = Context()

--- a/pcons/core/context.py
+++ b/pcons/core/context.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: MIT
+"""Core context and global state management for pcons build scripts."""
+
+from __future__ import annotations
+
+import logging
+
+from pcons.core.project import Project
+
+logger = logging.getLogger(__name__)
+
+
+class Context:
+    """Global context for pcons build scripts."""
+
+    @property
+    def current_project(self) -> Project:
+        """Current active Project instance."""
+        return Project.current()
+
+    def get_target(self, name: str):
+        """Get a target by name from the current project."""
+        return self.current_project.get_target(name)
+
+    def get_targets(self):
+        """Get all targets from the current project."""
+        return self.current_project.get_targets()
+
+
+context = Context()
+"""Internal context object for storing global state and providing convenient accessors.
+
+Example usage in pcons-build.py included with `add_subdirectory`:
+    from pcons import context
+    project = context.current_project
+    env = project.default_environment
+    libfoo = project.StaticLibrary("foo", env).add_sources(["foo.c"])
+"""

--- a/pcons/core/environment.py
+++ b/pcons/core/environment.py
@@ -21,7 +21,6 @@ from pcons.util.source_location import SourceLocation, get_caller_location
 if TYPE_CHECKING:
     from pcons.core._environment_stubs import _EnvironmentStubs
     from pcons.core.node import FileNode, Node
-    from pcons.core.project import Project
     from pcons.core.target import Target
     from pcons.tools.toolchain import Toolchain
 else:
@@ -90,7 +89,10 @@ class Environment(_EnvironmentStubs):
             "build_dir": Path("build"),
             "variant": "default",
         }
-        self._project: Project | None = None  # Set by Project when env is created
+        from pcons.core.project import Project
+
+        self._project = Project.current()
+
         self._toolchain = toolchain
         self._additional_toolchains: list[Toolchain] = []
         self._created_nodes: list[Any] = []  # Nodes created by builders
@@ -898,7 +900,6 @@ class Environment(_EnvironmentStubs):
             defined_at=get_caller_location(),
         )
         cmd_target._env = self
-        cmd_target._project = self._project
         cmd_target._builder_name = "Command"
 
         # Register nodes with the environment and add to target

--- a/pcons/core/environment.py
+++ b/pcons/core/environment.py
@@ -933,7 +933,6 @@ class Environment(_EnvironmentStubs):
                 counter += 1
             if name != base_name:
                 cmd_target.name = name
-            self._project.add_target(cmd_target)
 
         return cmd_target
 

--- a/pcons/core/paths.py
+++ b/pcons/core/paths.py
@@ -44,6 +44,19 @@ class PathResolver:
         else:
             self._resolved_build_dir = (self.project_root / build_dir).resolve()
 
+    def subdir(self, subdir: str) -> PathResolver:
+        """Create a new PathResolver for a subdirectory.
+
+        The new resolver will have both project_root and build_dir adjusted
+        to the subdirectory.
+
+        Args:
+            subdir: The subdirectory name to append.
+        Returns:
+            A new PathResolver instance for the subdirectory.
+        """
+        return PathResolver(self.project_root / subdir, self.build_dir / subdir)
+
     def normalize_target_path(
         self, path: Path | str, *, target_name: str | None = None
     ) -> Path:

--- a/pcons/core/paths.py
+++ b/pcons/core/paths.py
@@ -44,7 +44,7 @@ class PathResolver:
         else:
             self._resolved_build_dir = (self.project_root / build_dir).resolve()
 
-    def subdir(self, subdir: str) -> PathResolver:
+    def subdir(self, subdir: str | Path) -> PathResolver:
         """Create a new PathResolver for a subdirectory.
 
         The new resolver will have both project_root and build_dir adjusted

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -118,6 +118,7 @@ class Project(_ProjectBuilders):
             build_dir: Directory for build outputs. Defaults to the
                 PCONS_BUILD_DIR environment variable if set (the CLI
                 sets this automatically), otherwise "build".
+                Using it from a sub-project is not currently supported and will be ignored.
             config: Cached configuration from configure phase.
             defined_at: Source location where project was created.
         """
@@ -131,17 +132,6 @@ class Project(_ProjectBuilders):
             if caller_file.exists():
                 root_dir = str(caller_file.parent)
         self.root_dir = Path(root_dir) if root_dir else Path.cwd()
-        if build_dir is None:
-            build_dir = os.environ.get("PCONS_BUILD_DIR", "build")
-        if not self.root_dir.is_absolute():
-            raise ValueError(f"Root directory must be absolute (got: {self.root_dir})")
-        bd = Path(build_dir)
-        if bd.is_absolute():
-            try:
-                bd = bd.relative_to(self.root_dir)
-            except ValueError:
-                pass  # Out-of-tree build — keep absolute
-        self.build_dir = bd
         self._environments: list[Env] = []
         self._targets: list[Target] = []
         self._nodes: dict[Path, Node] = {}
@@ -149,7 +139,6 @@ class Project(_ProjectBuilders):
         self._default_targets: list[Target] = []
         self._config = config
         self._resolved = False
-        self._path_resolver = PathResolver(self.root_dir, self.build_dir)
         self._found_packages: dict[tuple[str, str | None, tuple[str, ...]], Target] = {}
         self._package_finder_chain: Any = None  # Lazy-initialized FinderChain
         self.defined_at = defined_at or get_caller_location()
@@ -167,6 +156,15 @@ class Project(_ProjectBuilders):
             self._parent = None
 
         if self._parent:
+            if build_dir is not None:
+                import warnings
+
+                warnings.warn(
+                    f"Project '{self.name}': build_dir argument is ignored for sub-projects; "
+                    f"using parent project's build_dir '{self._parent.build_dir}' instead.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             self._parent._children.append(self)
             self.build_dir = self._parent.build_dir
             # If the child project's root_dir is inside the top-level project,
@@ -176,8 +174,22 @@ class Project(_ProjectBuilders):
             rel = self.root_dir.relative_to(top_root)
             self.root_dir = top_root
             self._subdir = str(rel)
-            # Recreate the path resolver now that root_dir/build_dir changed
-            self._path_resolver = PathResolver(self.root_dir, self.build_dir)
+        else:
+            if build_dir is None:
+                build_dir = os.environ.get("PCONS_BUILD_DIR", "build")
+            if not self.root_dir.is_absolute():
+                raise ValueError(
+                    f"Root directory must be absolute (got: {self.root_dir})"
+                )
+            bd = Path(build_dir)
+            if bd.is_absolute():
+                try:
+                    bd = bd.relative_to(self.root_dir)
+                except ValueError:
+                    pass  # Out-of-tree build — keep absolute
+            self.build_dir = bd
+
+        self._path_resolver = PathResolver(self.root_dir, self.build_dir)
 
         Project.__current = self
         if Project.__top_level is None:

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -362,6 +362,17 @@ class Project(_ProjectBuilders):
                 return target
         return None
 
+    def get_targets(self, *names: str) -> list[Target | None]:
+        """Get multiple targets by name.
+
+        Args:
+            *names: Target names.
+
+        Returns:
+            List of targets, or None for names not found.
+        """
+        return [self.get_target(name) for name in names]
+
     @property
     def targets(self) -> list[Target]:
         """Get all registered targets."""
@@ -374,6 +385,17 @@ class Project(_ProjectBuilders):
     def environments(self) -> list[Env]:
         """Get all registered environments."""
         return list(self._environments)
+
+    @property
+    def default_environment(self) -> Env:
+        """Get the default environment (first one registered).
+
+        Raises:
+            ValueError: If no environments have been registered.
+        """
+        if not self._environments:
+            raise ValueError("No environments have been registered in this project.")
+        return self._environments[0]
 
     def Alias(
         self, name: str, *targets: Target | Node | list[Target | Node]

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -85,11 +85,18 @@ class Project(_ProjectBuilders):
         "_package_finder_chain",
         "defined_at",
         "_parent",
+        "_children",
         "_subdir",
     )
 
     __current: Project | None = None
     __top_level: Project | None = None
+
+    @staticmethod
+    def _clear_tree() -> None:
+        """Clear the project tree (for testing purposes)."""
+        Project.__current = None
+        Project.__top_level = None
 
     def __init__(
         self,
@@ -115,7 +122,7 @@ class Project(_ProjectBuilders):
             defined_at: Source location where project was created.
         """
         self.name = name
-        if root_dir is None:
+        if root_dir is None and Project.__top_level is None:
             root_dir = os.environ.get("PCONS_SOURCE_DIR")
         if root_dir is None:
             # Infer from the script that called Project()
@@ -126,6 +133,8 @@ class Project(_ProjectBuilders):
         self.root_dir = Path(root_dir) if root_dir else Path.cwd()
         if build_dir is None:
             build_dir = os.environ.get("PCONS_BUILD_DIR", "build")
+        if not self.root_dir.is_absolute():
+            raise ValueError(f"Root directory must be absolute (got: {self.root_dir})")
         bd = Path(build_dir)
         if bd.is_absolute():
             try:
@@ -145,6 +154,7 @@ class Project(_ProjectBuilders):
         self._package_finder_chain: Any = None  # Lazy-initialized FinderChain
         self.defined_at = defined_at or get_caller_location()
         self._subdir = None
+        self._children: list[Project] = []
 
         # Auto-register with global registry (for CLI access)
         from pcons import _register_project
@@ -156,21 +166,45 @@ class Project(_ProjectBuilders):
         else:
             self._parent = None
 
+        if self._parent:
+            self._parent._children.append(self)
+            self.build_dir = self._parent.build_dir
+            # If the child project's root_dir is inside the top-level project,
+            # normalize it so that the child's `root_dir` becomes the top-level
+            # root and `_subdir` holds the relative path under the top-level.
+            top_root = Project.top_level().root_dir
+            rel = self.root_dir.relative_to(top_root)
+            self.root_dir = top_root
+            self._subdir = str(rel)
+            # Recreate the path resolver now that root_dir/build_dir changed
+            self._path_resolver = PathResolver(self.root_dir, self.build_dir)
+
         Project.__current = self
         if Project.__top_level is None:
             Project.__top_level = self
 
     @staticmethod
-    def current() -> Project | None:
+    def current() -> Project:
+        if Project.__current is None:
+            raise ValueError("no project is currently active")
         return Project.__current
 
     @staticmethod
-    def top_level() -> Project | None:
+    def top_level() -> Project:
+        if Project.__top_level is None:
+            raise ValueError("no top-level project is currently active")
         return Project.__top_level
 
     @property
     def is_top_level(self) -> bool:
         return self == Project.top_level()
+
+    @property
+    def parent(self) -> Project:
+        """Get the parent project if this is a subdir, or None if top-level."""
+        if self._parent is None:
+            raise ValueError("This project has no parent (it is top-level).")
+        return self._parent
 
     @property
     def current_dir(self) -> Path:
@@ -321,12 +355,20 @@ class Project(_ProjectBuilders):
         Returns:
             The target, or None if not found.
         """
-        return self._targets.get(name)
+        if (target := self._targets.get(name)) is not None:
+            return target
+        for child in self._children:
+            if (target := child.get_target(name)) is not None:
+                return target
+        return None
 
     @property
     def targets(self) -> list[Target]:
         """Get all registered targets."""
-        return list(self._targets.values())
+        results: list[Target] = list(self._targets.values())
+        for child in self._children:
+            results.extend(child.targets)
+        return results
 
     @property
     def environments(self) -> list[Env]:
@@ -492,8 +534,15 @@ class Project(_ProjectBuilders):
             for source in target.sources:
                 if isinstance(source, FileNode):
                     # Only check source files (not generated files)
-                    if source.builder is None and not source.exists():
-                        errors.append(MissingSourceError(str(source.path)))
+
+                    if source.builder is None:
+                        p = source.path
+                        if not p.is_absolute():
+                            p = Project.top_level().root_dir / p
+                        if not p.exists():
+                            errors.append(
+                                MissingSourceError(str(p), target_name=target.name)
+                            )
 
         return errors
 

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -24,7 +24,7 @@ from pcons.core.graph import (
 )
 from pcons.core.node import AliasNode, DirNode, FileNode, Node
 from pcons.core.paths import PathResolver
-from pcons.core.target import Target
+from pcons.core.target import Target, split_qualified_name
 from pcons.util.source_location import SourceLocation, get_caller_location
 
 logger = logging.getLogger(__name__)
@@ -143,7 +143,7 @@ class Project(_ProjectBuilders):
                 pass  # Out-of-tree build — keep absolute
         self.build_dir = bd
         self._environments: list[Env] = []
-        self._targets: dict[str, Target] = {}
+        self._targets: list[Target] = []
         self._nodes: dict[Path, Node] = {}
         self._aliases: dict[str, AliasNode] = {}
         self._default_targets: list[Target] = []
@@ -329,8 +329,11 @@ class Project(_ProjectBuilders):
             )
         return node
 
-    def add_target(self, target: Target) -> None:
-        """Register a target with the project.
+    def _add_target(self, target: Target) -> None:
+        """Register a target with the project (should not be called directly).
+
+        Only Target should call this method, via Target.__init__,
+        to ensure that targets are registered as soon as they are created.
 
         Args:
             target: Target to register.
@@ -338,25 +341,30 @@ class Project(_ProjectBuilders):
         Raises:
             ValueError: If a target with the same name already exists.
         """
-        if target.name in self._targets:
-            existing = self._targets[target.name]
+        if (
+            existing := self.get_target(
+                target.name, raise_if_missing=False, recursive=False
+            )
+        ) is not None:
             raise ValueError(
                 f"Target '{target.name}' already exists "
                 f"(defined at {existing.defined_at})"
             )
-        self._targets[target.name] = target
+        self._targets.append(target)
 
     @overload
     def get_target(
-        self, name: str, raise_if_missing: Literal[True] = ...
+        self, name: str, raise_if_missing: Literal[True] = ..., recursive: bool = ...
     ) -> Target: ...
 
     @overload
     def get_target(
-        self, name: str, raise_if_missing: Literal[False]
+        self, name: str, raise_if_missing: Literal[False], recursive: bool = ...
     ) -> Target | None: ...
 
-    def get_target(self, name: str, raise_if_missing: bool = True) -> Target | None:
+    def get_target(
+        self, name: str, raise_if_missing: bool = True, recursive: bool = True
+    ) -> Target | None:
         """Get a target by name.
 
         Args:
@@ -369,11 +377,38 @@ class Project(_ProjectBuilders):
         Raises:
             KeyError: If the target is not found and raise_if_missing is True.
         """
-        if (target := self._targets.get(name)) is not None:
-            return target
-        for child in self._children:
-            if (target := child.get_target(name, raise_if_missing=False)) is not None:
-                return target
+
+        project, target_name = split_qualified_name(name)
+        if project is not None:
+            if project == self.name:
+                for target in self._targets:
+                    if target.name == target_name:
+                        return target
+                else:
+                    if raise_if_missing:
+                        raise KeyError(f"Target '{name}' not found")
+                    return None
+        else:
+            for target in self._targets:
+                if target.name == target_name:
+                    return target
+
+        if recursive:
+            targets_found = []
+            for child in self._children:
+                if (
+                    target := child.get_target(name, raise_if_missing=False)
+                ) is not None:
+                    targets_found.append(target)
+            if len(targets_found) > 1:
+                raise KeyError(
+                    f"Multiple targets named '{name}' found in child projects: "
+                    f"{', '.join(t.qualified_name for t in targets_found)}\n"
+                    f"Use qualified names (e.g., '{targets_found[0].qualified_name}') to disambiguate."
+                )
+            if targets_found:
+                return targets_found[0]
+
         if raise_if_missing:
             raise KeyError(f"Target '{name}' not found")
         return None
@@ -395,7 +430,7 @@ class Project(_ProjectBuilders):
     @property
     def targets(self) -> list[Target]:
         """Get all registered targets."""
-        results: list[Target] = list(self._targets.values())
+        results: list[Target] = list(self._targets)
         for child in self._children:
             results.extend(child.targets)
         return results
@@ -469,7 +504,7 @@ class Project(_ProjectBuilders):
                     self._default_targets.append(t)
             elif isinstance(t, str):
                 # Look up by name
-                target = self._targets.get(t)
+                target = self.get_target(t)
                 if target and target not in self._default_targets:
                     self._default_targets.append(target)
 
@@ -485,7 +520,7 @@ class Project(_ProjectBuilders):
 
     def all_nodes(self) -> set[Node]:
         """Collect all nodes from all targets."""
-        return collect_all_nodes(list(self._targets.values()))
+        return collect_all_nodes(self._targets)
 
     def _to_build_relative(self, p: Path) -> Path:
         """Strip the build_dir prefix from a canonicalized path.
@@ -562,7 +597,7 @@ class Project(_ProjectBuilders):
         errors: list[Exception] = []
 
         # Check for dependency cycles
-        cycles = detect_cycles_in_targets(list(self._targets.values()))
+        cycles = detect_cycles_in_targets(self._targets)
         for cycle in cycles:
             from pcons.core.errors import DependencyCycleError
 
@@ -571,7 +606,7 @@ class Project(_ProjectBuilders):
         # Check for missing sources
         from pcons.core.errors import MissingSourceError
 
-        for target in self._targets.values():
+        for target in self._targets:
             for source in target.sources:
                 if isinstance(source, FileNode):
                     # Only check source files (not generated files)
@@ -593,7 +628,7 @@ class Project(_ProjectBuilders):
         Returns:
             Targets sorted so dependencies come before dependents.
         """
-        return topological_sort_targets(list(self._targets.values()))
+        return topological_sort_targets(self._targets)
 
     def print_targets(self) -> None:
         """Print a human-readable summary of all targets.
@@ -604,8 +639,8 @@ class Project(_ProjectBuilders):
         print(f"Build dir: {self.build_dir}")
         print(f"Targets ({len(self._targets)}):")
 
-        for name, target in sorted(self._targets.items()):
-            print(f"  {name} ({target.target_type})")
+        for target in sorted(self._targets):
+            print(f"  {target.name} ({target.target_type})")
             if target.sources:
                 print(f"    sources: {len(target.sources)} files")
             if target.output_nodes:
@@ -912,7 +947,6 @@ class Project(_ProjectBuilders):
         from pcons.packages.imported import ImportedTarget
 
         target = ImportedTarget.from_package(pkg, components=components)
-        self.add_target(target)
         self._found_packages[cache_key] = target
         return target
 
@@ -998,7 +1032,7 @@ class Project(_ProjectBuilders):
         lines.append(f"  Root: {self.root_dir}")
         lines.append(f"  Build: {self.build_dir}")
         lines.append(f"  Targets: {len(self._targets)}")
-        for target in list(self._targets.values())[:5]:
+        for target in self._targets[:5]:
             target_type = target.target_type or "unknown"
             lines.append(f"    - {target.name} ({target_type})")
         if len(self._targets) > 5:

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -1050,3 +1050,24 @@ class Project(_ProjectBuilders):
             builder_method.__doc__ = create_target.__doc__
 
         return builder_method
+
+
+def get_target(name: str) -> Target:
+    """Convenience function to get a target by name from the top-level project."""
+    root = Project.top_level()
+    target = root.get_target(name)
+    if target is None:
+        raise ValueError(f"Target '{name}' not found in project '{root.name}'")
+    return target
+
+
+def get_targets(*names: str) -> list[Target]:
+    """Convenience function to get multiple targets by name from the top-level project."""
+    root = Project.top_level()
+    targets: list[Target] = []
+    for name in names:
+        target = root.get_target(name)
+        if target is None:
+            raise ValueError(f"Target '{name}' not found in project '{root.name}'")
+        targets.append(target)
+    return targets

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -1091,24 +1091,3 @@ class Project(_ProjectBuilders):
             builder_method.__doc__ = create_target.__doc__
 
         return builder_method
-
-
-def get_target(name: str) -> Target:
-    """Convenience function to get a target by name from the top-level project."""
-    root = Project.top_level()
-    target = root.get_target(name)
-    if target is None:
-        raise ValueError(f"Target '{name}' not found in project '{root.name}'")
-    return target
-
-
-def get_targets(*names: str) -> list[Target]:
-    """Convenience function to get multiple targets by name from the top-level project."""
-    root = Project.top_level()
-    targets: list[Target] = []
-    for name in names:
-        target = root.get_target(name)
-        if target is None:
-            raise ValueError(f"Target '{name}' not found in project '{root.name}'")
-        targets.append(target)
-    return targets

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -13,7 +13,7 @@ import os
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from pcons.core.builder_registry import BuilderRegistry
 from pcons.core.environment import Environment as Env
@@ -214,7 +214,7 @@ class Project(_ProjectBuilders):
         return self.root_dir
 
     @contextmanager
-    def _enter_subdir(self, subdir: str) -> Generator[None, None, None]:
+    def _enter_subdir(self, subdir: str | Path) -> Generator[None, None, None]:
         """Context manager for entering a subdirectory in the project."""
         old_subdir = self._subdir
         self._subdir = subdir if old_subdir is None else f"{old_subdir}/{subdir}"
@@ -346,30 +346,49 @@ class Project(_ProjectBuilders):
             )
         self._targets[target.name] = target
 
-    def get_target(self, name: str) -> Target | None:
+    @overload
+    def get_target(
+        self, name: str, raise_if_missing: Literal[True] = ...
+    ) -> Target: ...
+
+    @overload
+    def get_target(
+        self, name: str, raise_if_missing: Literal[False]
+    ) -> Target | None: ...
+
+    def get_target(self, name: str, raise_if_missing: bool = True) -> Target | None:
         """Get a target by name.
 
         Args:
             name: Target name.
+            raise_if_missing: Whether to raise an exception if the target is not found.
 
         Returns:
-            The target, or None if not found.
+            The target, or None if not found and raise_if_missing is False.
+
+        Raises:
+            KeyError: If the target is not found and raise_if_missing is True.
         """
         if (target := self._targets.get(name)) is not None:
             return target
         for child in self._children:
-            if (target := child.get_target(name)) is not None:
+            if (target := child.get_target(name, raise_if_missing=False)) is not None:
                 return target
+        if raise_if_missing:
+            raise KeyError(f"Target '{name}' not found")
         return None
 
-    def get_targets(self, *names: str) -> list[Target | None]:
+    def get_targets(self, *names: str) -> list[Target]:
         """Get multiple targets by name.
 
         Args:
             *names: Target names.
 
         Returns:
-            List of targets, or None for names not found.
+            List of targets.
+
+        Raises:
+            KeyError: If any target is not found.
         """
         return [self.get_target(name) for name in names]
 

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -82,7 +84,12 @@ class Project(_ProjectBuilders):
         "_found_packages",
         "_package_finder_chain",
         "defined_at",
+        "_parent",
+        "_subdir",
     )
+
+    __current: Project | None = None
+    __top_level: Project | None = None
 
     def __init__(
         self,
@@ -137,11 +144,51 @@ class Project(_ProjectBuilders):
         self._found_packages: dict[tuple[str, str | None, tuple[str, ...]], Target] = {}
         self._package_finder_chain: Any = None  # Lazy-initialized FinderChain
         self.defined_at = defined_at or get_caller_location()
+        self._subdir = None
 
         # Auto-register with global registry (for CLI access)
         from pcons import _register_project
 
         _register_project(self)
+
+        if Project.__current is not None:
+            self._parent = Project.__current
+        else:
+            self._parent = None
+
+        Project.__current = self
+        if Project.__top_level is None:
+            Project.__top_level = self
+
+    @staticmethod
+    def current() -> Project | None:
+        return Project.__current
+
+    @staticmethod
+    def top_level() -> Project | None:
+        return Project.__top_level
+
+    @property
+    def is_top_level(self) -> bool:
+        return self == Project.top_level()
+
+    @property
+    def current_dir(self) -> Path:
+        """Get the current directory for this project, taking subdirs into account."""
+        if self._subdir:
+            return self.root_dir / self._subdir
+        return self.root_dir
+
+    @contextmanager
+    def _enter_subdir(self, subdir: str) -> Generator[None, None, None]:
+        """Context manager for entering a subdirectory in the project."""
+        old_subdir = self._subdir
+        self._subdir = subdir if old_subdir is None else f"{old_subdir}/{subdir}"
+        try:
+            yield
+        finally:
+            self._subdir = old_subdir
+            Project.__current = self
 
     @property
     def config(self) -> Any:
@@ -156,7 +203,10 @@ class Project(_ProjectBuilders):
     @property
     def path_resolver(self) -> PathResolver:
         """Get the path resolver for this project."""
-        return self._path_resolver
+        if self._subdir:
+            return self._path_resolver.subdir(self._subdir)
+        else:
+            return self._path_resolver
 
     def Environment(
         self,
@@ -199,7 +249,7 @@ class Project(_ProjectBuilders):
         """
         if path.is_absolute():
             try:
-                return path.relative_to(self.root_dir)
+                return path.relative_to(self.current_dir)
             except ValueError:
                 return path  # External path
         return Path(os.path.normpath(path))
@@ -772,7 +822,6 @@ class Project(_ProjectBuilders):
         from pcons.packages.imported import ImportedTarget
 
         target = ImportedTarget.from_package(pkg, components=components)
-        target._project = self
         self.add_target(target)
         self._found_packages[cache_key] = target
         return target

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -269,7 +269,6 @@ class Target:
         self._collected_requirements: UsageRequirements | None = None
         self.target_type: str | None = target_type
         self._env: Environment | None = None
-        self.__project: Project | None = None  # Set by Project when target is created
         self.intermediate_nodes: list[FileNode] = []
         self.output_nodes: list[FileNode] = []
         self._resolved: bool = False
@@ -300,49 +299,18 @@ class Target:
         from pcons.core.project import Project
 
         project = Project.current()
-        if project is not None:
-            self.__project = project
-            self._subdir = project._subdir
 
-            if self._env is None:
-                # default to the last environment in the project, if available
-                self._env = project.environments[-1] if project.environments else None
-        else:
-            self.__project = None
-            self._subdir = None
-            self._env = None
+        self.__project = project
+        self._subdir = project._subdir
+
+        if self._env is None:
+            # default to the last environment in the project, if available
+            self._env = project.environments[-1] if project.environments else None
 
     @property
     def project(self) -> Project:
         """Get the project this target belongs to."""
-        if self.__project is None:
-            raise RuntimeError(
-                f"Target '{self.name}' is not associated with any project. "
-                f"Ensure it was created via a Project method like "
-                f"project.Program() or project.Library()."
-            )
         return self.__project
-
-    # @project.setter
-    # def project(self, project: Project | None) -> None:
-    #     if project is None:
-    #         from pcons.core.project import Project
-
-    #         if Project.current() is not None:
-    #             project = Project.current()
-    #         else:
-    #             return  # skip, some target may not belong to a project (e.g., Command)
-
-    #     if self.__project is not None:
-    #         raise RuntimeError(
-    #             f"Target '{self.name}' is already associated with a project. "
-    #         )
-    #     self.__project = project
-    #     self._subdir = project._subdir
-
-    #     if self._env is None:
-    #         # default to the last environment in the project, if available
-    #         self._env = project.environments[-1] if project.environments else None
 
     @property
     def sources(self) -> list[Node]:
@@ -632,17 +600,12 @@ class Target:
 
     def _to_node(self, source: Node | Path | str) -> Node:
         """Convert a source specification to a Node."""
-        from pcons.core.node import FileNode
         from pcons.core.node import Node as NodeClass
 
         if isinstance(source, NodeClass):
             return source
         path = Path(source)
-        # Use project's node() if available for deduplication
-        if self.project is not None:
-            node: Node = self.project.node(path)
-            return node
-        return FileNode(path)
+        return self.project.node(path)
 
     def set_option(self, key: str, value: Any) -> Target:
         """Set a builder/toolchain option on this target (fluent API).

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -152,6 +152,42 @@ def _validate_target_name(name: str) -> None:
         )
 
 
+def split_qualified_name(
+    name: str, raise_on_invalid: bool = True
+) -> tuple[str | None, str]:
+    """Split a qualified name into (project, target).
+
+    A qualified name contains a project qualifier, in the form "project::target".
+    If the name is not qualified, returns (None, name).
+
+    Args:
+        name: The qualified or unqualified name to split.
+    Returns:
+        A tuple of (project, target) where project is None if not qualified.
+    """
+    parts = name.split("::")
+    count = len(parts)
+    if count == 2:
+        return parts[0], parts[1]
+    elif count == 1:
+        return None, parts[0]
+    else:
+        if raise_on_invalid:
+            raise ValueError(
+                f"Invalid qualified name: {name!r}. Too many '::' separators."
+            )
+        return None, name
+
+
+def is_qualified_name(name: str) -> bool:
+    """Check if a name is a qualified name.
+
+    A qualified name contains a project qualifier, in the form "project::target".
+    """
+    project, _target = split_qualified_name(name, raise_on_invalid=False)
+    return project is not None
+
+
 class Target:
     """A named build target with usage requirements.
 
@@ -307,10 +343,21 @@ class Target:
             # default to the last environment in the project, if available
             self._env = project.environments[-1] if project.environments else None
 
+        self.__project._add_target(self)
+
     @property
     def project(self) -> Project:
         """Get the project this target belongs to."""
         return self.__project
+
+    @property
+    def qualified_name(self) -> str:
+        """Get the qualified name.
+
+        Returns:
+            The qualified name, in the form "<project>::<target>".
+        """
+        return f"{self.project.name}::{self.name}"
 
     @property
     def sources(self) -> list[Node]:
@@ -759,7 +806,9 @@ class Target:
         if self.output_nodes:
             lines.append(f"  Outputs: {[str(n.path) for n in self.output_nodes]}")
         if self.dependencies:
-            lines.append(f"  Dependencies: {[d.name for d in self.dependencies]}")
+            lines.append(
+                f"  Dependencies: {[d.qualified_name for d in self.dependencies]}"
+            )
         if self.public.include_dirs:
             lines.append(f"  Public includes: {self.public.include_dirs}")
         if self.public.defines:
@@ -767,16 +816,16 @@ class Target:
         return "\n".join(lines)
 
     def __repr__(self) -> str:
-        deps = ", ".join(d.name for d in self.dependencies)
-        return f"Target({self.name!r}, deps=[{deps}])"
+        deps = ", ".join(d.qualified_name for d in self.dependencies)
+        return f"Target({self.qualified_name!r}, deps=[{deps}])"
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Target):
             return NotImplemented
-        return self.name == other.name
+        return self.qualified_name == other.qualified_name
 
     def __hash__(self) -> int:
-        return hash(self.name)
+        return hash(self.qualified_name)
 
 
 class ImportedTarget(Target):

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
     from pcons.core._usage_requirements_stubs import _UsageRequirementsStubs
     from pcons.core.builder import Builder
     from pcons.core.environment import Environment
-    from pcons.core.node import FileNode, Node
+    from pcons.core.node import BuildInfo, FileNode, Node
+    from pcons.core.paths import PathResolver
     from pcons.core.project import Project
 else:
     # At runtime, UsageRequirements inherits from `object`. The mixin only
@@ -200,7 +201,7 @@ class Target:
         # NEW for target-centric build model:
         "target_type",
         "_env",
-        "_project",
+        "__project",
         "intermediate_nodes",
         "output_nodes",
         "_resolved",
@@ -236,6 +237,7 @@ class Target:
         # Implicit target deps with propagate=False (output nodes only,
         # no usage requirement propagation).
         "_implicit_target_deps_output_only",
+        "_subdir",
     )
 
     def __init__(
@@ -267,7 +269,7 @@ class Target:
         self._collected_requirements: UsageRequirements | None = None
         self.target_type: str | None = target_type
         self._env: Environment | None = None
-        self._project: Project | None = None  # Set by Project when target is created
+        self.__project: Project | None = None  # Set by Project when target is created
         self.intermediate_nodes: list[FileNode] = []
         self.output_nodes: list[FileNode] = []
         self._resolved: bool = False
@@ -282,7 +284,7 @@ class Target:
         # Sources that need resolution after main resolve phase
         self._pending_sources: list[Target | Node | Path | str] | None = None
         # Build info for archive and command targets
-        self._build_info: dict[str, Any] | None = None
+        self._build_info: BuildInfo | dict[str, Any] | None = None
         # Generic builder support (extensible builder architecture)
         self._builder_name: str | None = None
         # Builder-specific data dict, initialized to empty dict (not None)
@@ -294,6 +296,53 @@ class Target:
         # Implicit target deps (from target.depends(other_target))
         self._implicit_target_deps: list[Target] = []
         self._implicit_target_deps_output_only: list[Target] = []
+
+        from pcons.core.project import Project
+
+        project = Project.current()
+        if project is not None:
+            self.__project = project
+            self._subdir = project._subdir
+
+            if self._env is None:
+                # default to the last environment in the project, if available
+                self._env = project.environments[-1] if project.environments else None
+        else:
+            self.__project = None
+            self._subdir = None
+            self._env = None
+
+    @property
+    def project(self) -> Project:
+        """Get the project this target belongs to."""
+        if self.__project is None:
+            raise RuntimeError(
+                f"Target '{self.name}' is not associated with any project. "
+                f"Ensure it was created via a Project method like "
+                f"project.Program() or project.Library()."
+            )
+        return self.__project
+
+    # @project.setter
+    # def project(self, project: Project | None) -> None:
+    #     if project is None:
+    #         from pcons.core.project import Project
+
+    #         if Project.current() is not None:
+    #             project = Project.current()
+    #         else:
+    #             return  # skip, some target may not belong to a project (e.g., Command)
+
+    #     if self.__project is not None:
+    #         raise RuntimeError(
+    #             f"Target '{self.name}' is already associated with a project. "
+    #         )
+    #     self.__project = project
+    #     self._subdir = project._subdir
+
+    #     if self._env is None:
+    #         # default to the last environment in the project, if available
+    #         self._env = project.environments[-1] if project.environments else None
 
     @property
     def sources(self) -> list[Node]:
@@ -332,6 +381,25 @@ class Target:
             f"Use add_source() or add_sources() instead. "
             f"Example: target.add_sources({value!r})"
         )
+
+    @property
+    def build_dir(self) -> Path:
+        if self._subdir:
+            return self.project.build_dir / self._subdir
+        return self.project.build_dir
+
+    @property
+    def source_dir(self) -> Path:
+        if self._subdir:
+            return self.project.root_dir / self._subdir
+        return self.project.root_dir
+
+    @property
+    def path_resolver(self) -> PathResolver:
+        """Get the Path resolver for this target's project."""
+        if self._subdir:
+            return self.project.path_resolver.subdir(self._subdir)
+        return self.project.path_resolver
 
     @property
     def nodes(self) -> list[FileNode]:
@@ -442,7 +510,7 @@ class Target:
                     file_list.append(item)
                 else:
                     # str or Path — convert to FileNode via project
-                    project = self._project
+                    project = self.project
                     if project is not None:
                         file_list.append(project.node(item))
                     else:
@@ -554,6 +622,10 @@ class Target:
                     path = Path(source)
                     if not path.is_absolute():
                         source = base_path / path
+                # Only join subdir when source is a string or Path. If it's
+                # already a Node, leave it alone.
+                if self._subdir and isinstance(source, (str, Path)):
+                    source = Path(self._subdir) / source
                 node = self._to_node(source)
                 self._sources.append(node)
         return self
@@ -567,8 +639,8 @@ class Target:
             return source
         path = Path(source)
         # Use project's node() if available for deduplication
-        if self._project is not None:
-            node: Node = self._project.node(path)
+        if self.project is not None:
+            node: Node = self.project.node(path)
             return node
         return FileNode(path)
 

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -833,7 +833,7 @@ class XcodeGenerator(BaseGenerator):
 
         env = target._env
 
-        # Collect include directories
+        # Collect include directories (coerce to Path so strings work)
         include_dirs: list[str] = []
         for inc_dir in target.public.include_dirs:
             include_dirs.append(str(self._make_relative_path(Path(inc_dir))))

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -92,6 +92,10 @@ class XcodeGenerator(BaseGenerator):
         self._products_group_id: str = ""
         self._sources_group_id: str = ""
         self._topdir: str = ".."  # Relative path from output_dir to project root
+        self._frameworks_phase_ids: dict[
+            str, str
+        ] = {}  # target name -> frameworks phase id
+        self._product_ref_ids: dict[str, str] = {}  # target name -> product file ref id
 
     def _generate_impl(self, project: Project, output_dir: Path) -> None:
         """Generate .xcodeproj bundle.
@@ -108,6 +112,8 @@ class XcodeGenerator(BaseGenerator):
         self._pcons_project = project
         self._target_ids = {}
         self._objects = {}
+        self._frameworks_phase_ids = {}
+        self._product_ref_ids = {}
 
         # Compute relative path from output_dir to project root
         # This is used for source file paths in the Xcode project
@@ -172,12 +178,34 @@ class XcodeGenerator(BaseGenerator):
         objects: dict[str, dict[str, Any]] = {}
         target_ids: list[str] = []
 
-        # Create targets first
+        # First pass: create all target objects (populates _product_ref_ids, _frameworks_phase_ids)
         for target in project.targets:
             target_id = self._create_target_objects(target, objects)
             if target_id:
                 target_ids.append(target_id)
                 self._target_ids[target.name] = target_id
+
+        # Second pass: add library deps to the frameworks link phase.
+        # Must be done here, directly on the plain-dict `objects`, BEFORE XcodeProject
+        # is created from the tree — mutations to PBXGenericObject after construction
+        # do not reliably persist in the serialized output.
+        for target in project.targets:
+            frameworks_phase_id = self._frameworks_phase_ids.get(target.name)
+            if not frameworks_phase_id:
+                continue
+            for dep in target.dependencies:
+                dep_type = str(dep.target_type) if dep.target_type else None
+                if dep_type not in ("static_library", "shared_library"):
+                    continue
+                dep_product_ref = self._product_ref_ids.get(dep.name)
+                if not dep_product_ref:
+                    continue
+                build_file_id = _generate_id()
+                objects[build_file_id] = {
+                    "isa": "PBXBuildFile",
+                    "fileRef": dep_product_ref,
+                }
+                objects[frameworks_phase_id]["files"].append(build_file_id)
 
         # Project-level build configurations
         # SYMROOT = "." ensures build products go directly in build dir,
@@ -387,6 +415,10 @@ class XcodeGenerator(BaseGenerator):
             "productReference": product_ref_id,
             "productType": product_type,
         }
+
+        # Store phase and product IDs for later linking setup
+        self._frameworks_phase_ids[target.name] = frameworks_phase_id
+        self._product_ref_ids[target.name] = product_ref_id
 
         return target_id
 

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -811,8 +811,9 @@ class XcodeGenerator(BaseGenerator):
             target.private.include_dirs
         )
 
+        path_resolver = target.path_resolver
         for inc_dir_raw in include_dirs:
-            inc_dir = Path(inc_dir_raw)
+            inc_dir = path_resolver.normalize_source_path(inc_dir_raw)
             if inc_dir.is_dir():
                 for ext in [".h", ".hpp", ".hxx", ".H", ".hh"]:
                     headers.extend(inc_dir.rglob(f"*{ext}"))
@@ -833,12 +834,36 @@ class XcodeGenerator(BaseGenerator):
 
         env = target._env
 
-        # Collect include directories (coerce to Path so strings work)
+        # Collect include directories with proper subdir resolution and
+        # transitive dependency propagation. Raw include_dirs from subdirectory
+        # targets (e.g. "include" set inside libfoo/) must be resolved relative
+        # to the target's _subdir, not the project root.
         include_dirs: list[str] = []
-        for inc_dir in target.public.include_dirs:
-            include_dirs.append(str(self._make_relative_path(Path(inc_dir))))
-        for inc_dir in target.private.include_dirs:
-            include_dirs.append(str(self._make_relative_path(Path(inc_dir))))
+        if env is not None:
+            from pcons.tools.requirements import compute_effective_requirements
+
+            eff = compute_effective_requirements(target, env)
+            for inc_path in eff.includes:
+                include_dirs.append(str(self._make_relative_path(inc_path)))
+        else:
+            # Fallback: apply _subdir resolution manually
+            path_resolver = target.path_resolver
+            for inc_dir in target.public.include_dirs:
+                include_dirs.append(
+                    str(
+                        self._make_relative_path(
+                            path_resolver.normalize_source_path(inc_dir)
+                        )
+                    )
+                )
+            for inc_dir in target.private.include_dirs:
+                include_dirs.append(
+                    str(
+                        self._make_relative_path(
+                            path_resolver.normalize_source_path(inc_dir)
+                        )
+                    )
+                )
 
         if include_dirs:
             self._xcode_project.set_flags(

--- a/pcons/tools/archive.py
+++ b/pcons/tools/archive.py
@@ -306,7 +306,6 @@ class TarfileBuilder:
             defined_at=get_caller_location(),
         )
         target._env = env
-        target._project = project
 
         # Set builder metadata
         target._builder_name = "Tarfile"
@@ -372,7 +371,6 @@ class ZipfileBuilder:
             defined_at=get_caller_location(),
         )
         target._env = env
-        target._project = project
 
         # Set builder metadata
         target._builder_name = "Zipfile"

--- a/pcons/tools/archive.py
+++ b/pcons/tools/archive.py
@@ -317,7 +317,6 @@ class TarfileBuilder:
         }
         target._pending_sources = list(sources) if sources else []
 
-        project.add_target(target)
         return target
 
 
@@ -381,7 +380,6 @@ class ZipfileBuilder:
         }
         target._pending_sources = list(sources) if sources else []
 
-        project.add_target(target)
         return target
 
 

--- a/pcons/tools/compile_link.py
+++ b/pcons/tools/compile_link.py
@@ -218,7 +218,7 @@ class CompileLinkFactory:
 
         Format: ``<build_dir>/obj.<target>/<relative_dir>/<name>.<src_ext><obj_ext>``
         """
-        build_dir = self.project.build_dir
+        build_dir = target.build_dir
         obj_dir = build_dir / f"obj.{target.name}"
 
         handler = self._get_source_handler(source, env)
@@ -229,10 +229,8 @@ class CompileLinkFactory:
             obj_suffix = toolchain.get_object_suffix() if toolchain else ".o"
 
         obj_name = source.name + obj_suffix
-        rel_dir = source.parent
-        parts = [
-            p for p in rel_dir.parts if p not in ("..", "/") and p != rel_dir.anchor
-        ]
+        rel_dir = target.path_resolver.normalize_source_path(source.parent)
+        parts = [p for p in rel_dir.parts if p not in ("..", "/")]
         if parts:
             return obj_dir.joinpath(*parts) / obj_name
         return obj_dir / obj_name
@@ -380,9 +378,8 @@ class CompileLinkFactory:
                 target.name,
             )
             return
-
-        build_dir = self.project.build_dir
-        path_resolver = self.project.path_resolver
+        build_dir = target.build_dir
+        path_resolver = target.path_resolver
 
         lib_name = self._apply_output_naming(target, env, "static_library")
         lib_path = build_dir / path_resolver.normalize_target_path(lib_name)
@@ -416,8 +413,8 @@ class CompileLinkFactory:
             )
             return
 
-        build_dir = self.project.build_dir
-        path_resolver = self.project.path_resolver
+        build_dir = target.build_dir
+        path_resolver = target.path_resolver
 
         lib_name = self._apply_output_naming(target, env, "shared_library")
         lib_path = build_dir / path_resolver.normalize_target_path(lib_name)
@@ -457,8 +454,8 @@ class CompileLinkFactory:
             )
             return
 
-        build_dir = self.project.build_dir
-        path_resolver = self.project.path_resolver
+        build_dir = target.build_dir
+        path_resolver = target.path_resolver
 
         prog_name = self._apply_output_naming(target, env, "program")
         prog_path = build_dir / path_resolver.normalize_target_path(prog_name)

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -465,7 +465,6 @@ class InstallBuilder:
         install_target._builder_data = {"dest_dir": str(dest_dir)}
         install_target._pending_sources = list(sources)
 
-        project.add_target(install_target)
         return install_target
 
 
@@ -524,7 +523,6 @@ class InstallAsBuilder:
         install_target._builder_data = {"dest": str(dest)}
         install_target._pending_sources = [source]
 
-        project.add_target(install_target)
         return install_target
 
 
@@ -572,5 +570,4 @@ class InstallDirBuilder:
         install_target._builder_data = {"dest_dir": str(dest_dir)}
         install_target._pending_sources = [source]
 
-        project.add_target(install_target)
         return install_target

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -51,7 +51,7 @@ def _deduplicate_target_name(project: Project, base_name: str) -> str:
     """
     target_name = base_name
     counter = 1
-    while project.get_target(target_name) is not None:
+    while project.get_target(target_name, False) is not None:
         target_name = f"{base_name}_{counter}"
         counter += 1
     if target_name != base_name:

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -198,7 +198,7 @@ class InstallNodeFactory(PendingSourceFactory):
         sources use copycmd.
         """
         # Normalize destination directory using PathResolver
-        path_resolver = self.project.path_resolver
+        path_resolver = target.path_resolver
         dest_dir = path_resolver.normalize_target_path(
             dest_dir, target_name=target.name
         )
@@ -261,7 +261,7 @@ class InstallNodeFactory(PendingSourceFactory):
         dest_path = dest_dir / source_path.name
 
         # Stamp file for ninja tracking
-        stamps_dir = self.project.build_dir / ".stamps"
+        stamps_dir = target.build_dir / ".stamps"
         stamp_name = str(dest_path).replace("/", "_").replace("\\", "_") + ".stamp"
         stamp_path = stamps_dir / stamp_name
 
@@ -275,7 +275,7 @@ class InstallNodeFactory(PendingSourceFactory):
 
         # Build destination path relative to build directory
         try:
-            rel_dest = dest_path.relative_to(self.project.build_dir)
+            rel_dest = dest_path.relative_to(target.build_dir)
         except ValueError:
             rel_dest = dest_path
 
@@ -318,7 +318,7 @@ class InstallNodeFactory(PendingSourceFactory):
             )
 
         # Normalize destination path using PathResolver
-        path_resolver = self.project.path_resolver
+        path_resolver = target.path_resolver
         dest = path_resolver.normalize_target_path(dest, target_name=target.name)
 
         source_node = sources[0]
@@ -359,7 +359,7 @@ class InstallNodeFactory(PendingSourceFactory):
             )
 
         # Normalize destination directory using PathResolver
-        path_resolver = self.project.path_resolver
+        path_resolver = target.path_resolver
         dest_dir = path_resolver.normalize_target_path(
             dest_dir, target_name=target.name
         )
@@ -371,7 +371,7 @@ class InstallNodeFactory(PendingSourceFactory):
         dest_path = dest_dir / source_path.name
 
         # Put stamp files in a dedicated .stamps directory
-        stamps_dir = self.project.build_dir / ".stamps"
+        stamps_dir = target.build_dir / ".stamps"
         stamp_name = str(dest_path).replace("/", "_").replace("\\", "_") + ".stamp"
         stamp_path = stamps_dir / stamp_name
 
@@ -386,7 +386,7 @@ class InstallNodeFactory(PendingSourceFactory):
 
         # Build the destination path relative to build directory for the command
         try:
-            rel_dest = dest_path.relative_to(self.project.build_dir)
+            rel_dest = dest_path.relative_to(target.build_dir)
         except ValueError:
             rel_dest = dest_path
 

--- a/pcons/tools/requirements.py
+++ b/pcons/tools/requirements.py
@@ -122,7 +122,11 @@ def _resolve_and_add_includes_for(
         p = Path(inc) if not isinstance(inc, Path) else inc
         if owner._subdir and not p.is_absolute():
             p = Path(owner._subdir) / p
-        return owner.project.path_resolver.canonicalize(p)
+        # Canonicalize relative to the top-level project's resolver so
+        # generators (which use the top-level resolver) see consistent
+        # project-relative paths for includes coming from subprojects.
+        top = owner.project.top_level()
+        return top.path_resolver.canonicalize(p)
 
     result.include_dirs = [_update_include(inc) for inc in reqs.include_dirs]
     return result

--- a/pcons/tools/requirements.py
+++ b/pcons/tools/requirements.py
@@ -112,6 +112,22 @@ class EffectiveRequirements:
         )
 
 
+def _resolve_and_add_includes_for(
+    reqs: UsageRequirements, owner: Target
+) -> UsageRequirements:
+    """Resolve include directories in requirements and return a new UsageRequirements."""
+    result = reqs.clone()
+
+    def _update_include(inc: str | Path) -> Path:
+        p = Path(inc) if not isinstance(inc, Path) else inc
+        if owner._subdir and not p.is_absolute():
+            p = Path(owner._subdir) / p
+        return owner.project.path_resolver.canonicalize(p)
+
+    result.include_dirs = [_update_include(inc) for inc in reqs.include_dirs]
+    return result
+
+
 def compute_effective_requirements(
     target: Target,
     env: Environment,
@@ -171,14 +187,14 @@ def compute_effective_requirements(
 
     # Layer 2: Target's own requirements
     # Private: only for this target
-    result.merge(target.private)
+    result.merge(_resolve_and_add_includes_for(target.private, target))
     # Public: also available to this target's own sources (not just consumers)
-    result.merge(target.public)
+    result.merge(_resolve_and_add_includes_for(target.public, target))
 
     # Layer 3: All dependencies' public requirements (transitive)
     # transitive_dependencies() includes direct dependencies via DFS
     for dep in target.transitive_dependencies():
-        result.merge(dep.public)
+        result.merge(_resolve_and_add_includes_for(dep.public, dep))
 
     # Layer 4: Implicit target deps from target.depends(other_target)
     # These propagate public usage requirements (includes, defines) to
@@ -186,7 +202,7 @@ def compute_effective_requirements(
     # to the linker's $in.  Only propagated deps (not output-only).
     if for_compilation:
         for dep in target._implicit_target_deps:
-            result.merge(dep.public)
+            result.merge(_resolve_and_add_includes_for(dep.public, dep))
 
     return result
 

--- a/pcons/util/add_subdirectory.py
+++ b/pcons/util/add_subdirectory.py
@@ -45,9 +45,6 @@ def add_subdirectory(
           (in order), e.g. ``lib, hdr = add_subdirectory("sub", pick=["lib", "hdr"])``.
     """
     project = Project.current()
-    if project is None:
-        raise RuntimeError("add_subdirectory() must be called within a Project context")
-
     subdir_path = project.current_dir / subdir
     if not (subdir_path / "pcons-build.py").exists():
         raise FileNotFoundError(f"No pcons-build.py found in {subdir_path}")

--- a/pcons/util/add_subdirectory.py
+++ b/pcons/util/add_subdirectory.py
@@ -1,26 +1,24 @@
 import runpy
+from pathlib import Path
 
 from pcons.core.project import Project
 
 
-def add_subdirectory(subdir):
-    """Adds a subdirectory to the project by running its pcons-build.py.
+def add_subdirectory(subdir: str | Path):
+    """Adds a subdirectory to the project.
 
-    The subdir must contain a pcons-build.py that defines a function
-    `build_subdir(build_dir)` which adds targets to the given project.
-
-    Args:
-        project: The parent Project instance to which the subdir will add targets.
-        subdir: Path to the subdirectory containing pcons-build.py.
+    This function looks for a pcons-build.py file in the specified subdirectory and executes it in the context of the current project.
+    This allows you to organize your project into multiple subdirectories,
 
     Returns:
-        The result of the subdir's build function, if any.
+        The loaded module from the subdirectory's pcons-build.py,
+        which can be used to access any variables or functions defined there.
     """
     project = Project.current()
     if project is None:
         raise RuntimeError("add_subdirectory() must be called within a Project context")
 
-    subdir_path = project.root_dir / subdir
+    subdir_path = project.current_dir / subdir
     if not (subdir_path / "pcons-build.py").exists():
         raise FileNotFoundError(f"No pcons-build.py found in {subdir_path}")
 

--- a/pcons/util/add_subdirectory.py
+++ b/pcons/util/add_subdirectory.py
@@ -1,18 +1,48 @@
 import runpy
 from pathlib import Path
+from types import SimpleNamespace
+from typing import overload
 
 from pcons.core.project import Project
 
 
-def add_subdirectory(subdir: str | Path):
+@overload
+def add_subdirectory(subdir: str | Path, pick: list[str]) -> tuple: ...
+
+
+@overload
+def add_subdirectory(subdir: str | Path, pick: None = None) -> SimpleNamespace: ...
+
+
+def add_subdirectory(
+    subdir: str | Path, pick: list[str] | None = None
+) -> tuple | SimpleNamespace:
     """Adds a subdirectory to the project.
 
-    This function looks for a pcons-build.py file in the specified subdirectory and executes it in the context of the current project.
-    This allows you to organize your project into multiple subdirectories,
+    Looks for a ``pcons-build.py`` file in the specified subdirectory and
+    executes it in the context of the current project.
+    Any name assigned at module scope in that script is *exported*: it becomes
+    an attribute of the returned ``SimpleNamespace``, so callers can write ``ns.my_lib``
+    instead of looking up targets by string.
+
+    Example:
+
+        # subdir/pcons-build.py
+        my_lib = project.StaticLibrary("my_lib", env, sources=["lib.c"])
+
+        # parent pcons-build.py
+        sub = add_subdirectory("subdir")
+        app.link(sub.my_lib)
+
+        # Or, with pick:
+        my_lib, = add_subdirectory("subdir", pick=["my_lib"])
+        app.link(my_lib)
 
     Returns:
-        The loaded module from the subdirectory's pcons-build.py,
-        which can be used to access any variables or functions defined there.
+        - If ``pick`` is not specified, a ``SimpleNamespace`` whose attributes
+          are all module-level names defined in the subdirectory script.
+        - If ``pick`` is specified, a tuple containing only the listed names
+          (in order), e.g. ``lib, hdr = add_subdirectory("sub", pick=["lib", "hdr"])``.
     """
     project = Project.current()
     if project is None:
@@ -23,4 +53,8 @@ def add_subdirectory(subdir: str | Path):
         raise FileNotFoundError(f"No pcons-build.py found in {subdir_path}")
 
     with project._enter_subdir(subdir):
-        return runpy.run_path(str(subdir_path / "pcons-build.py"))
+        module = runpy.run_path(str(subdir_path / "pcons-build.py"))
+        if pick is not None:
+            return tuple(module[name] for name in pick)
+        else:
+            return SimpleNamespace(**module)

--- a/pcons/util/add_subdirectory.py
+++ b/pcons/util/add_subdirectory.py
@@ -1,0 +1,28 @@
+import runpy
+
+from pcons.core.project import Project
+
+
+def add_subdirectory(subdir):
+    """Adds a subdirectory to the project by running its pcons-build.py.
+
+    The subdir must contain a pcons-build.py that defines a function
+    `build_subdir(build_dir)` which adds targets to the given project.
+
+    Args:
+        project: The parent Project instance to which the subdir will add targets.
+        subdir: Path to the subdirectory containing pcons-build.py.
+
+    Returns:
+        The result of the subdir's build function, if any.
+    """
+    project = Project.current()
+    if project is None:
+        raise RuntimeError("add_subdirectory() must be called within a Project context")
+
+    subdir_path = project.root_dir / subdir
+    if not (subdir_path / "pcons-build.py").exists():
+        raise FileNotFoundError(f"No pcons-build.py found in {subdir_path}")
+
+    with project._enter_subdir(subdir):
+        return runpy.run_path(str(subdir_path / "pcons-build.py"))

--- a/pcons/util/macos.py
+++ b/pcons/util/macos.py
@@ -197,7 +197,6 @@ def create_universal_binary(
         from pcons.core.environment import Environment
 
         env = Environment()
-        env._project = project
 
     # Create the lipo command
     # The command uses $SOURCES and $TARGET (generator-agnostic variables)

--- a/tests/configure/test_checks.py
+++ b/tests/configure/test_checks.py
@@ -9,6 +9,7 @@ import pytest
 from pcons.configure.checks import CheckResult, ToolChecks
 from pcons.configure.config import Configure
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 
 
 class TestCheckResult:
@@ -61,6 +62,7 @@ class TestToolChecksWithCompiler:
     @pytest.fixture
     def setup(self, tmp_path):
         config = Configure(build_dir=tmp_path)
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
 
@@ -225,6 +227,7 @@ class TestToolChecksWithoutCompiler:
 
     def test_no_compiler_configured(self, tmp_path):
         config = Configure(build_dir=tmp_path)
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         # Don't set env.cc.cmd
@@ -237,6 +240,7 @@ class TestToolChecksWithoutCompiler:
 
     def test_cache_key_format(self, tmp_path):
         config = Configure(build_dir=tmp_path)
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"

--- a/tests/configure/test_checks.py
+++ b/tests/configure/test_checks.py
@@ -9,7 +9,6 @@ import pytest
 from pcons.configure.checks import CheckResult, ToolChecks
 from pcons.configure.config import Configure
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 
 
 class TestCheckResult:

--- a/tests/configure/test_checks.py
+++ b/tests/configure/test_checks.py
@@ -60,9 +60,8 @@ class TestToolChecksWithCompiler:
     """Tests that require a real compiler."""
 
     @pytest.fixture
-    def setup(self, tmp_path):
+    def setup(self, tmp_path, test_project):  # noqa: F811
         config = Configure(build_dir=tmp_path)
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
 
@@ -225,9 +224,8 @@ class TestToolChecksWithCompiler:
 class TestToolChecksWithoutCompiler:
     """Tests that don't require a real compiler."""
 
-    def test_no_compiler_configured(self, tmp_path):
+    def test_no_compiler_configured(self, tmp_path, test_project):  # noqa: F811
         config = Configure(build_dir=tmp_path)
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         # Don't set env.cc.cmd
@@ -238,9 +236,8 @@ class TestToolChecksWithoutCompiler:
         assert result.success is False
         assert "No compiler" in result.output
 
-    def test_cache_key_format(self, tmp_path):
+    def test_cache_key_format(self, tmp_path, test_project):  # noqa: F811
         config = Configure(build_dir=tmp_path)
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def clear_project_tree():
     yield
     Project._clear_tree()
 
+
 @pytest.fixture
 def test_project():
     """Create a default project for testing."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 
 import pytest
 
+from pcons.core.project import Project
 from pcons.toolchains.gcc import (
     GccArchiver,
     GccCCompiler,
@@ -55,3 +56,15 @@ int main(void) {
 """
     )
     return src_file
+
+
+@pytest.fixture(autouse=True)
+def clear_project_tree():
+    """Ensure global Project state is cleared for each test.
+
+    Calls `Project._clear_tree()` before the test and again after to
+    guarantee a clean project registry and avoid cross-test leakage.
+    """
+    Project._clear_tree()
+    yield
+    Project._clear_tree()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,3 +68,9 @@ def clear_project_tree():
     Project._clear_tree()
     yield
     Project._clear_tree()
+
+@pytest.fixture
+def test_project():
+    """Create a default project for testing."""
+    project = Project(name="test_project")
+    return project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -71,7 +71,7 @@ def clear_project_tree():
 
 
 @pytest.fixture
-def test_project():
+def test_project(tmp_path):
     """Create a default project for testing."""
-    project = Project(name="test_project")
+    project = Project(name="test_project", root_dir=tmp_path)
     return project

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pcons.core.builder import BaseBuilder, Builder, CommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode, Node
+from pcons.core.project import Project
 
 
 class TestBuilderProtocol:
@@ -45,6 +46,7 @@ class TestBaseBuilder:
                 return sources
 
         builder = TestBuilder("Test", "test", target_suffixes=[".out"])
+        Project("test_project")
         env = Environment()
 
         # Mix of strings, Paths, and Nodes
@@ -78,6 +80,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmdline = "$cc.cmd -c -o $TARGET $SOURCE"
@@ -99,6 +102,7 @@ class TestCommandBuilder:
             single_source=False,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmdline = "$link.cmd -o $TARGET $SOURCES"
@@ -121,6 +125,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -143,6 +148,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -163,6 +169,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -184,6 +191,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -206,6 +214,7 @@ class TestCommandBuilder:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -238,6 +247,7 @@ class TestCommandBuilderDepfile:
             deps_style="gcc",
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -266,6 +276,7 @@ class TestCommandBuilderDepfile:
             deps_style="msvc",
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"
@@ -289,6 +300,7 @@ class TestCommandBuilderDepfile:
             single_source=False,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "gcc"

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from pcons.core.builder import BaseBuilder, Builder, CommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode, Node
-from pcons.core.project import Project
 
 
 class TestBuilderProtocol:

--- a/tests/core/test_builder.py
+++ b/tests/core/test_builder.py
@@ -40,13 +40,12 @@ class TestBaseBuilder:
         assert builder.target_suffixes == [".o"]
         assert builder.language == "c"
 
-    def test_normalize_sources(self):
+    def test_normalize_sources(self, test_project):  # noqa: F811
         class TestBuilder(BaseBuilder):
             def _build(self, env, targets, sources, **kwargs):
                 return sources
 
         builder = TestBuilder("Test", "test", target_suffixes=[".out"])
-        Project("test_project")
         env = Environment()
 
         # Mix of strings, Paths, and Nodes
@@ -70,7 +69,7 @@ class TestCommandBuilder:
         assert builder.name == "Object"
         assert builder.tool_name == "cc"
 
-    def test_single_source_mode(self):
+    def test_single_source_mode(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -80,7 +79,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmdline = "$cc.cmd -c -o $TARGET $SOURCE"
@@ -92,7 +90,7 @@ class TestCommandBuilder:
         assert len(result) == 2
         assert all(isinstance(n, FileNode) for n in result)
 
-    def test_multi_source_mode(self):
+    def test_multi_source_mode(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Program",
             "link",
@@ -102,7 +100,6 @@ class TestCommandBuilder:
             single_source=False,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmdline = "$link.cmd -o $TARGET $SOURCES"
@@ -115,7 +112,7 @@ class TestCommandBuilder:
         assert isinstance(result[0], FileNode)
         assert result[0].path == Path("app")
 
-    def test_default_target_path(self):
+    def test_default_target_path(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -125,7 +122,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -138,7 +134,7 @@ class TestCommandBuilder:
         assert isinstance(result[0], FileNode)
         assert result[0].path == Path("out/foo.o")
 
-    def test_explicit_target_path(self):
+    def test_explicit_target_path(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -148,7 +144,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -159,7 +154,7 @@ class TestCommandBuilder:
         assert isinstance(result[0], FileNode)
         assert result[0].path == Path("custom/output.o")
 
-    def test_target_has_dependencies(self):
+    def test_target_has_dependencies(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -169,7 +164,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -181,7 +175,7 @@ class TestCommandBuilder:
         target = result[0]
         assert source in target.explicit_deps
 
-    def test_target_has_builder_reference(self):
+    def test_target_has_builder_reference(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -191,7 +185,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -203,7 +196,7 @@ class TestCommandBuilder:
         assert target.is_target
         assert not target.is_source
 
-    def test_target_has_build_info(self):
+    def test_target_has_build_info(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -214,7 +207,6 @@ class TestCommandBuilder:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -232,7 +224,7 @@ class TestCommandBuilder:
 
 
 class TestCommandBuilderDepfile:
-    def test_depfile_and_deps_style_stored(self):
+    def test_depfile_and_deps_style_stored(self, test_project):  # noqa: F811
         from pcons.core.subst import PathToken, TargetPath
 
         builder = CommandBuilder(
@@ -247,7 +239,6 @@ class TestCommandBuilderDepfile:
             deps_style="gcc",
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -264,7 +255,7 @@ class TestCommandBuilderDepfile:
         assert info["depfile"].path == "foo.o"
         assert info["deps_style"] == "gcc"
 
-    def test_msvc_deps_style_no_depfile(self):
+    def test_msvc_deps_style_no_depfile(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Object",
             "cc",
@@ -276,7 +267,6 @@ class TestCommandBuilderDepfile:
             deps_style="msvc",
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"
@@ -290,7 +280,7 @@ class TestCommandBuilderDepfile:
         assert info["depfile"] is None
         assert info["deps_style"] == "msvc"
 
-    def test_no_deps_by_default(self):
+    def test_no_deps_by_default(self, test_project):  # noqa: F811
         builder = CommandBuilder(
             "Program",
             "link",
@@ -300,7 +290,6 @@ class TestCommandBuilderDepfile:
             single_source=False,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "gcc"

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -120,7 +120,6 @@ class TestEnvironmentCommand:
     def test_command_with_single_target_and_source(self, test_project):  # noqa: F811
         """Command with single target and source."""
         env = Environment()
-        Project("dummy")
 
         result = env.Command(
             target="output.txt", source="input.txt", command="cp $SOURCE $TARGET"

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -120,6 +120,7 @@ class TestEnvironmentCommand:
     def test_command_with_single_target_and_source(self):
         """Command with single target and source."""
         env = Environment()
+        Project("dummy")
 
         result = env.Command(
             target="output.txt", source="input.txt", command="cp $SOURCE $TARGET"
@@ -544,7 +545,6 @@ class TestTargetAsSources:
 
         # Create a target that uses the generated source
         consumer = Target("consumer", target_type="program")
-        consumer._project = project
         consumer.add_source("main.cpp")
         consumer.add_source(generated)
 

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -32,30 +32,26 @@ class TestGenericCommandBuilder:
         # $SOURCE and $TARGET are converted to typed markers
         assert builder.command == ["python", "script.py", SourcePath(), TargetPath()]
 
-    def test_unique_rule_names(self):
+    def test_unique_rule_names(self, test_project):  # noqa: F811
         """Each builder gets a unique rule name."""
-        Project("test_project")
         builder1 = GenericCommandBuilder("cmd1")
         builder2 = GenericCommandBuilder("cmd2")
         assert builder1.rule_name != builder2.rule_name
 
-    def test_custom_rule_name(self):
+    def test_custom_rule_name(self, test_project):  # noqa: F811
         """Builder can have a custom rule name."""
-        Project("test_project")
         builder = GenericCommandBuilder("cmd", rule_name="my_custom_rule")
         assert builder.rule_name == "my_custom_rule"
 
-    def test_requires_explicit_target(self):
+    def test_requires_explicit_target(self, test_project):  # noqa: F811
         """Builder raises error if no target is provided."""
-        Project("test_project")
         builder = GenericCommandBuilder("echo hello")
         env = Environment()
         with pytest.raises(ValueError, match="requires explicit target"):
             builder(env, None, ["source.txt"])
 
-    def test_creates_target_node(self):
+    def test_creates_target_node(self, test_project):  # noqa: F811
         """Builder creates target node with proper dependencies."""
-        Project("test_project")
         builder = GenericCommandBuilder("cp $SOURCE $TARGET")
         env = Environment()
 
@@ -66,9 +62,8 @@ class TestGenericCommandBuilder:
         assert result[0].path == Path("output.txt")
         assert result[0].builder is builder
 
-    def test_target_depends_on_sources(self):
+    def test_target_depends_on_sources(self, test_project):  # noqa: F811
         """Target node depends on all sources."""
-        Project("test_project")
         builder = GenericCommandBuilder("cat $SOURCES > $TARGET")
         env = Environment()
 
@@ -80,11 +75,10 @@ class TestGenericCommandBuilder:
         assert source1 in target.explicit_deps
         assert source2 in target.explicit_deps
 
-    def test_build_info_contains_command(self):
+    def test_build_info_contains_command(self, test_project):  # noqa: F811
         """Target node contains build info with command."""
         from pcons.core.subst import SourcePath, TargetPath
 
-        Project("test_project")
         builder = GenericCommandBuilder("process $SOURCE > $TARGET")
         env = Environment()
 
@@ -103,9 +97,8 @@ class TestGenericCommandBuilder:
         ]
         assert target._build_info.get("rule_name") == builder.rule_name
 
-    def test_srcdir_preserved_in_tokens(self):
+    def test_srcdir_preserved_in_tokens(self, test_project):  # noqa: F811
         """$SRCDIR is preserved as a plain string token (generators handle it)."""
-        Project("test_project")
         builder = GenericCommandBuilder("python $SRCDIR/scripts/gen.py $SOURCE $TARGET")
         from pcons.core.subst import SourcePath, TargetPath
 
@@ -124,9 +117,8 @@ class TestEnvironmentCommand:
     list[FileNode], and uses keyword-only arguments.
     """
 
-    def test_command_with_single_target_and_source(self):
+    def test_command_with_single_target_and_source(self, test_project):  # noqa: F811
         """Command with single target and source."""
-        Project("test_project")
         env = Environment()
         Project("dummy")
 
@@ -141,9 +133,8 @@ class TestEnvironmentCommand:
         assert len(result.output_nodes) == 1
         assert result.output_nodes[0].path == Path("output.txt")
 
-    def test_command_with_multiple_sources(self):
+    def test_command_with_multiple_sources(self, test_project):  # noqa: F811
         """Command with multiple sources."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -156,9 +147,8 @@ class TestEnvironmentCommand:
         output_node = result.output_nodes[0]
         assert len(output_node.explicit_deps) == 3
 
-    def test_command_with_multiple_targets(self):
+    def test_command_with_multiple_targets(self, test_project):  # noqa: F811
         """Command with multiple targets."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -172,9 +162,8 @@ class TestEnvironmentCommand:
         assert Path("output.h") in paths
         assert Path("output.c") in paths
 
-    def test_command_with_no_sources(self):
+    def test_command_with_no_sources(self, test_project):  # noqa: F811
         """Command with no source dependencies."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -184,9 +173,8 @@ class TestEnvironmentCommand:
         assert len(result.output_nodes) == 1
         assert len(result.output_nodes[0].explicit_deps) == 0
 
-    def test_command_with_path_objects(self):
+    def test_command_with_path_objects(self, test_project):  # noqa: F811
         """Command accepts Path objects."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -198,18 +186,16 @@ class TestEnvironmentCommand:
         assert len(result.output_nodes) == 1
         assert result.output_nodes[0].path == Path("build/output.txt")
 
-    def test_command_registers_nodes(self):
+    def test_command_registers_nodes(self, test_project):  # noqa: F811
         """Command registers nodes with environment."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(target="out.txt", source="in.txt", command="cmd")
 
         assert result.output_nodes[0] in env.created_nodes
 
-    def test_command_returns_target(self):
+    def test_command_returns_target(self, test_project):  # noqa: F811
         """Command returns Target object (not list[FileNode])."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -221,18 +207,16 @@ class TestEnvironmentCommand:
         assert isinstance(result, Target)
         assert all(isinstance(n, FileNode) for n in result.output_nodes)
 
-    def test_command_name_derived_from_target(self):
+    def test_command_name_derived_from_target(self, test_project):  # noqa: F811
         """Command target name is derived from first target file if not specified."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(target="my_output.txt", source="in.txt", command="cmd")
 
         assert result.name == "my_output"
 
-    def test_command_explicit_name(self):
+    def test_command_explicit_name(self, test_project):  # noqa: F811
         """Command can have an explicit name."""
-        Project("test_project")
         env = Environment()
 
         result = env.Command(

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -34,17 +34,20 @@ class TestGenericCommandBuilder:
 
     def test_unique_rule_names(self):
         """Each builder gets a unique rule name."""
+        Project("test_project")
         builder1 = GenericCommandBuilder("cmd1")
         builder2 = GenericCommandBuilder("cmd2")
         assert builder1.rule_name != builder2.rule_name
 
     def test_custom_rule_name(self):
         """Builder can have a custom rule name."""
+        Project("test_project")
         builder = GenericCommandBuilder("cmd", rule_name="my_custom_rule")
         assert builder.rule_name == "my_custom_rule"
 
     def test_requires_explicit_target(self):
         """Builder raises error if no target is provided."""
+        Project("test_project")
         builder = GenericCommandBuilder("echo hello")
         env = Environment()
         with pytest.raises(ValueError, match="requires explicit target"):
@@ -52,6 +55,7 @@ class TestGenericCommandBuilder:
 
     def test_creates_target_node(self):
         """Builder creates target node with proper dependencies."""
+        Project("test_project")
         builder = GenericCommandBuilder("cp $SOURCE $TARGET")
         env = Environment()
 
@@ -64,6 +68,7 @@ class TestGenericCommandBuilder:
 
     def test_target_depends_on_sources(self):
         """Target node depends on all sources."""
+        Project("test_project")
         builder = GenericCommandBuilder("cat $SOURCES > $TARGET")
         env = Environment()
 
@@ -79,6 +84,7 @@ class TestGenericCommandBuilder:
         """Target node contains build info with command."""
         from pcons.core.subst import SourcePath, TargetPath
 
+        Project("test_project")
         builder = GenericCommandBuilder("process $SOURCE > $TARGET")
         env = Environment()
 
@@ -99,6 +105,7 @@ class TestGenericCommandBuilder:
 
     def test_srcdir_preserved_in_tokens(self):
         """$SRCDIR is preserved as a plain string token (generators handle it)."""
+        Project("test_project")
         builder = GenericCommandBuilder("python $SRCDIR/scripts/gen.py $SOURCE $TARGET")
         from pcons.core.subst import SourcePath, TargetPath
 
@@ -119,6 +126,7 @@ class TestEnvironmentCommand:
 
     def test_command_with_single_target_and_source(self):
         """Command with single target and source."""
+        Project("test_project")
         env = Environment()
         Project("dummy")
 
@@ -135,6 +143,7 @@ class TestEnvironmentCommand:
 
     def test_command_with_multiple_sources(self):
         """Command with multiple sources."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -149,6 +158,7 @@ class TestEnvironmentCommand:
 
     def test_command_with_multiple_targets(self):
         """Command with multiple targets."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -164,6 +174,7 @@ class TestEnvironmentCommand:
 
     def test_command_with_no_sources(self):
         """Command with no source dependencies."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -175,6 +186,7 @@ class TestEnvironmentCommand:
 
     def test_command_with_path_objects(self):
         """Command accepts Path objects."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -188,6 +200,7 @@ class TestEnvironmentCommand:
 
     def test_command_registers_nodes(self):
         """Command registers nodes with environment."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(target="out.txt", source="in.txt", command="cmd")
@@ -196,6 +209,7 @@ class TestEnvironmentCommand:
 
     def test_command_returns_target(self):
         """Command returns Target object (not list[FileNode])."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(
@@ -209,6 +223,7 @@ class TestEnvironmentCommand:
 
     def test_command_name_derived_from_target(self):
         """Command target name is derived from first target file if not specified."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(target="my_output.txt", source="in.txt", command="cmd")
@@ -217,6 +232,7 @@ class TestEnvironmentCommand:
 
     def test_command_explicit_name(self):
         """Command can have an explicit name."""
+        Project("test_project")
         env = Environment()
 
         result = env.Command(

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import pytest
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.core.toolconfig import ToolConfig
 
 

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -11,54 +11,46 @@ from pcons.core.toolconfig import ToolConfig
 
 
 class TestEnvironmentBasic:
-    def test_creation(self):
-        Project("test_project")
+    def test_creation(self, test_project):  # noqa: F811
         env = Environment()
         assert env.defined_at is not None
 
-    def test_default_build_dir(self):
-        Project("test_project")
+    def test_default_build_dir(self, test_project):  # noqa: F811
         env = Environment()
         assert env.build_dir == Path("build")
 
-    def test_set_cross_tool_var(self):
-        Project("test_project")
+    def test_set_cross_tool_var(self, test_project):  # noqa: F811
         env = Environment()
         env.variant = "release"
         assert env.variant == "release"
 
-    def test_get_missing_raises(self):
-        Project("test_project")
+    def test_get_missing_raises(self, test_project):  # noqa: F811
         env = Environment()
         with pytest.raises(AttributeError) as exc_info:
             _ = env.missing
         assert "missing" in str(exc_info.value)
 
-    def test_get_with_default(self):
-        Project("test_project")
+    def test_get_with_default(self, test_project):  # noqa: F811
         env = Environment()
         assert env.get("missing") is None
         assert env.get("missing", "default") == "default"
 
 
 class TestEnvironmentTools:
-    def test_add_tool(self):
-        Project("test_project")
+    def test_add_tool(self, test_project):  # noqa: F811
         env = Environment()
         cc = env.add_tool("cc")
         assert isinstance(cc, ToolConfig)
         assert cc.name == "cc"
 
-    def test_add_tool_with_config(self):
-        Project("test_project")
+    def test_add_tool_with_config(self, test_project):  # noqa: F811
         env = Environment()
         config = ToolConfig("cc", cmd="gcc")
         cc = env.add_tool("cc", config)
         assert cc is config
         assert env.cc.cmd == "gcc"
 
-    def test_add_existing_tool_returns_it(self):
-        Project("test_project")
+    def test_add_existing_tool_returns_it(self, test_project):  # noqa: F811
         env = Environment()
         cc1 = env.add_tool("cc")
         cc1.cmd = "gcc"
@@ -66,15 +58,13 @@ class TestEnvironmentTools:
         assert cc1 is cc2
         assert cc2.cmd == "gcc"
 
-    def test_has_tool(self):
-        Project("test_project")
+    def test_has_tool(self, test_project):  # noqa: F811
         env = Environment()
         assert not env.has_tool("cc")
         env.add_tool("cc")
         assert env.has_tool("cc")
 
-    def test_tool_names(self):
-        Project("test_project")
+    def test_tool_names(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.add_tool("cxx")
@@ -82,15 +72,13 @@ class TestEnvironmentTools:
         assert "cc" in names
         assert "cxx" in names
 
-    def test_access_tool_via_attribute(self):
-        Project("test_project")
+    def test_access_tool_via_attribute(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
         assert env.cc.cmd == "gcc"
 
-    def test_tool_takes_precedence_over_var(self):
-        Project("test_project")
+    def test_tool_takes_precedence_over_var(self, test_project):  # noqa: F811
         env = Environment()
         env.cc = "variable_value"  # Set as variable
         tool_config = env.add_tool("cc")  # Now add tool
@@ -100,15 +88,13 @@ class TestEnvironmentTools:
 
 
 class TestEnvironmentClone:
-    def test_clone_basic(self):
-        Project("test_project")
+    def test_clone_basic(self, test_project):  # noqa: F811
         env = Environment()
         env.variant = "debug"
         clone = env.clone()
         assert clone.variant == "debug"
 
-    def test_clone_is_independent(self):
-        Project("test_project")
+    def test_clone_is_independent(self, test_project):  # noqa: F811
         env = Environment()
         env.variant = "debug"
         clone = env.clone()
@@ -117,8 +103,7 @@ class TestEnvironmentClone:
         assert env.variant == "debug"
         assert clone.variant == "release"
 
-    def test_clone_deep_copies_tools(self):
-        Project("test_project")
+    def test_clone_deep_copies_tools(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -135,15 +120,13 @@ class TestEnvironmentClone:
 
 
 class TestEnvironmentSubst:
-    def test_subst_cross_tool_var(self):
-        Project("test_project")
+    def test_subst_cross_tool_var(self, test_project):  # noqa: F811
         env = Environment()
         env.name = "myapp"
         result = env.subst("Building $name")
         assert result == "Building myapp"
 
-    def test_subst_tool_var(self):
-        Project("test_project")
+    def test_subst_tool_var(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -152,15 +135,13 @@ class TestEnvironmentSubst:
         assert "Compiler:" in result
         assert "gcc" in result
 
-    def test_subst_with_extra(self):
-        Project("test_project")
+    def test_subst_with_extra(self, test_project):  # noqa: F811
         env = Environment()
         result = env.subst("Target: $target", target="app.exe")
         assert "Target:" in result
         assert "app.exe" in result
 
-    def test_subst_list(self):
-        Project("test_project")
+    def test_subst_list(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = ["-Wall", "-O2"]
@@ -168,8 +149,7 @@ class TestEnvironmentSubst:
         # subst_list() returns a list of tokens
         assert result == ["-Wall", "-O2"]
 
-    def test_subst_list_with_string(self):
-        Project("test_project")
+    def test_subst_list_with_string(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = "-Wall -O2"
@@ -177,8 +157,7 @@ class TestEnvironmentSubst:
         # Single token stays as a single token
         assert result == ["-Wall -O2"]
 
-    def test_subst_list_string_tokenized(self):
-        Project("test_project")
+    def test_subst_list_string_tokenized(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = "-Wall -O2"
@@ -187,8 +166,7 @@ class TestEnvironmentSubst:
         # String template tokenizes, then $cc.flags stays as one token
         assert result == ["-Wall -O2", "more", "flags"]
 
-    def test_subst_complex(self):
-        Project("test_project")
+    def test_subst_complex(self, test_project):  # noqa: F811
         # For complex command templates with list variables, use list templates
         env = Environment()
         env.add_tool("cc")
@@ -207,8 +185,7 @@ class TestEnvironmentSubst:
         assert "foo.o" in result
         assert "foo.c" in result
 
-    def test_subst_list_template(self):
-        Project("test_project")
+    def test_subst_list_template(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -217,8 +194,7 @@ class TestEnvironmentSubst:
         result = env.subst_list(["$cc.cmd", "$cc.flags", "-c", "file.c"])
         assert result == ["gcc", "-Wall", "-O2", "-c", "file.c"]
 
-    def test_subst_with_prefix_function(self):
-        Project("test_project")
+    def test_subst_with_prefix_function(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -232,9 +208,8 @@ class TestEnvironmentSubst:
 class TestEnvironmentOverride:
     """Tests for env.override() context manager."""
 
-    def test_override_simple_var(self):
+    def test_override_simple_var(self, test_project):  # noqa: F811
         """Override a simple variable."""
-        Project("test_project")
         env = Environment()
         env.variant = "release"
 
@@ -244,9 +219,8 @@ class TestEnvironmentOverride:
 
         assert env.variant == "release"
 
-    def test_override_tool_setting(self):
+    def test_override_tool_setting(self, test_project):  # noqa: F811
         """Override tool settings using double-underscore notation."""
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = ["-Wall"]
@@ -255,9 +229,8 @@ class TestEnvironmentOverride:
             assert temp_env.cc.flags == ["-Wall", "-Werror"]
             assert env.cc.flags == ["-Wall"]  # Original unchanged
 
-    def test_override_add_define(self):
+    def test_override_add_define(self, test_project):  # noqa: F811
         """Common use case: add a specific define for some files."""
-        Project("test_project")
         env = Environment()
         env.add_tool("cxx")
         env.cxx.defines = ["RELEASE"]
@@ -266,9 +239,8 @@ class TestEnvironmentOverride:
             assert "SPECIAL_BUILD" in temp_env.cxx.defines
             assert "SPECIAL_BUILD" not in env.cxx.defines
 
-    def test_override_multiple_settings(self):
+    def test_override_multiple_settings(self, test_project):  # noqa: F811
         """Override multiple settings at once."""
-        Project("test_project")
         env = Environment()
         env.variant = "release"
         env.add_tool("cc")
@@ -278,9 +250,8 @@ class TestEnvironmentOverride:
             assert temp_env.variant == "debug"
             assert temp_env.cc.cmd == "clang"
 
-    def test_override_returns_clone(self):
+    def test_override_returns_clone(self, test_project):  # noqa: F811
         """Override returns a cloned environment, not the original."""
-        Project("test_project")
         env = Environment()
         env.variant = "release"
 
@@ -291,9 +262,8 @@ class TestEnvironmentOverride:
 class TestCompilerCache:
     """Tests for use_compiler_cache()."""
 
-    def test_auto_detect_skips_when_not_found(self) -> None:
+    def test_auto_detect_skips_when_not_found(self, test_project) -> None:  # noqa: F811
         """Auto-detect should be a no-op when no cache tool is found."""
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -305,11 +275,10 @@ class TestCompilerCache:
         env.use_compiler_cache()
         # cmd might or might not be wrapped depending on the test machine
 
-    def test_explicit_tool_wraps_commands(self) -> None:
+    def test_explicit_tool_wraps_commands(self, test_project) -> None:  # noqa: F811
         """Explicit tool name should wrap cc and cxx commands."""
         import shutil
 
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -334,7 +303,7 @@ class TestCompilerCache:
         assert "gcc" in env.cc.cmd
         assert "g++" in env.cxx.cmd
 
-    def test_no_double_wrapping(self) -> None:
+    def test_no_double_wrapping(self, test_project) -> None:  # noqa: F811
         """Should not double-wrap if already prefixed."""
         import shutil
 
@@ -347,7 +316,6 @@ class TestCompilerCache:
         if tool is None:
             pytest.skip("No compiler cache tool available")
 
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", f"{tool} gcc")
@@ -357,7 +325,7 @@ class TestCompilerCache:
         # Should not be double-wrapped
         assert env.cc.cmd == f"{tool} gcc"
 
-    def test_skips_tools_not_present(self) -> None:
+    def test_skips_tools_not_present(self, test_project) -> None:  # noqa: F811
         """Should skip tools that don't exist."""
         import shutil
 
@@ -370,7 +338,6 @@ class TestCompilerCache:
         if tool is None:
             pytest.skip("No compiler cache tool available")
 
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -379,9 +346,8 @@ class TestCompilerCache:
         env.use_compiler_cache(tool)
         assert env.cc.cmd.startswith(tool)
 
-    def test_unknown_tool_warns(self) -> None:
+    def test_unknown_tool_warns(self, test_project) -> None:  # noqa: F811
         """Unknown tool name should warn and not modify."""
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -389,11 +355,10 @@ class TestCompilerCache:
         env.use_compiler_cache("nonexistent-cache-tool")
         assert env.cc.cmd == "gcc"
 
-    def test_missing_explicit_tool_warns(self) -> None:
+    def test_missing_explicit_tool_warns(self, test_project) -> None:  # noqa: F811
         """Explicit tool not in PATH should warn and not modify."""
         import shutil
 
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -411,8 +376,7 @@ class TestCompilerCache:
 
 
 class TestEnvironmentRepr:
-    def test_repr(self):
-        Project("test_project")
+    def test_repr(self, test_project):  # noqa: F811
         env = Environment()
         env.add_tool("cc")
         r = repr(env)

--- a/tests/core/test_environment.py
+++ b/tests/core/test_environment.py
@@ -6,30 +6,36 @@ from pathlib import Path
 import pytest
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.core.toolconfig import ToolConfig
 
 
 class TestEnvironmentBasic:
     def test_creation(self):
+        Project("test_project")
         env = Environment()
         assert env.defined_at is not None
 
     def test_default_build_dir(self):
+        Project("test_project")
         env = Environment()
         assert env.build_dir == Path("build")
 
     def test_set_cross_tool_var(self):
+        Project("test_project")
         env = Environment()
         env.variant = "release"
         assert env.variant == "release"
 
     def test_get_missing_raises(self):
+        Project("test_project")
         env = Environment()
         with pytest.raises(AttributeError) as exc_info:
             _ = env.missing
         assert "missing" in str(exc_info.value)
 
     def test_get_with_default(self):
+        Project("test_project")
         env = Environment()
         assert env.get("missing") is None
         assert env.get("missing", "default") == "default"
@@ -37,12 +43,14 @@ class TestEnvironmentBasic:
 
 class TestEnvironmentTools:
     def test_add_tool(self):
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         assert isinstance(cc, ToolConfig)
         assert cc.name == "cc"
 
     def test_add_tool_with_config(self):
+        Project("test_project")
         env = Environment()
         config = ToolConfig("cc", cmd="gcc")
         cc = env.add_tool("cc", config)
@@ -50,6 +58,7 @@ class TestEnvironmentTools:
         assert env.cc.cmd == "gcc"
 
     def test_add_existing_tool_returns_it(self):
+        Project("test_project")
         env = Environment()
         cc1 = env.add_tool("cc")
         cc1.cmd = "gcc"
@@ -58,12 +67,14 @@ class TestEnvironmentTools:
         assert cc2.cmd == "gcc"
 
     def test_has_tool(self):
+        Project("test_project")
         env = Environment()
         assert not env.has_tool("cc")
         env.add_tool("cc")
         assert env.has_tool("cc")
 
     def test_tool_names(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.add_tool("cxx")
@@ -72,12 +83,14 @@ class TestEnvironmentTools:
         assert "cxx" in names
 
     def test_access_tool_via_attribute(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
         assert env.cc.cmd == "gcc"
 
     def test_tool_takes_precedence_over_var(self):
+        Project("test_project")
         env = Environment()
         env.cc = "variable_value"  # Set as variable
         tool_config = env.add_tool("cc")  # Now add tool
@@ -88,12 +101,14 @@ class TestEnvironmentTools:
 
 class TestEnvironmentClone:
     def test_clone_basic(self):
+        Project("test_project")
         env = Environment()
         env.variant = "debug"
         clone = env.clone()
         assert clone.variant == "debug"
 
     def test_clone_is_independent(self):
+        Project("test_project")
         env = Environment()
         env.variant = "debug"
         clone = env.clone()
@@ -103,6 +118,7 @@ class TestEnvironmentClone:
         assert clone.variant == "release"
 
     def test_clone_deep_copies_tools(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -120,12 +136,14 @@ class TestEnvironmentClone:
 
 class TestEnvironmentSubst:
     def test_subst_cross_tool_var(self):
+        Project("test_project")
         env = Environment()
         env.name = "myapp"
         result = env.subst("Building $name")
         assert result == "Building myapp"
 
     def test_subst_tool_var(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -135,12 +153,14 @@ class TestEnvironmentSubst:
         assert "gcc" in result
 
     def test_subst_with_extra(self):
+        Project("test_project")
         env = Environment()
         result = env.subst("Target: $target", target="app.exe")
         assert "Target:" in result
         assert "app.exe" in result
 
     def test_subst_list(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = ["-Wall", "-O2"]
@@ -149,6 +169,7 @@ class TestEnvironmentSubst:
         assert result == ["-Wall", "-O2"]
 
     def test_subst_list_with_string(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = "-Wall -O2"
@@ -157,6 +178,7 @@ class TestEnvironmentSubst:
         assert result == ["-Wall -O2"]
 
     def test_subst_list_string_tokenized(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = "-Wall -O2"
@@ -166,6 +188,7 @@ class TestEnvironmentSubst:
         assert result == ["-Wall -O2", "more", "flags"]
 
     def test_subst_complex(self):
+        Project("test_project")
         # For complex command templates with list variables, use list templates
         env = Environment()
         env.add_tool("cc")
@@ -185,6 +208,7 @@ class TestEnvironmentSubst:
         assert "foo.c" in result
 
     def test_subst_list_template(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -194,6 +218,7 @@ class TestEnvironmentSubst:
         assert result == ["gcc", "-Wall", "-O2", "-c", "file.c"]
 
     def test_subst_with_prefix_function(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "gcc"
@@ -209,6 +234,7 @@ class TestEnvironmentOverride:
 
     def test_override_simple_var(self):
         """Override a simple variable."""
+        Project("test_project")
         env = Environment()
         env.variant = "release"
 
@@ -220,6 +246,7 @@ class TestEnvironmentOverride:
 
     def test_override_tool_setting(self):
         """Override tool settings using double-underscore notation."""
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.flags = ["-Wall"]
@@ -230,6 +257,7 @@ class TestEnvironmentOverride:
 
     def test_override_add_define(self):
         """Common use case: add a specific define for some files."""
+        Project("test_project")
         env = Environment()
         env.add_tool("cxx")
         env.cxx.defines = ["RELEASE"]
@@ -240,6 +268,7 @@ class TestEnvironmentOverride:
 
     def test_override_multiple_settings(self):
         """Override multiple settings at once."""
+        Project("test_project")
         env = Environment()
         env.variant = "release"
         env.add_tool("cc")
@@ -251,6 +280,7 @@ class TestEnvironmentOverride:
 
     def test_override_returns_clone(self):
         """Override returns a cloned environment, not the original."""
+        Project("test_project")
         env = Environment()
         env.variant = "release"
 
@@ -263,6 +293,7 @@ class TestCompilerCache:
 
     def test_auto_detect_skips_when_not_found(self) -> None:
         """Auto-detect should be a no-op when no cache tool is found."""
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -278,6 +309,7 @@ class TestCompilerCache:
         """Explicit tool name should wrap cc and cxx commands."""
         import shutil
 
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -315,6 +347,7 @@ class TestCompilerCache:
         if tool is None:
             pytest.skip("No compiler cache tool available")
 
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", f"{tool} gcc")
@@ -337,6 +370,7 @@ class TestCompilerCache:
         if tool is None:
             pytest.skip("No compiler cache tool available")
 
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -347,6 +381,7 @@ class TestCompilerCache:
 
     def test_unknown_tool_warns(self) -> None:
         """Unknown tool name should warn and not modify."""
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -358,6 +393,7 @@ class TestCompilerCache:
         """Explicit tool not in PATH should warn and not modify."""
         import shutil
 
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("cmd", "gcc")
@@ -376,6 +412,7 @@ class TestCompilerCache:
 
 class TestEnvironmentRepr:
     def test_repr(self):
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         r = repr(env)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -21,14 +21,12 @@ class TestTopologicalSortTargets:
         result = topological_sort_targets([])
         assert result == []
 
-    def test_single_target(self):
-        Project("test_project")
+    def test_single_target(self, test_project):  # noqa: F811
         target = Target("app")
         result = topological_sort_targets([target])
         assert result == [target]
 
-    def test_linear_dependency(self):
-        Project("test_project")
+    def test_linear_dependency(self, test_project):  # noqa: F811
         # A depends on B depends on C
         c = Target("C")
         b = Target("B")
@@ -42,9 +40,8 @@ class TestTopologicalSortTargets:
         assert result.index(c) < result.index(b)
         assert result.index(b) < result.index(a)
 
-    def test_diamond_dependency(self):
+    def test_diamond_dependency(self, test_project):  # noqa: F811
         # A depends on B and C, both depend on D
-        Project("test_project")
         d = Target("D")
         b = Target("B")
         b.link(d)
@@ -62,8 +59,7 @@ class TestTopologicalSortTargets:
         assert result.index(b) < result.index(a)
         assert result.index(c) < result.index(a)
 
-    def test_cycle_raises_error(self):
-        Project("test_project")
+    def test_cycle_raises_error(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -74,8 +70,7 @@ class TestTopologicalSortTargets:
 
 
 class TestDetectCycles:
-    def test_no_cycle(self):
-        Project("test_project")
+    def test_no_cycle(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -83,8 +78,7 @@ class TestDetectCycles:
         cycles = detect_cycles_in_targets([a, b])
         assert cycles == []
 
-    def test_simple_cycle(self):
-        Project("test_project")
+    def test_simple_cycle(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -95,16 +89,14 @@ class TestDetectCycles:
         assert "A" in cycles[0]
         assert "B" in cycles[0]
 
-    def test_self_cycle(self):
-        Project("test_project")
+    def test_self_cycle(self, test_project):  # noqa: F811
         a = Target("A")
         # Self-link is now caught early by link() validation
         with pytest.raises(ValueError, match="cannot link itself"):
             a.link(a)
 
-    def test_multiple_cycles(self):
+    def test_multiple_cycles(self, test_project):  # noqa: F811
         # Two separate cycles: A<->B and C<->D
-        Project("test_project")
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -153,8 +145,7 @@ class TestCollectAllNodes:
         nodes = collect_all_nodes([])
         assert nodes == set()
 
-    def test_collects_from_single_target(self):
-        Project("test_project")
+    def test_collects_from_single_target(self, test_project):  # noqa: F811
         target = Target("app")
         src = FileNode("main.c")
         out = FileNode("app")
@@ -166,8 +157,7 @@ class TestCollectAllNodes:
         assert src in nodes
         assert out in nodes
 
-    def test_collects_from_dependencies(self):
-        Project("test_project")
+    def test_collects_from_dependencies(self, test_project):  # noqa: F811
         lib = Target("lib")
         lib_src = FileNode("lib.c")
         lib_out = FileNode("lib.o")
@@ -190,14 +180,12 @@ class TestCollectAllNodes:
 
 
 class TestCollectBuildOrder:
-    def test_single_target(self):
-        Project("test_project")
+    def test_single_target(self, test_project):  # noqa: F811
         app = Target("app")
         order = collect_build_order(app)
         assert order == [app]
 
-    def test_with_dependencies(self):
-        Project("test_project")
+    def test_with_dependencies(self, test_project):  # noqa: F811
         lib = Target("lib")
         app = Target("app")
         app.link(lib)
@@ -206,8 +194,7 @@ class TestCollectBuildOrder:
 
         assert order.index(lib) < order.index(app)
 
-    def test_diamond_dependency(self):
-        Project("test_project")
+    def test_diamond_dependency(self, test_project):  # noqa: F811
         base = Target("base")
         left = Target("left")
         left.link(base)

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -12,7 +12,6 @@ from pcons.core.graph import (
     topological_sort_targets,
 )
 from pcons.core.node import FileNode
-from pcons.core.project import Project
 from pcons.core.target import Target
 
 

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -12,6 +12,7 @@ from pcons.core.graph import (
     topological_sort_targets,
 )
 from pcons.core.node import FileNode
+from pcons.core.project import Project
 from pcons.core.target import Target
 
 
@@ -21,11 +22,13 @@ class TestTopologicalSortTargets:
         assert result == []
 
     def test_single_target(self):
+        Project("test_project")
         target = Target("app")
         result = topological_sort_targets([target])
         assert result == [target]
 
     def test_linear_dependency(self):
+        Project("test_project")
         # A depends on B depends on C
         c = Target("C")
         b = Target("B")
@@ -41,6 +44,7 @@ class TestTopologicalSortTargets:
 
     def test_diamond_dependency(self):
         # A depends on B and C, both depend on D
+        Project("test_project")
         d = Target("D")
         b = Target("B")
         b.link(d)
@@ -59,6 +63,7 @@ class TestTopologicalSortTargets:
         assert result.index(c) < result.index(a)
 
     def test_cycle_raises_error(self):
+        Project("test_project")
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -70,6 +75,7 @@ class TestTopologicalSortTargets:
 
 class TestDetectCycles:
     def test_no_cycle(self):
+        Project("test_project")
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -78,6 +84,7 @@ class TestDetectCycles:
         assert cycles == []
 
     def test_simple_cycle(self):
+        Project("test_project")
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -89,6 +96,7 @@ class TestDetectCycles:
         assert "B" in cycles[0]
 
     def test_self_cycle(self):
+        Project("test_project")
         a = Target("A")
         # Self-link is now caught early by link() validation
         with pytest.raises(ValueError, match="cannot link itself"):
@@ -96,6 +104,7 @@ class TestDetectCycles:
 
     def test_multiple_cycles(self):
         # Two separate cycles: A<->B and C<->D
+        Project("test_project")
         a = Target("A")
         b = Target("B")
         a.link(b)
@@ -145,6 +154,7 @@ class TestCollectAllNodes:
         assert nodes == set()
 
     def test_collects_from_single_target(self):
+        Project("test_project")
         target = Target("app")
         src = FileNode("main.c")
         out = FileNode("app")
@@ -157,6 +167,7 @@ class TestCollectAllNodes:
         assert out in nodes
 
     def test_collects_from_dependencies(self):
+        Project("test_project")
         lib = Target("lib")
         lib_src = FileNode("lib.c")
         lib_out = FileNode("lib.o")
@@ -180,11 +191,13 @@ class TestCollectAllNodes:
 
 class TestCollectBuildOrder:
     def test_single_target(self):
+        Project("test_project")
         app = Target("app")
         order = collect_build_order(app)
         assert order == [app]
 
     def test_with_dependencies(self):
+        Project("test_project")
         lib = Target("lib")
         app = Target("app")
         app.link(lib)
@@ -194,6 +207,7 @@ class TestCollectBuildOrder:
         assert order.index(lib) < order.index(app)
 
     def test_diamond_dependency(self):
+        Project("test_project")
         base = Target("base")
         left = Target("left")
         left.link(base)

--- a/tests/core/test_multi_output.py
+++ b/tests/core/test_multi_output.py
@@ -12,7 +12,6 @@ from pcons.core.builder import (
 )
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode
-from pcons.core.project import Project
 
 
 class TestOutputSpec:

--- a/tests/core/test_multi_output.py
+++ b/tests/core/test_multi_output.py
@@ -169,7 +169,7 @@ class TestMultiOutputBuilder:
         )
         assert builder.outputs == outputs
 
-    def test_build_returns_output_group(self):
+    def test_build_returns_output_group(self, test_project):  # noqa: F811
         builder = MultiOutputBuilder(
             "SharedLibrary",
             "link",
@@ -181,7 +181,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -194,7 +193,7 @@ class TestMultiOutputBuilder:
         assert result.primary.path == Path("test.dll")
         assert result.import_lib.path == Path("test.lib")
 
-    def test_build_creates_nodes_with_correct_suffixes(self):
+    def test_build_creates_nodes_with_correct_suffixes(self, test_project):  # noqa: F811
         builder = MultiOutputBuilder(
             "SharedLibrary",
             "link",
@@ -207,7 +206,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -220,7 +218,7 @@ class TestMultiOutputBuilder:
         assert result.import_lib.path == Path("build/mylib.lib")
         assert result.export_file.path == Path("build/mylib.exp")
 
-    def test_primary_node_has_dependencies(self):
+    def test_primary_node_has_dependencies(self, test_project):  # noqa: F811
         builder = MultiOutputBuilder(
             "SharedLibrary",
             "link",
@@ -232,7 +230,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -244,7 +241,7 @@ class TestMultiOutputBuilder:
         assert isinstance(result, OutputGroup)
         assert source in result.primary.explicit_deps
 
-    def test_primary_node_has_build_info(self):
+    def test_primary_node_has_build_info(self, test_project):  # noqa: F811
         builder = MultiOutputBuilder(
             "SharedLibrary",
             "link",
@@ -256,7 +253,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -273,7 +269,7 @@ class TestMultiOutputBuilder:
         assert "primary" in info["outputs"]
         assert "import_lib" in info["outputs"]
 
-    def test_output_group_is_iterable_for_backward_compat(self):
+    def test_output_group_is_iterable_for_backward_compat(self, test_project):  # noqa: F811
         """OutputGroup should work with list += operations."""
         builder = MultiOutputBuilder(
             "SharedLibrary",
@@ -286,7 +282,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -300,7 +295,7 @@ class TestMultiOutputBuilder:
         nodes.extend(result)
         assert len(nodes) == 2
 
-    def test_secondary_nodes_reference_primary(self):
+    def test_secondary_nodes_reference_primary(self, test_project):  # noqa: F811
         builder = MultiOutputBuilder(
             "SharedLibrary",
             "link",
@@ -312,7 +307,6 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -328,7 +322,7 @@ class TestMultiOutputBuilder:
 
 
 class TestMultiOutputBuilderSingleSource:
-    def test_single_source_mode_returns_list(self):
+    def test_single_source_mode_returns_list(self, test_project):  # noqa: F811
         """In single_source mode, returns a flat list for compatibility."""
         builder = MultiOutputBuilder(
             "Object",
@@ -342,7 +336,6 @@ class TestMultiOutputBuilderSingleSource:
             single_source=True,
         )
 
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"

--- a/tests/core/test_multi_output.py
+++ b/tests/core/test_multi_output.py
@@ -12,6 +12,7 @@ from pcons.core.builder import (
 )
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode
+from pcons.core.project import Project
 
 
 class TestOutputSpec:
@@ -180,6 +181,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -205,6 +207,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -229,6 +232,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -252,6 +256,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -281,6 +286,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -306,6 +312,7 @@ class TestMultiOutputBuilder:
             src_suffixes=[".obj"],
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -335,6 +342,7 @@ class TestMultiOutputBuilderSingleSource:
             single_source=True,
         )
 
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"

--- a/tests/core/test_multi_toolchain.py
+++ b/tests/core/test_multi_toolchain.py
@@ -132,6 +132,7 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
+        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         assert env.has_tool("cc")
         assert env.has_tool("cxx")
@@ -148,6 +149,7 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
+        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         assert len(env.toolchains) == 1
         assert env.toolchains[0] is c_toolchain
@@ -159,6 +161,7 @@ class TestMultiToolchainEnvironment:
 
     def test_toolchains_property_empty_without_toolchain(self):
         """Test that toolchains returns empty list when no toolchain set."""
+        Project("test_project")
         env = Environment()
         assert env.toolchains == []
 
@@ -170,6 +173,7 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
+        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         env.add_toolchain(cuda_toolchain)
 
@@ -186,6 +190,7 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
+        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         env.add_toolchain(cuda_toolchain)
 
@@ -198,6 +203,7 @@ class TestMultiToolchainEnvironment:
 
     def test_set_variant_no_toolchains(self):
         """Test set_variant works when no toolchains configured."""
+        Project("test_project")
         env = Environment()
         env.set_variant("release")
         assert env.variant == "release"

--- a/tests/core/test_multi_toolchain.py
+++ b/tests/core/test_multi_toolchain.py
@@ -124,7 +124,7 @@ class MockCudaToolchain(BaseToolchain):
 class TestMultiToolchainEnvironment:
     """Tests for multi-toolchain Environment methods."""
 
-    def test_add_toolchain(self):
+    def test_add_toolchain(self, test_project):  # noqa: F811
         """Test adding additional toolchains."""
         c_toolchain = MockCToolchain()
         c_toolchain.configure(None)
@@ -132,7 +132,6 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
-        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         assert env.has_tool("cc")
         assert env.has_tool("cxx")
@@ -141,7 +140,7 @@ class TestMultiToolchainEnvironment:
         env.add_toolchain(cuda_toolchain)
         assert env.has_tool("cuda")
 
-    def test_toolchains_property_returns_all(self):
+    def test_toolchains_property_returns_all(self, test_project):  # noqa: F811
         """Test that toolchains property includes primary and additional."""
         c_toolchain = MockCToolchain()
         c_toolchain.configure(None)
@@ -149,7 +148,6 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
-        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         assert len(env.toolchains) == 1
         assert env.toolchains[0] is c_toolchain
@@ -159,13 +157,12 @@ class TestMultiToolchainEnvironment:
         assert env.toolchains[0] is c_toolchain
         assert env.toolchains[1] is cuda_toolchain
 
-    def test_toolchains_property_empty_without_toolchain(self):
+    def test_toolchains_property_empty_without_toolchain(self, test_project):  # noqa: F811
         """Test that toolchains returns empty list when no toolchain set."""
-        Project("test_project")
         env = Environment()
         assert env.toolchains == []
 
-    def test_clone_preserves_additional_toolchains(self):
+    def test_clone_preserves_additional_toolchains(self, test_project):  # noqa: F811
         """Test that clone copies additional toolchains."""
         c_toolchain = MockCToolchain()
         c_toolchain.configure(None)
@@ -173,7 +170,6 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
-        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         env.add_toolchain(cuda_toolchain)
 
@@ -182,7 +178,7 @@ class TestMultiToolchainEnvironment:
         assert cloned.toolchains[0] is c_toolchain
         assert cloned.toolchains[1] is cuda_toolchain
 
-    def test_set_variant_applies_to_all_toolchains(self):
+    def test_set_variant_applies_to_all_toolchains(self, test_project):  # noqa: F811
         """Test that set_variant calls apply_variant on all toolchains."""
         c_toolchain = MockCToolchain()
         c_toolchain.configure(None)
@@ -190,7 +186,6 @@ class TestMultiToolchainEnvironment:
         cuda_toolchain = MockCudaToolchain()
         cuda_toolchain.configure(None)
 
-        Project("test_project")
         env = Environment(toolchain=c_toolchain)
         env.add_toolchain(cuda_toolchain)
 
@@ -201,9 +196,8 @@ class TestMultiToolchainEnvironment:
         assert "-G" in env.cuda.flags
         assert "-g" in env.cuda.flags
 
-    def test_set_variant_no_toolchains(self):
+    def test_set_variant_no_toolchains(self, test_project):  # noqa: F811
         """Test set_variant works when no toolchains configured."""
-        Project("test_project")
         env = Environment()
         env.set_variant("release")
         assert env.variant == "release"

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -134,19 +134,15 @@ class TestProjectTargets:
     def test_add_target(self):
         project = Project("myproject")
         target = Target("mylib")
-        project.add_target(target)
 
         assert target in project.targets
         assert project.get_target("mylib") is target
 
     def test_duplicate_target_raises(self):
-        project = Project("myproject")
-        target1 = Target("mylib")
-        target2 = Target("mylib")
-
-        project.add_target(target1)
+        Project("myproject")
+        Target("mylib")
         with pytest.raises(ValueError) as exc_info:
-            project.add_target(target2)
+            Target("mylib")
 
         assert "already exists" in str(exc_info.value)
 
@@ -162,11 +158,9 @@ class TestProjectTargets:
         with root._enter_subdir("child1"):
             child1 = Project("child1")
             mylib1 = Target("mylib1")
-            child1.add_target(mylib1)
         with root._enter_subdir("child2"):
             child2 = Project("child2")
             mylib2 = Target("mylib2")
-            child2.add_target(mylib2)
 
         # may we support parent lookup ??? not currently implemented
         assert child1.get_target("mylib2", raise_if_missing=False) is None
@@ -189,7 +183,6 @@ class TestProjectAliases:
         project = Project("myproject")
         target = Target("mylib")
         target.output_nodes.append(FileNode("lib.a"))
-        project.add_target(target)
 
         alias = project.Alias("libs", target)
 
@@ -211,7 +204,6 @@ class TestProjectAliases:
         """Alias should pick up target output_nodes even if empty at Alias() time."""
         project = Project("myproject")
         target = Target("install_stuff")
-        project.add_target(target)
 
         # Create alias while target has no nodes at all
         alias = project.Alias("install", target)
@@ -230,7 +222,6 @@ class TestProjectAliases:
         target = Target("mylib")
         node = FileNode("lib.a")
         target.output_nodes.append(node)
-        project.add_target(target)
 
         alias = project.Alias("libs", target)
 
@@ -242,7 +233,6 @@ class TestProjectDefaults:
     def test_set_default_targets(self):
         project = Project("myproject")
         target = Target("app")
-        project.add_target(target)
 
         project.Default(target)
 
@@ -251,7 +241,6 @@ class TestProjectDefaults:
     def test_default_by_name(self):
         project = Project("myproject")
         target = Target("app")
-        project.add_target(target)
 
         project.Default("app")
 
@@ -260,7 +249,6 @@ class TestProjectDefaults:
     def test_default_avoids_duplicates(self):
         project = Project("myproject")
         target = Target("app")
-        project.add_target(target)
 
         project.Default(target)
         project.Default(target)
@@ -277,7 +265,6 @@ class TestProjectValidation:
 
         target = Target("app")
         target.add_source(FileNode(source_file))
-        project.add_target(target)
 
         errors = project.validate()
         assert errors == []
@@ -286,7 +273,6 @@ class TestProjectValidation:
         project = Project("myproject", root_dir=tmp_path)
         target = Target("app")
         target.add_source(FileNode("nonexistent.c"))
-        project.add_target(target)
 
         errors = project.validate()
         assert len(errors) == 1
@@ -298,8 +284,6 @@ class TestProjectValidation:
         b = Target("B")
         a.link(b)
         b.link(a)
-        project.add_target(a)
-        project.add_target(b)
 
         errors = project.validate()
         assert len(errors) > 0
@@ -312,8 +296,6 @@ class TestProjectBuildOrder:
         lib = Target("lib")
         app = Target("app")
         app.link(lib)
-        project.add_target(lib)
-        project.add_target(app)
 
         order = project.build_order()
 
@@ -332,9 +314,6 @@ class TestProjectAllNodes:
         app.add_source(FileNode("main.c"))
         app.output_nodes.append(FileNode("app"))
         app.link(lib)
-
-        project.add_target(lib)
-        project.add_target(app)
 
         nodes = project.all_nodes()
 
@@ -394,7 +373,6 @@ class TestGeneratePcFile:
         target.public.include_dirs.append(Path("include"))
         target.public.defines.append("MYLIB_STATIC")
         target.public.link_libs.append("m")
-        project.add_target(target)
 
         pc = project.generate_pc_file(target, version="2.1.0", description="My lib")
 
@@ -412,7 +390,6 @@ class TestGeneratePcFile:
         """generate_pc_file() doesn't rewrite if content unchanged."""
         project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
         target = Target("foo")
-        project.add_target(target)
 
         pc = project.generate_pc_file(target, version="1.0")
         mtime1 = pc.stat().st_mtime
@@ -439,7 +416,6 @@ class TestGeneratePcFile:
 
         target = Target("mylib")
         target.link(zlib)
-        project.add_target(target)
 
         pc = project.generate_pc_file(target, version="1.0")
         content = pc.read_text()
@@ -452,7 +428,6 @@ class TestGeneratePcFile:
         project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
         target = Target("mylib")
         target.public.include_dirs.append(tmp_path / "include")
-        project.add_target(target)
 
         pc = project.generate_pc_file(target, version="1.0")
         content = pc.read_text()
@@ -471,7 +446,6 @@ class TestGeneratePcFile:
         else:
             ext_inc = Path("/opt/external/include")
         target.public.include_dirs.append(ext_inc)
-        project.add_target(target)
 
         pc = project.generate_pc_file(target, version="1.0")
         content = pc.read_text()
@@ -484,8 +458,6 @@ class TestAlias:
         project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
         t1 = Target("lib1")
         t2 = Target("lib2")
-        project.add_target(t1)
-        project.add_target(t2)
 
         alias = project.Alias("install", [t1, t2])
         assert len(alias._target_refs) == 2
@@ -495,8 +467,6 @@ class TestAlias:
         project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
         t1 = Target("lib1")
         t2 = Target("lib2")
-        project.add_target(t1)
-        project.add_target(t2)
 
         alias = project.Alias("install", t1, t2)
         assert len(alias._target_refs) == 2

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -32,6 +32,17 @@ class TestProjectCreation:
         assert project.defined_at is not None
         assert project.defined_at.lineno > 0
 
+    def test_top_level_project(self):
+        project1 = Project("project1")
+        assert Project.top_level() is project1
+        assert project1.is_top_level
+
+        project2 = Project("project2")
+        assert Project.top_level() is project1
+        assert not project2.is_top_level
+        assert project2 in project1._children
+        assert project2._parent is project1
+
 
 class TestProjectEnvironments:
     def test_create_environment(self):

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -43,6 +43,27 @@ class TestProjectCreation:
         assert project2 in project1._children
         assert project2._parent is project1
 
+    def test_root_dir_must_be_absolute(self):
+        with pytest.raises(ValueError):
+            Project("myproject", root_dir="relative/path")
+
+    def test_retrieving_current_project_while_none_is_active_raises_a_value_error(self):
+        with pytest.raises(ValueError):
+            Project.current()
+
+    def test_retrieving_top_level_project_while_none_is_active_raises_a_value_error(
+        self,
+    ):
+        with pytest.raises(ValueError):
+            Project.top_level()
+
+    def test_retrieving_parent_project_while_no_parent_available_raises_a_value_error(
+        self,
+    ):
+        project = Project("testproject")
+        with pytest.raises(ValueError):
+            _ = project.parent
+
 
 class TestProjectEnvironments:
     def test_create_environment(self):
@@ -66,6 +87,18 @@ class TestProjectEnvironments:
 
         assert len(project.environments) == 2
         assert env1 is not env2
+
+    def test_default_environment(self):
+        project = Project("myproject")
+        env1 = project.Environment()
+        project.Environment()
+
+        assert project.default_environment is env1
+
+    def test_missing_default_environment(self):
+        project = Project("myproject")
+        with pytest.raises(ValueError):
+            _ = project.default_environment
 
 
 class TestProjectNodes:
@@ -123,6 +156,32 @@ class TestProjectTargets:
 
         with pytest.raises(KeyError):
             project.get_target("missing", raise_if_missing=True)
+
+    def test_target_lookup(self):
+        root = Project("root")
+        with root._enter_subdir("child1"):
+            child1 = Project("child1")
+            mylib1 = Target("mylib1")
+            child1.add_target(mylib1)
+        with root._enter_subdir("child2"):
+            child2 = Project("child2")
+            mylib2 = Target("mylib2")
+            child2.add_target(mylib2)
+
+        # may we support parent lookup ??? not currently implemented
+        assert child1.get_target("mylib2", raise_if_missing=False) is None
+        assert child2.get_target("mylib1", raise_if_missing=False) is None
+
+        assert child1.get_target("mylib1") is mylib1
+        assert child2.get_target("mylib2") is mylib2
+        assert root.get_target("mylib1") is mylib1
+        assert root.get_target("mylib2") is mylib2
+
+        with pytest.raises(KeyError):
+            child1.get_target("mylib2", raise_if_missing=True)
+
+        with pytest.raises(KeyError):
+            child2.get_target("mylib1", raise_if_missing=True)
 
 
 class TestProjectAliases:

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -179,12 +179,12 @@ class TestSubproject:
         with pytest.raises(KeyError):
             child2.get_target("mylib1", raise_if_missing=True)
 
-    def test_subproject_build_dir_warns(self, test_project):
+    def test_subproject_build_dir_warns(self, tmp_path, test_project):
         with pytest.warns(
             UserWarning, match="build_dir argument is ignored for sub-projects"
         ):
             with test_project._enter_subdir("child"):
-                Project("child", build_dir="ignored_build")
+                Project("child", build_dir="ignored_build", root_dir=tmp_path / "child")
 
 
 class TestProjectAliases:

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -119,7 +119,10 @@ class TestProjectTargets:
 
     def test_get_nonexistent_target(self):
         project = Project("myproject")
-        assert project.get_target("missing") is None
+        assert project.get_target("missing", raise_if_missing=False) is None
+
+        with pytest.raises(KeyError):
+            project.get_target("missing", raise_if_missing=True)
 
 
 class TestProjectAliases:

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -153,6 +153,8 @@ class TestProjectTargets:
         with pytest.raises(KeyError):
             project.get_target("missing", raise_if_missing=True)
 
+
+class TestSubproject:
     def test_target_lookup(self):
         root = Project("root")
         with root._enter_subdir("child1"):
@@ -176,6 +178,13 @@ class TestProjectTargets:
 
         with pytest.raises(KeyError):
             child2.get_target("mylib1", raise_if_missing=True)
+
+    def test_subproject_build_dir_warns(self, test_project):
+        with pytest.warns(
+            UserWarning, match="build_dir argument is ignored for sub-projects"
+        ):
+            with test_project._enter_subdir("child"):
+                Project("child", build_dir="ignored_build")
 
 
 class TestProjectAliases:

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 from pcons.core.node import FileNode
+from pcons.core.project import Project
 from pcons.core.target import ImportedTarget, Target, UsageRequirements
 
 
@@ -69,6 +70,7 @@ class TestUsageRequirements:
 
 class TestTarget:
     def test_creation(self):
+        Project("test_project")
         target = Target("mylib")
         assert target.name == "mylib"
         assert target.nodes == []
@@ -76,11 +78,13 @@ class TestTarget:
         assert target.dependencies == []
 
     def test_tracks_source_location(self):
+        Project("test_project")
         target = Target("mylib")
         assert target.defined_at is not None
         assert target.defined_at.lineno > 0
 
     def test_link_adds_dependency(self):
+        Project("test_project")
         lib1 = Target("lib1")
         lib2 = Target("lib2")
         app = Target("app")
@@ -92,6 +96,7 @@ class TestTarget:
         assert lib2 in app.dependencies
 
     def test_link_avoids_duplicates(self):
+        Project("test_project")
         lib = Target("lib")
         app = Target("app")
 
@@ -101,6 +106,7 @@ class TestTarget:
         assert app.dependencies.count(lib) == 1
 
     def test_usage_requirements(self):
+        Project("test_project")
         lib = Target("lib")
         lib.public.include_dirs.append(Path("include"))
         lib.public.defines.append("LIB_API")
@@ -113,6 +119,7 @@ class TestTarget:
     def test_collect_usage_requirements(self):
         """Test transitive requirement collection."""
         # Create a dependency chain: app -> libB -> libA
+        Project("test_project")
         libA = Target("libA")
         libA.public.include_dirs.append(Path("libA/include"))
         libA.public.defines.append("LIBA_API")
@@ -135,6 +142,7 @@ class TestTarget:
 
     def test_collect_usage_requirements_cached(self):
         """Test that collection is cached."""
+        Project("test_project")
         lib = Target("lib")
         app = Target("app")
         app.link(lib)
@@ -146,6 +154,7 @@ class TestTarget:
 
     def test_collect_usage_requirements_invalidated(self):
         """Test that cache is invalidated on new link."""
+        Project("test_project")
         lib1 = Target("lib1")
         lib2 = Target("lib2")
         lib2.public.defines.append("LIB2")
@@ -162,6 +171,7 @@ class TestTarget:
         assert "LIB2" in req2.defines
 
     def test_get_all_languages(self):
+        Project("test_project")
         lib = Target("lib")
         lib.required_languages.add("c")
 
@@ -174,6 +184,7 @@ class TestTarget:
         assert "cxx" in langs
 
     def test_equality_by_name(self):
+        Project("test_project")
         t1 = Target("mylib")
         t2 = Target("mylib")
         t3 = Target("other")
@@ -182,6 +193,7 @@ class TestTarget:
         assert t1 != t3
 
     def test_hashable(self):
+        Project("test_project")
         t1 = Target("mylib")
         t2 = Target("mylib")
 
@@ -191,6 +203,7 @@ class TestTarget:
 
 class TestImportedTarget:
     def test_creation(self):
+        Project("test_project")
         target = ImportedTarget("zlib", version="1.2.11")
         assert target.name == "zlib"
         assert target.is_imported is True
@@ -198,6 +211,7 @@ class TestImportedTarget:
         assert target.version == "1.2.11"
 
     def test_can_have_usage_requirements(self):
+        Project("test_project")
         target = ImportedTarget("zlib")
         target.public.include_dirs.append(Path("/usr/include"))
         target.public.link_libs.append("z")
@@ -206,6 +220,7 @@ class TestImportedTarget:
         assert target.public.link_libs == ["z"]
 
     def test_can_be_dependency(self):
+        Project("test_project")
         zlib = ImportedTarget("zlib")
         zlib.public.link_libs.append("z")
 
@@ -221,6 +236,7 @@ class TestFluentAPI:
 
     def test_link_returns_self(self):
         """link() returns self for chaining."""
+        Project("test_project")
         lib = Target("lib")
         app = Target("app")
 
@@ -231,6 +247,7 @@ class TestFluentAPI:
 
     def test_add_source_returns_self(self, tmp_path):
         """add_source() returns self for chaining."""
+        Project("test_project")
         target = Target("app")
         src = tmp_path / "main.c"
         src.touch()
@@ -242,6 +259,7 @@ class TestFluentAPI:
 
     def test_add_sources_returns_self(self, tmp_path):
         """add_sources() returns self for chaining."""
+        Project("test_project")
         target = Target("app")
         src1 = tmp_path / "main.c"
         src2 = tmp_path / "util.c"
@@ -255,6 +273,7 @@ class TestFluentAPI:
 
     def test_add_sources_with_base(self, tmp_path):
         """add_sources() with base directory works."""
+        Project("test_project")
         target = Target("app")
         src_dir = tmp_path / "src"
         src_dir.mkdir()
@@ -271,6 +290,7 @@ class TestFluentAPI:
 
     def test_public_private_requirements(self):
         """Usage requirements can be set directly on public/private."""
+        Project("test_project")
         target = Target("lib")
 
         target.public.include_dirs.append(Path("include"))
@@ -286,6 +306,7 @@ class TestFluentAPI:
 
     def test_link_chain(self, tmp_path):
         """link() can be chained with other fluent methods."""
+        Project("test_project")
         lib = Target("lib")
         app = Target("app")
         src = tmp_path / "main.c"
@@ -303,6 +324,7 @@ class TestPostBuild:
 
     def test_post_build_adds_command(self):
         """post_build() adds a command to the list."""
+        Project("test_project")
         target = Target("app")
 
         target.post_build("install_name_tool -add_rpath @loader_path $out")
@@ -313,6 +335,7 @@ class TestPostBuild:
 
     def test_post_build_fluent_returns_self(self):
         """post_build() returns self for chaining."""
+        Project("test_project")
         target = Target("app")
 
         result = target.post_build("echo done")
@@ -321,6 +344,7 @@ class TestPostBuild:
 
     def test_post_build_multiple_commands(self):
         """Multiple post_build() calls accumulate commands in order."""
+        Project("test_project")
         target = Target("plugin")
 
         target.post_build("install_name_tool -add_rpath @loader_path $out")
@@ -338,6 +362,7 @@ class TestPostBuild:
 
     def test_post_build_chain_with_other_methods(self, tmp_path):
         """post_build() can be chained with other fluent methods."""
+        Project("test_project")
         target = Target("app")
         src = tmp_path / "main.c"
         src.touch()
@@ -353,6 +378,7 @@ class TestPostBuild:
 
     def test_post_build_empty_by_default(self):
         """Target has no post_build commands by default."""
+        Project("test_project")
         target = Target("app")
 
         post_build_cmds = target._builder_data.get("post_build_commands", [])
@@ -364,6 +390,7 @@ class TestTargetDepends:
 
     def test_depends_with_file_node(self):
         """depends() accepts FileNode objects."""
+        Project("test_project")
         target = Target("app")
         dep = FileNode("tools/codegen.py")
 
@@ -373,6 +400,7 @@ class TestTargetDepends:
 
     def test_depends_with_string_no_project(self):
         """depends() with string creates FileNode when no project."""
+        Project("test_project")
         target = Target("app")
 
         target.depends("tools/codegen.py")
@@ -382,6 +410,7 @@ class TestTargetDepends:
 
     def test_depends_with_target(self):
         """depends() with Target adds to implicit target deps, not link deps."""
+        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
 
@@ -393,6 +422,7 @@ class TestTargetDepends:
 
     def test_depends_mixed_args(self):
         """depends() handles mixed Target and file args."""
+        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
         config = FileNode("config.yaml")
@@ -406,6 +436,7 @@ class TestTargetDepends:
 
     def test_depends_fluent(self):
         """depends() returns self for chaining."""
+        Project("test_project")
         target = Target("app")
 
         result = target.depends("a.txt").depends("b.txt")
@@ -415,8 +446,6 @@ class TestTargetDepends:
 
     def test_depends_applied_during_resolve(self, tmp_path):
         """depends() deps are applied to output nodes during resolve."""
-        from pcons.core.project import Project
-
         project = Project("test", root_dir=tmp_path, build_dir="build")
         env = project.Environment()
 
@@ -437,6 +466,7 @@ class TestTargetDepends:
 
     def test_apply_extra_implicit_deps_propagated(self):
         """Propagated deps go on both object nodes and output nodes."""
+        Project("test_project")
         target = Target("app")
         obj = FileNode("build/main.o")
         exe = FileNode("build/app")
@@ -452,6 +482,7 @@ class TestTargetDepends:
 
     def test_apply_extra_implicit_deps_output_only(self):
         """Output-only deps go on output nodes but not object nodes."""
+        Project("test_project")
         target = Target("app")
         obj = FileNode("build/main.o")
         exe = FileNode("build/app")
@@ -467,6 +498,7 @@ class TestTargetDepends:
 
     def test_depends_propagate_false(self):
         """depends(propagate=False) stores in output-only lists."""
+        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
 
@@ -479,6 +511,7 @@ class TestTargetDepends:
 
     def test_apply_no_duplicates(self):
         """_apply_extra_implicit_deps doesn't add duplicates."""
+        Project("test_project")
         target = Target("app")
         output = FileNode("build/app")
         target.output_nodes.append(output)
@@ -492,8 +525,6 @@ class TestTargetDepends:
 
     def test_depends_with_project(self, tmp_path):
         """depends() uses project.node() when project is available."""
-        from pcons.core.project import Project
-
         project = Project("test", root_dir=tmp_path, build_dir="build")
         target = Target("app")
 

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -7,7 +7,13 @@ import pytest
 
 from pcons.core.node import FileNode
 from pcons.core.project import Project
-from pcons.core.target import ImportedTarget, Target, UsageRequirements
+from pcons.core.target import (
+    ImportedTarget,
+    Target,
+    UsageRequirements,
+    is_qualified_name,
+    split_qualified_name,
+)
 
 
 class TestUsageRequirements:
@@ -68,6 +74,27 @@ class TestUsageRequirements:
         # Modifying clone doesn't affect original
         clone.include_dirs.append(Path("other"))
         assert Path("other") not in req.include_dirs
+
+
+class TestQualifiedName:
+    def test_qualified_name(self):
+        assert is_qualified_name("project::target")
+        assert not is_qualified_name("target")
+        assert not is_qualified_name("this::is::invalid")  # Only one '::' allowed
+        with pytest.raises(ValueError):
+            split_qualified_name("this::is::invalid")
+
+        p, n = split_qualified_name("project::target")
+        assert p == "project"
+        assert n == "target"
+
+        p, n = split_qualified_name("target")
+        assert p is None
+        assert n == "target"
+
+    def test_qualified_name_property(self, test_project):  # noqa: F811
+        target = Target("mylib")
+        assert target.qualified_name == "test_project::mylib"
 
 
 class TestTarget:
@@ -178,7 +205,9 @@ class TestTarget:
 
     def test_equality_by_name(self, test_project):  # noqa: F811
         t1 = Target("mylib")
+        t1.name = "fake"
         t2 = Target("mylib")
+        t1.name = "mylib"  # Reset to original name for equality
         t3 = Target("other")
 
         assert t1 == t2
@@ -186,7 +215,9 @@ class TestTarget:
 
     def test_hashable(self, test_project):  # noqa: F811
         t1 = Target("mylib")
+        t1.name = "fake"
         t2 = Target("mylib")
+        t1.name = "mylib"  # Reset to original name for hashing
 
         targets = {t1, t2}
         assert len(targets) == 1  # Same name = same target
@@ -516,5 +547,27 @@ class TestTargetSubdir:
             target = Target("mylib")
 
         assert target.source_dir == (root / "lib")
-        print(target.build_dir)
         assert target.build_dir.as_posix() == Path("/build/lib").as_posix()
+
+        assert target.qualified_name == "test_project::mylib"
+        assert project.get_target("test_project::mylib") == target
+        assert project.get_target("mylib") == target  # Unqualified lookup should work
+
+    def test_collision(self, test_project):
+        with test_project._enter_subdir("lib1"):
+            Project("sub1")
+            target1 = Target("mylib")
+        with test_project._enter_subdir("lib2"):
+            Project("sub2")
+            target2 = Target("mylib")
+
+        assert target1 is not target2
+        assert target1.qualified_name == "sub1::mylib"
+        assert target2.qualified_name == "sub2::mylib"
+
+        assert test_project.get_target("sub1::mylib") == target1
+        assert test_project.get_target("sub2::mylib") == target2
+
+        with pytest.raises(KeyError):
+            # Unqualified lookup should fail due to collision
+            test_project.get_target("mylib")

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import ImportedTarget, Target, UsageRequirements
@@ -199,6 +201,11 @@ class TestTarget:
 
         targets = {t1, t2}
         assert len(targets) == 1  # Same name = same target
+
+    def test_target_without_project(self):
+        """Test that Target can be created without an active project."""
+        with pytest.raises(ValueError):
+            Target("orphan")
 
 
 class TestImportedTarget:
@@ -533,3 +540,15 @@ class TestTargetDepends:
         dep = target._extra_implicit_deps[0]
         # project.node() canonicalizes the path
         assert dep is project.node("tools/codegen.py")
+
+
+class TestTargetSubdir:
+    def test_directories(self):
+        root = Path.cwd().resolve()
+        project = Project("test_project", root_dir=root, build_dir="/build")
+        with project._enter_subdir("lib"):
+            target = Target("mylib")
+
+        assert target.source_dir == (root / "lib")
+        print(target.build_dir)
+        assert target.build_dir.as_posix() == Path("/build/lib").as_posix()

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -110,6 +110,12 @@ class TestTarget:
         assert target.defined_at is not None
         assert target.defined_at.lineno > 0
 
+    def test_tracks_source_dir_is_project_root_dir(self, test_project):
+        target = Target("mylib")
+        assert target.defined_at is not None
+        assert target.defined_at.lineno > 0
+        assert target.source_dir == test_project.root_dir
+
     def test_link_adds_dependency(self, test_project):  # noqa: F811
         lib1 = Target("lib1")
         lib2 = Target("lib2")

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -71,22 +71,19 @@ class TestUsageRequirements:
 
 
 class TestTarget:
-    def test_creation(self):
-        Project("test_project")
+    def test_creation(self, test_project):  # noqa: F811
         target = Target("mylib")
         assert target.name == "mylib"
         assert target.nodes == []
         assert target.sources == []
         assert target.dependencies == []
 
-    def test_tracks_source_location(self):
-        Project("test_project")
+    def test_tracks_source_location(self, test_project):  # noqa: F811
         target = Target("mylib")
         assert target.defined_at is not None
         assert target.defined_at.lineno > 0
 
-    def test_link_adds_dependency(self):
-        Project("test_project")
+    def test_link_adds_dependency(self, test_project):  # noqa: F811
         lib1 = Target("lib1")
         lib2 = Target("lib2")
         app = Target("app")
@@ -97,8 +94,7 @@ class TestTarget:
         assert lib1 in app.dependencies
         assert lib2 in app.dependencies
 
-    def test_link_avoids_duplicates(self):
-        Project("test_project")
+    def test_link_avoids_duplicates(self, test_project):  # noqa: F811
         lib = Target("lib")
         app = Target("app")
 
@@ -107,8 +103,7 @@ class TestTarget:
 
         assert app.dependencies.count(lib) == 1
 
-    def test_usage_requirements(self):
-        Project("test_project")
+    def test_usage_requirements(self, test_project):  # noqa: F811
         lib = Target("lib")
         lib.public.include_dirs.append(Path("include"))
         lib.public.defines.append("LIB_API")
@@ -118,10 +113,9 @@ class TestTarget:
         assert lib.public.defines == ["LIB_API"]
         assert lib.private.defines == ["LIB_BUILDING"]
 
-    def test_collect_usage_requirements(self):
+    def test_collect_usage_requirements(self, test_project):  # noqa: F811
         """Test transitive requirement collection."""
         # Create a dependency chain: app -> libB -> libA
-        Project("test_project")
         libA = Target("libA")
         libA.public.include_dirs.append(Path("libA/include"))
         libA.public.defines.append("LIBA_API")
@@ -142,9 +136,8 @@ class TestTarget:
         assert "LIBA_API" in requirements.defines
         assert "APP_PRIVATE" in requirements.defines
 
-    def test_collect_usage_requirements_cached(self):
+    def test_collect_usage_requirements_cached(self, test_project):  # noqa: F811
         """Test that collection is cached."""
-        Project("test_project")
         lib = Target("lib")
         app = Target("app")
         app.link(lib)
@@ -154,9 +147,8 @@ class TestTarget:
 
         assert req1 is req2  # Same object (cached)
 
-    def test_collect_usage_requirements_invalidated(self):
+    def test_collect_usage_requirements_invalidated(self, test_project):  # noqa: F811
         """Test that cache is invalidated on new link."""
-        Project("test_project")
         lib1 = Target("lib1")
         lib2 = Target("lib2")
         lib2.public.defines.append("LIB2")
@@ -172,8 +164,7 @@ class TestTarget:
         assert req2 is not req1
         assert "LIB2" in req2.defines
 
-    def test_get_all_languages(self):
-        Project("test_project")
+    def test_get_all_languages(self, test_project):  # noqa: F811
         lib = Target("lib")
         lib.required_languages.add("c")
 
@@ -185,8 +176,7 @@ class TestTarget:
         assert "c" in langs
         assert "cxx" in langs
 
-    def test_equality_by_name(self):
-        Project("test_project")
+    def test_equality_by_name(self, test_project):  # noqa: F811
         t1 = Target("mylib")
         t2 = Target("mylib")
         t3 = Target("other")
@@ -194,8 +184,7 @@ class TestTarget:
         assert t1 == t2
         assert t1 != t3
 
-    def test_hashable(self):
-        Project("test_project")
+    def test_hashable(self, test_project):  # noqa: F811
         t1 = Target("mylib")
         t2 = Target("mylib")
 
@@ -209,16 +198,14 @@ class TestTarget:
 
 
 class TestImportedTarget:
-    def test_creation(self):
-        Project("test_project")
+    def test_creation(self, test_project):  # noqa: F811
         target = ImportedTarget("zlib", version="1.2.11")
         assert target.name == "zlib"
         assert target.is_imported is True
         assert target.package_name == "zlib"
         assert target.version == "1.2.11"
 
-    def test_can_have_usage_requirements(self):
-        Project("test_project")
+    def test_can_have_usage_requirements(self, test_project):  # noqa: F811
         target = ImportedTarget("zlib")
         target.public.include_dirs.append(Path("/usr/include"))
         target.public.link_libs.append("z")
@@ -226,8 +213,7 @@ class TestImportedTarget:
         assert target.public.include_dirs == [Path("/usr/include")]
         assert target.public.link_libs == ["z"]
 
-    def test_can_be_dependency(self):
-        Project("test_project")
+    def test_can_be_dependency(self, test_project):  # noqa: F811
         zlib = ImportedTarget("zlib")
         zlib.public.link_libs.append("z")
 
@@ -241,9 +227,8 @@ class TestImportedTarget:
 class TestFluentAPI:
     """Tests for fluent API methods."""
 
-    def test_link_returns_self(self):
+    def test_link_returns_self(self, test_project):  # noqa: F811
         """link() returns self for chaining."""
-        Project("test_project")
         lib = Target("lib")
         app = Target("app")
 
@@ -252,9 +237,8 @@ class TestFluentAPI:
         assert result is app
         assert lib in app.dependencies
 
-    def test_add_source_returns_self(self, tmp_path):
+    def test_add_source_returns_self(self, tmp_path, test_project):  # noqa: F811
         """add_source() returns self for chaining."""
-        Project("test_project")
         target = Target("app")
         src = tmp_path / "main.c"
         src.touch()
@@ -264,9 +248,8 @@ class TestFluentAPI:
         assert result is target
         assert len(target.sources) == 1
 
-    def test_add_sources_returns_self(self, tmp_path):
+    def test_add_sources_returns_self(self, tmp_path, test_project):  # noqa: F811
         """add_sources() returns self for chaining."""
-        Project("test_project")
         target = Target("app")
         src1 = tmp_path / "main.c"
         src2 = tmp_path / "util.c"
@@ -278,9 +261,8 @@ class TestFluentAPI:
         assert result is target
         assert len(target.sources) == 2
 
-    def test_add_sources_with_base(self, tmp_path):
+    def test_add_sources_with_base(self, tmp_path, test_project):  # noqa: F811
         """add_sources() with base directory works."""
-        Project("test_project")
         target = Target("app")
         src_dir = tmp_path / "src"
         src_dir.mkdir()
@@ -295,9 +277,8 @@ class TestFluentAPI:
         assert src_dir / "main.c" in paths
         assert src_dir / "util.c" in paths
 
-    def test_public_private_requirements(self):
+    def test_public_private_requirements(self, test_project):  # noqa: F811
         """Usage requirements can be set directly on public/private."""
-        Project("test_project")
         target = Target("lib")
 
         target.public.include_dirs.append(Path("include"))
@@ -311,9 +292,8 @@ class TestFluentAPI:
         assert Path("src") in target.private.include_dirs
         assert "BUILDING_LIB" in target.private.defines
 
-    def test_link_chain(self, tmp_path):
+    def test_link_chain(self, tmp_path, test_project):  # noqa: F811
         """link() can be chained with other fluent methods."""
-        Project("test_project")
         lib = Target("lib")
         app = Target("app")
         src = tmp_path / "main.c"
@@ -329,9 +309,8 @@ class TestFluentAPI:
 class TestPostBuild:
     """Tests for post_build() functionality."""
 
-    def test_post_build_adds_command(self):
+    def test_post_build_adds_command(self, test_project):  # noqa: F811
         """post_build() adds a command to the list."""
-        Project("test_project")
         target = Target("app")
 
         target.post_build("install_name_tool -add_rpath @loader_path $out")
@@ -340,18 +319,16 @@ class TestPostBuild:
         assert len(post_build_cmds) == 1
         assert post_build_cmds[0] == "install_name_tool -add_rpath @loader_path $out"
 
-    def test_post_build_fluent_returns_self(self):
+    def test_post_build_fluent_returns_self(self, test_project):  # noqa: F811
         """post_build() returns self for chaining."""
-        Project("test_project")
         target = Target("app")
 
         result = target.post_build("echo done")
 
         assert result is target
 
-    def test_post_build_multiple_commands(self):
+    def test_post_build_multiple_commands(self, test_project):  # noqa: F811
         """Multiple post_build() calls accumulate commands in order."""
-        Project("test_project")
         target = Target("plugin")
 
         target.post_build("install_name_tool -add_rpath @loader_path $out")
@@ -367,9 +344,8 @@ class TestPostBuild:
         )
         assert post_build_cmds[2] == "codesign --sign - $out"
 
-    def test_post_build_chain_with_other_methods(self, tmp_path):
+    def test_post_build_chain_with_other_methods(self, tmp_path, test_project):  # noqa: F811
         """post_build() can be chained with other fluent methods."""
-        Project("test_project")
         target = Target("app")
         src = tmp_path / "main.c"
         src.touch()
@@ -383,9 +359,8 @@ class TestPostBuild:
         assert len(post_build_cmds) == 1
         assert "DEBUG" in target.private.defines
 
-    def test_post_build_empty_by_default(self):
+    def test_post_build_empty_by_default(self, test_project):  # noqa: F811
         """Target has no post_build commands by default."""
-        Project("test_project")
         target = Target("app")
 
         post_build_cmds = target._builder_data.get("post_build_commands", [])
@@ -395,9 +370,8 @@ class TestPostBuild:
 class TestTargetDepends:
     """Tests for target.depends() implicit dependency support."""
 
-    def test_depends_with_file_node(self):
+    def test_depends_with_file_node(self, test_project):  # noqa: F811
         """depends() accepts FileNode objects."""
-        Project("test_project")
         target = Target("app")
         dep = FileNode("tools/codegen.py")
 
@@ -405,9 +379,8 @@ class TestTargetDepends:
 
         assert dep in target._extra_implicit_deps
 
-    def test_depends_with_string_no_project(self):
+    def test_depends_with_string_no_project(self, test_project):  # noqa: F811
         """depends() with string creates FileNode when no project."""
-        Project("test_project")
         target = Target("app")
 
         target.depends("tools/codegen.py")
@@ -415,9 +388,8 @@ class TestTargetDepends:
         assert len(target._extra_implicit_deps) == 1
         assert target._extra_implicit_deps[0].path == Path("tools/codegen.py")
 
-    def test_depends_with_target(self):
+    def test_depends_with_target(self, test_project):  # noqa: F811
         """depends() with Target adds to implicit target deps, not link deps."""
-        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
 
@@ -427,9 +399,8 @@ class TestTargetDepends:
         assert len(target.dependencies) == 0
         assert len(target._extra_implicit_deps) == 0
 
-    def test_depends_mixed_args(self):
+    def test_depends_mixed_args(self, test_project):  # noqa: F811
         """depends() handles mixed Target and file args."""
-        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
         config = FileNode("config.yaml")
@@ -441,9 +412,8 @@ class TestTargetDepends:
         assert config in target._extra_implicit_deps
         assert len(target._extra_implicit_deps) == 2
 
-    def test_depends_fluent(self):
+    def test_depends_fluent(self, test_project):  # noqa: F811
         """depends() returns self for chaining."""
-        Project("test_project")
         target = Target("app")
 
         result = target.depends("a.txt").depends("b.txt")
@@ -471,9 +441,8 @@ class TestTargetDepends:
         # After resolve, the dep is on the output node
         assert len(cmd.output_nodes[0].implicit_deps) == 1
 
-    def test_apply_extra_implicit_deps_propagated(self):
+    def test_apply_extra_implicit_deps_propagated(self, test_project):  # noqa: F811
         """Propagated deps go on both object nodes and output nodes."""
-        Project("test_project")
         target = Target("app")
         obj = FileNode("build/main.o")
         exe = FileNode("build/app")
@@ -487,9 +456,8 @@ class TestTargetDepends:
         assert dep in obj.implicit_deps
         assert dep in exe.implicit_deps
 
-    def test_apply_extra_implicit_deps_output_only(self):
+    def test_apply_extra_implicit_deps_output_only(self, test_project):  # noqa: F811
         """Output-only deps go on output nodes but not object nodes."""
-        Project("test_project")
         target = Target("app")
         obj = FileNode("build/main.o")
         exe = FileNode("build/app")
@@ -503,9 +471,8 @@ class TestTargetDepends:
         assert dep not in obj.implicit_deps
         assert dep in exe.implicit_deps
 
-    def test_depends_propagate_false(self):
+    def test_depends_propagate_false(self, test_project):  # noqa: F811
         """depends(propagate=False) stores in output-only lists."""
-        Project("test_project")
         target = Target("app")
         lib = Target("mylib")
 
@@ -516,9 +483,8 @@ class TestTargetDepends:
         assert len(target._extra_implicit_deps) == 0
         assert len(target._extra_implicit_deps_output_only) == 1
 
-    def test_apply_no_duplicates(self):
+    def test_apply_no_duplicates(self, test_project):  # noqa: F811
         """_apply_extra_implicit_deps doesn't add duplicates."""
-        Project("test_project")
         target = Target("app")
         output = FileNode("build/app")
         target.output_nodes.append(output)

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -292,10 +292,10 @@ class TestFluentAPI:
         assert result is target
         assert len(target.sources) == 2
 
-    def test_add_sources_with_base(self, tmp_path, test_project):  # noqa: F811
+    def test_add_sources_with_base(self, test_project):
         """add_sources() with base directory works."""
         target = Target("app")
-        src_dir = tmp_path / "src"
+        src_dir = test_project.root_dir / "src"
         src_dir.mkdir()
         (src_dir / "main.c").touch()
         (src_dir / "util.c").touch()
@@ -305,8 +305,9 @@ class TestFluentAPI:
         assert len(target.sources) == 2
         # Verify paths are resolved correctly
         paths = [n.path for n in target.sources if isinstance(n, FileNode)]
-        assert src_dir / "main.c" in paths
-        assert src_dir / "util.c" in paths
+        rel_src_dir = src_dir.relative_to(test_project.root_dir)
+        assert rel_src_dir / "main.c" in paths
+        assert rel_src_dir / "util.c" in paths
 
     def test_public_private_requirements(self, test_project):  # noqa: F811
         """Usage requirements can be set directly on public/private."""
@@ -555,10 +556,10 @@ class TestTargetSubdir:
 
     def test_collision(self, test_project):
         with test_project._enter_subdir("lib1"):
-            Project("sub1")
+            Project("sub1", root_dir=test_project.root_dir / "lib1")
             target1 = Target("mylib")
         with test_project._enter_subdir("lib2"):
-            Project("sub2")
+            Project("sub2", root_dir=test_project.root_dir / "lib2")
             target2 = Target("mylib")
 
         assert target1 is not target2

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -496,7 +496,6 @@ class TestTargetDepends:
 
         project = Project("test", root_dir=tmp_path, build_dir="build")
         target = Target("app")
-        target._project = project
 
         target.depends("tools/codegen.py")
 

--- a/tests/core/test_test_builder.py
+++ b/tests/core/test_test_builder.py
@@ -434,7 +434,6 @@ class TestSetTestPropertyEdgeCases:
         # set_test_property should refuse, with a clear message.
         proj, _env, _prog = project
         bogus = Target("not_a_real_test", target_type="test")
-        bogus._project = proj
         bogus._builder_data = {}  # no spec_partial
         with pytest.raises(RuntimeError, match="no partial spec"):
             set_test_property(bogus, "timeout", 1.0)

--- a/tests/generators/test_compile_commands.py
+++ b/tests/generators/test_compile_commands.py
@@ -66,7 +66,6 @@ class TestCompileCommandsEntries:
         # Use intermediate_nodes for compilation outputs
         target.intermediate_nodes.append(output_node)
         target._sources.append(source_node)
-        project.add_target(target)
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
@@ -100,7 +99,6 @@ class TestCompileCommandsEntries:
 
         # Use intermediate_nodes for compilation outputs
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
@@ -124,7 +122,6 @@ class TestCompileCommandsEntries:
         }
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
@@ -154,7 +151,6 @@ class TestCompileCommandsEntries:
         )
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
@@ -184,7 +180,6 @@ class TestCompileCommandsEntries:
         )
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = CompileCommandsGenerator()
         gen.generate(project)

--- a/tests/generators/test_makefile.py
+++ b/tests/generators/test_makefile.py
@@ -100,7 +100,6 @@ class TestMakefileBuildStatements:
 
         target.intermediate_nodes.append(output_node)
         target.add_source(source_node)
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -126,7 +125,6 @@ class TestMakefileBuildStatements:
         )
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -151,7 +149,6 @@ class TestMakefileBuildStatements:
         )
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -169,7 +166,6 @@ class TestMakefileAliases:
         target = Target("mylib")
         output_node = FileNode(tmp_path / "build" / "libmylib.a")
         target.output_nodes.append(output_node)
-        project.add_target(target)
 
         # Create an alias
         project.Alias("all_libs", output_node)
@@ -189,7 +185,6 @@ class TestMakefileDefaultTarget:
         output_node = FileNode(tmp_path / "build" / "app")
         target.output_nodes.append(output_node)
         target._resolved = True
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -227,7 +222,6 @@ class TestMakefileDepfiles:
         )
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -259,7 +253,6 @@ class TestMakefileImplicitDeps:
         output_node.implicit_deps.append(header_node)
 
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = MakefileGenerator()
         gen.generate(project)
@@ -303,7 +296,6 @@ class TestMakefilePostBuild:
             "chmod +x $out",
             "echo 'Built $out'",
         ]
-        project.add_target(target)
         project._resolved = True  # Skip auto-resolve since we set up nodes manually
 
         gen = MakefileGenerator()

--- a/tests/generators/test_mermaid.py
+++ b/tests/generators/test_mermaid.py
@@ -57,7 +57,6 @@ class TestMermaidGeneratorGraph:
         target.intermediate_nodes.append(obj)
         target.output_nodes.append(exe)
 
-        project.add_target(target)
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -100,9 +99,6 @@ class TestMermaidGeneratorGraph:
         app.output_nodes.append(app_exe)
         app.link(libphysics)
 
-        project.add_target(libmath)
-        project.add_target(libphysics)
-        project.add_target(app)
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -135,10 +131,6 @@ class TestMermaidGeneratorGraph:
         iface = Target("headers", target_type="interface")
         iface.output_nodes.append(FileNode(Path("include/headers")))
 
-        project.add_target(lib)
-        project.add_target(shared)
-        project.add_target(prog)
-        project.add_target(iface)
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -227,8 +219,6 @@ class TestMermaidGeneratorIntegration:
         app.output_nodes.append(app_exe)
         app.link(libmath)
 
-        project.add_target(libmath)
-        project.add_target(app)
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -274,9 +264,6 @@ class TestMermaidGeneratorIntegration:
         pkg_output.depends([bundle_dir])
         pkg.output_nodes.append(pkg_output)
 
-        project.add_target(install1)
-        project.add_target(install2)
-        project.add_target(pkg)
 
         gen = MermaidGenerator()
         gen.generate(project)

--- a/tests/generators/test_mermaid.py
+++ b/tests/generators/test_mermaid.py
@@ -57,7 +57,6 @@ class TestMermaidGeneratorGraph:
         target.intermediate_nodes.append(obj)
         target.output_nodes.append(exe)
 
-
         gen = MermaidGenerator()
         gen.generate(project)
 
@@ -99,7 +98,6 @@ class TestMermaidGeneratorGraph:
         app.output_nodes.append(app_exe)
         app.link(libphysics)
 
-
         gen = MermaidGenerator()
         gen.generate(project)
 
@@ -130,7 +128,6 @@ class TestMermaidGeneratorGraph:
         # Interface
         iface = Target("headers", target_type="interface")
         iface.output_nodes.append(FileNode(Path("include/headers")))
-
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -219,7 +216,6 @@ class TestMermaidGeneratorIntegration:
         app.output_nodes.append(app_exe)
         app.link(libmath)
 
-
         gen = MermaidGenerator()
         gen.generate(project)
 
@@ -263,7 +259,6 @@ class TestMermaidGeneratorIntegration:
         pkg_output = FileNode(Path("build/MyApp.pkg"))
         pkg_output.depends([bundle_dir])
         pkg.output_nodes.append(pkg_output)
-
 
         gen = MermaidGenerator()
         gen.generate(project)

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -42,7 +42,6 @@ class TestMetadataGenerator:
         lib = Target("mylib", target_type="static_library")
         lib.output_nodes.append(FileNode("build/libmylib.a"))
         lib.add_source("src/lib.c")
-        project.add_target(lib)
 
         app = Target(
             "app",
@@ -52,7 +51,6 @@ class TestMetadataGenerator:
         app.output_nodes.append(FileNode("build/app"))
         app.add_source("src/main.c")
         app.dependencies.append(lib)
-        project.add_target(app)
 
         project.Default(app)
         project.Alias("all", app)

--- a/tests/generators/test_ninja.py
+++ b/tests/generators/test_ninja.py
@@ -74,7 +74,6 @@ class TestNinjaBuildStatements:
         # Use intermediate_nodes for .o file outputs
         target.intermediate_nodes.append(output_node)
         target._sources.append(source_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -102,7 +101,6 @@ class TestNinjaBuildStatements:
 
         # Use intermediate_nodes for .o file outputs
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -120,7 +118,6 @@ class TestNinjaAliases:
         lib_node = FileNode("build/libmy.a")
         # Use output_nodes for final library outputs
         target.output_nodes.append(lib_node)
-        project.add_target(target)
 
         project.Alias("libs", target)
 
@@ -140,7 +137,6 @@ class TestNinjaDefaults:
         app_node = FileNode("build/app")
         # Use output_nodes for final executable outputs
         target.output_nodes.append(app_node)
-        project.add_target(target)
 
         project.Default(target)
 
@@ -195,7 +191,6 @@ class TestNinjaPostBuild:
         # Use output_nodes for final program outputs
         target.output_nodes.append(output_node)
         target.post_build("install_name_tool -add_rpath @loader_path $out")
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -233,7 +228,6 @@ class TestNinjaPostBuild:
         target.output_nodes.append(output_node)
         target.post_build("install_name_tool -add_rpath @loader_path $out")
         target.post_build("codesign --sign - $out")
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -265,7 +259,6 @@ class TestNinjaPostBuild:
         # Use output_nodes for final program outputs
         target.output_nodes.append(output_node)
         target.post_build("echo Built $out from $in")
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -295,7 +288,6 @@ class TestNinjaPostBuild:
         # Use output_nodes for final program outputs
         target.output_nodes.append(output_node)
         # No post_build() calls
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -334,7 +326,6 @@ class TestNinjaDepsDirectives:
 
         # Use intermediate_nodes for .o file outputs
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -368,7 +359,6 @@ class TestNinjaDepsDirectives:
 
         # Use intermediate_nodes for .obj file outputs
         target.intermediate_nodes.append(output_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -398,7 +388,6 @@ class TestNinjaDepsDirectives:
 
         # Use output_nodes for final program outputs
         target.output_nodes.append(output_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)

--- a/tests/generators/test_ninja_multi_output.py
+++ b/tests/generators/test_ninja_multi_output.py
@@ -79,7 +79,6 @@ class TestNinjaMultiOutput:
 
         target.output_nodes.extend([dll_node, lib_node, exp_node])
         target.add_source(source_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -135,7 +134,6 @@ class TestNinjaMultiOutput:
         )
 
         target.output_nodes.append(dll_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -191,7 +189,6 @@ class TestNinjaMultiOutput:
         lib_node.builder = dll_node.builder
 
         target.output_nodes.extend([dll_node, lib_node])
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)
@@ -239,7 +236,6 @@ class TestNinjaSingleOutput:
         )
 
         target.output_nodes.append(exe_node)
-        project.add_target(target)
 
         gen = NinjaGenerator()
         gen.generate(project)

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -396,7 +396,6 @@ class TestXcodeGeneratorInstallDir:
         install_dir_target = Target("install_assets", target_type="interface")
         install_dir_target._builder_name = "InstallDir"
         install_dir_target._builder_data = {"dest_dir": "dist"}
-        install_dir_target._project = project
 
         # Create source directory node
         source = FileNode(Path("assets"))
@@ -448,7 +447,6 @@ class TestXcodeGeneratorArchive:
             "compression": "gzip",
             "base_dir": ".",
         }
-        tar_target._project = project
 
         # Create source file nodes
         source1 = FileNode(Path("src/file1.c"))
@@ -495,7 +493,6 @@ class TestXcodeGeneratorArchive:
             "output": str(tmp_path / "archive.zip"),
             "base_dir": ".",
         }
-        zip_target._project = project
 
         # Create source file node
         source = FileNode(Path("docs/readme.txt"))
@@ -538,7 +535,6 @@ class TestXcodeGeneratorInstallDependencies:
 
         # Create a program target
         prog = Target("myapp", target_type="program")
-        prog._project = project
 
         # Add output to program target
         prog_output = FileNode(tmp_path / "myapp")
@@ -550,7 +546,6 @@ class TestXcodeGeneratorInstallDependencies:
         install_target = Target("install_myapp", target_type="interface")
         install_target._builder_name = "Install"
         install_target._builder_data = {"dest_dir": "bin"}
-        install_target._project = project
 
         # Create output node referencing program output
         dest = FileNode(tmp_path / "bin" / "myapp")
@@ -586,7 +581,6 @@ class TestXcodeGeneratorInstallDependencies:
 
         # Create a program target
         prog = Target("myapp", target_type="program")
-        prog._project = project
 
         prog_output = FileNode(tmp_path / "myapp")
         prog.output_nodes.append(prog_output)
@@ -602,7 +596,6 @@ class TestXcodeGeneratorInstallDependencies:
             "compression": "gzip",
             "base_dir": ".",
         }
-        tar_target._project = project
 
         # Create archive node referencing program output
         archive = FileNode(tmp_path / "myapp.tar.gz")

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -153,6 +153,32 @@ class TestXcodeGeneratorBuildSettings:
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "OTHER_CFLAGS" in content
 
+    def test_subdir_include_dirs_resolved(self, tmp_path):
+        """Regression: include dirs from subdirectory targets must be resolved
+        relative to the target's _subdir, not the project root.
+
+        Previously, ``libfoo.public.include_dirs.append("include")`` (set from
+        inside ``libfoo/``) was resolved as ``<project_root>/include`` instead
+        of ``<project_root>/libfoo/include``, causing Xcode builds to fail with
+        'file not found' errors.
+        """
+        project = Project("myapp", build_dir=tmp_path / "build")
+        # Simulate a target that lives in a subdirectory
+        target = Target("foo", target_type="static_library")
+        target._subdir = "libfoo"
+        target.public.include_dirs.append("include")  # relative to libfoo/
+        project.add_target(target)
+
+        gen = XcodeGenerator()
+        gen.generate(project)
+
+        content = (
+            tmp_path / "build" / "myapp.xcodeproj" / "project.pbxproj"
+        ).read_text()
+        # The search path must include libfoo/include, not just include
+        assert "libfoo" in content
+        assert "HEADER_SEARCH_PATHS" in content
+
 
 class TestXcodeGeneratorDependencies:
     """Tests for target dependencies."""

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -206,6 +206,35 @@ class TestXcodeGeneratorDependencies:
         # Should have dependency objects
         assert "PBXTargetDependency" in content
 
+    def test_library_dep_added_to_link_phase(self, tmp_path):
+        """Test that a library dependency's product is in the frameworks link phase."""
+        project = Project("myapp", build_dir=tmp_path)
+
+        lib = Target("mylib", target_type="static_library")
+        project.add_target(lib)
+
+        app = Target("myapp", target_type="program")
+        app.link(lib)
+        project.add_target(app)
+
+        gen = XcodeGenerator()
+        gen.generate(project)
+
+        content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
+        # A PBXBuildFile referencing the library product must exist
+        assert "PBXBuildFile" in content
+        # The PBXFrameworksBuildPhase for app must reference that PBXBuildFile
+        # (i.e. its "files" list must be non-empty)
+        import re
+
+        frameworks_sections = re.findall(
+            r"PBXFrameworksBuildPhase.*?};", content, re.DOTALL
+        )
+        assert any(
+            "files" in s and re.search(r"files\s*=\s*\(.*\S", s, re.DOTALL)
+            for s in frameworks_sections
+        ), "PBXFrameworksBuildPhase for app has no files (library not linked)"
+
 
 class TestXcodeGeneratorBuildPhases:
     """Tests for build phases."""

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -22,7 +22,6 @@ class TestXcodeGeneratorBasic:
 
         # Add a minimal target
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -35,7 +34,6 @@ class TestXcodeGeneratorBasic:
         """Test that project.pbxproj file is created."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -57,7 +55,6 @@ class TestXcodeGeneratorTargets:
         """Test program target has correct product type."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -70,7 +67,6 @@ class TestXcodeGeneratorTargets:
         """Test static library target has correct product type."""
         project = Project("mylib", build_dir=tmp_path)
         target = Target("mylib", target_type="static_library")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -83,7 +79,6 @@ class TestXcodeGeneratorTargets:
         """Test shared library target has correct product type."""
         project = Project("mylib", build_dir=tmp_path)
         target = Target("mylib", target_type="shared_library")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -96,7 +91,6 @@ class TestXcodeGeneratorTargets:
         """Test interface-only projects don't create xcodeproj."""
         project = Project("mylib", build_dir=tmp_path)
         target = Target("headers", target_type="interface")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -118,7 +112,6 @@ class TestXcodeGeneratorBuildSettings:
         target = Target("myapp", target_type="program")
         target.public.include_dirs.append(Path("include"))
         target.private.include_dirs.append(Path("src"))
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -132,7 +125,6 @@ class TestXcodeGeneratorBuildSettings:
         target = Target("myapp", target_type="program")
         target.public.defines.append("DEBUG=1")
         target.private.defines.append("INTERNAL")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -145,7 +137,6 @@ class TestXcodeGeneratorBuildSettings:
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
         target.private.compile_flags.extend(["-Wall", "-Wextra"])
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -167,7 +158,6 @@ class TestXcodeGeneratorBuildSettings:
         target = Target("foo", target_type="static_library")
         target._subdir = "libfoo"
         target.public.include_dirs.append("include")  # relative to libfoo/
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -189,12 +179,10 @@ class TestXcodeGeneratorDependencies:
 
         # Create library
         lib = Target("mylib", target_type="static_library")
-        project.add_target(lib)
 
         # Create app that depends on lib
         app = Target("myapp", target_type="program")
         app.link(lib)
-        project.add_target(app)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -211,11 +199,9 @@ class TestXcodeGeneratorDependencies:
         project = Project("myapp", build_dir=tmp_path)
 
         lib = Target("mylib", target_type="static_library")
-        project.add_target(lib)
 
         app = Target("myapp", target_type="program")
         app.link(lib)
-        project.add_target(app)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -243,7 +229,6 @@ class TestXcodeGeneratorBuildPhases:
         """Test targets have PBXSourcesBuildPhase."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -255,7 +240,6 @@ class TestXcodeGeneratorBuildPhases:
         """Test targets have PBXFrameworksBuildPhase."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -271,7 +255,6 @@ class TestXcodeGeneratorConfigurations:
         """Test project has Debug configuration."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -283,7 +266,6 @@ class TestXcodeGeneratorConfigurations:
         """Test project has Release configuration."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -299,7 +281,6 @@ class TestXcodeGeneratorGroups:
         """Test project has Products group."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -311,7 +292,6 @@ class TestXcodeGeneratorGroups:
         """Test project has Sources group."""
         project = Project("myapp", build_dir=tmp_path)
         target = Target("myapp", target_type="program")
-        project.add_target(target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -335,9 +315,6 @@ class TestXcodeGeneratorMultiTarget:
         lib2.link(lib1)
         app.link(lib2)
 
-        project.add_target(lib1)
-        project.add_target(lib2)
-        project.add_target(app)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -384,7 +361,6 @@ class TestXcodeGeneratorInstall:
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
 
-        project.add_target(install_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -424,7 +400,6 @@ class TestXcodeGeneratorInstall:
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
 
-        project.add_target(install_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -467,7 +442,6 @@ class TestXcodeGeneratorInstallDir:
         install_dir_target.output_nodes.append(stamp)
         install_dir_target._pending_sources = [source]
 
-        project.add_target(install_dir_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -519,7 +493,6 @@ class TestXcodeGeneratorArchive:
         tar_target.output_nodes.append(archive)
         tar_target.output_nodes.append(archive)
 
-        project.add_target(tar_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -564,7 +537,6 @@ class TestXcodeGeneratorArchive:
         zip_target.output_nodes.append(archive)
         zip_target.output_nodes.append(archive)
 
-        project.add_target(zip_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -595,7 +567,6 @@ class TestXcodeGeneratorInstallDependencies:
         prog_output = FileNode(tmp_path / "myapp")
         prog.output_nodes.append(prog_output)
 
-        project.add_target(prog)
 
         # Create install target that installs the program
         install_target = Target("install_myapp", target_type="interface")
@@ -614,7 +585,6 @@ class TestXcodeGeneratorInstallDependencies:
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
 
-        project.add_target(install_target)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -640,7 +610,6 @@ class TestXcodeGeneratorInstallDependencies:
         prog_output = FileNode(tmp_path / "myapp")
         prog.output_nodes.append(prog_output)
 
-        project.add_target(prog)
 
         # Create tarfile target that archives the program
         tar_target = Target("bin_archive", target_type="archive")
@@ -664,7 +633,6 @@ class TestXcodeGeneratorInstallDependencies:
         tar_target.output_nodes.append(archive)
         tar_target.output_nodes.append(archive)
 
-        project.add_target(tar_target)
 
         gen = XcodeGenerator()
         gen.generate(project)

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -21,7 +21,7 @@ class TestXcodeGeneratorBasic:
         project = Project("myapp", build_dir=tmp_path)
 
         # Add a minimal target
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -33,7 +33,7 @@ class TestXcodeGeneratorBasic:
     def test_creates_project_pbxproj(self, tmp_path):
         """Test that project.pbxproj file is created."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -54,7 +54,7 @@ class TestXcodeGeneratorTargets:
     def test_program_target(self, tmp_path):
         """Test program target has correct product type."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -66,7 +66,7 @@ class TestXcodeGeneratorTargets:
     def test_static_library_target(self, tmp_path):
         """Test static library target has correct product type."""
         project = Project("mylib", build_dir=tmp_path)
-        target = Target("mylib", target_type="static_library")
+        Target("mylib", target_type="static_library")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -78,7 +78,7 @@ class TestXcodeGeneratorTargets:
     def test_shared_library_target(self, tmp_path):
         """Test shared library target has correct product type."""
         project = Project("mylib", build_dir=tmp_path)
-        target = Target("mylib", target_type="shared_library")
+        Target("mylib", target_type="shared_library")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -90,7 +90,7 @@ class TestXcodeGeneratorTargets:
     def test_interface_target_skipped(self, tmp_path):
         """Test interface-only projects don't create xcodeproj."""
         project = Project("mylib", build_dir=tmp_path)
-        target = Target("headers", target_type="interface")
+        Target("headers", target_type="interface")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -228,7 +228,7 @@ class TestXcodeGeneratorBuildPhases:
     def test_has_sources_phase(self, tmp_path):
         """Test targets have PBXSourcesBuildPhase."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -239,7 +239,7 @@ class TestXcodeGeneratorBuildPhases:
     def test_has_frameworks_phase(self, tmp_path):
         """Test targets have PBXFrameworksBuildPhase."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -254,7 +254,7 @@ class TestXcodeGeneratorConfigurations:
     def test_has_debug_configuration(self, tmp_path):
         """Test project has Debug configuration."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -265,7 +265,7 @@ class TestXcodeGeneratorConfigurations:
     def test_has_release_configuration(self, tmp_path):
         """Test project has Release configuration."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -280,7 +280,7 @@ class TestXcodeGeneratorGroups:
     def test_has_products_group(self, tmp_path):
         """Test project has Products group."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -291,7 +291,7 @@ class TestXcodeGeneratorGroups:
     def test_has_sources_group(self, tmp_path):
         """Test project has Sources group."""
         project = Project("myapp", build_dir=tmp_path)
-        target = Target("myapp", target_type="program")
+        Target("myapp", target_type="program")
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -314,7 +314,6 @@ class TestXcodeGeneratorMultiTarget:
 
         lib2.link(lib1)
         app.link(lib2)
-
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -361,7 +360,6 @@ class TestXcodeGeneratorInstall:
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
 
-
         gen = XcodeGenerator()
         gen.generate(project)
 
@@ -399,7 +397,6 @@ class TestXcodeGeneratorInstall:
 
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
-
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -441,7 +438,6 @@ class TestXcodeGeneratorInstallDir:
 
         install_dir_target.output_nodes.append(stamp)
         install_dir_target._pending_sources = [source]
-
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -493,7 +489,6 @@ class TestXcodeGeneratorArchive:
         tar_target.output_nodes.append(archive)
         tar_target.output_nodes.append(archive)
 
-
         gen = XcodeGenerator()
         gen.generate(project)
 
@@ -537,7 +532,6 @@ class TestXcodeGeneratorArchive:
         zip_target.output_nodes.append(archive)
         zip_target.output_nodes.append(archive)
 
-
         gen = XcodeGenerator()
         gen.generate(project)
 
@@ -567,7 +561,6 @@ class TestXcodeGeneratorInstallDependencies:
         prog_output = FileNode(tmp_path / "myapp")
         prog.output_nodes.append(prog_output)
 
-
         # Create install target that installs the program
         install_target = Target("install_myapp", target_type="interface")
         install_target._builder_name = "Install"
@@ -584,7 +577,6 @@ class TestXcodeGeneratorInstallDependencies:
 
         install_target.output_nodes.append(dest)
         install_target._install_nodes = [dest]
-
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -610,7 +602,6 @@ class TestXcodeGeneratorInstallDependencies:
         prog_output = FileNode(tmp_path / "myapp")
         prog.output_nodes.append(prog_output)
 
-
         # Create tarfile target that archives the program
         tar_target = Target("bin_archive", target_type="archive")
         tar_target._builder_name = "Tarfile"
@@ -632,7 +623,6 @@ class TestXcodeGeneratorInstallDependencies:
 
         tar_target.output_nodes.append(archive)
         tar_target.output_nodes.append(archive)
-
 
         gen = XcodeGenerator()
         gen.generate(project)

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pcons.core.project import Project
 from pcons.packages.description import ComponentDescription, PackageDescription
 from pcons.packages.imported import ImportedTarget
 
@@ -14,6 +15,7 @@ class TestImportedTarget:
 
     def test_create_imported_target(self) -> None:
         """Test creating an imported target directly."""
+        Project("test_project")
         pkg = PackageDescription(
             name="zlib",
             version="1.2.13",
@@ -28,6 +30,7 @@ class TestImportedTarget:
 
     def test_from_package(self) -> None:
         """Test creating from a PackageDescription."""
+        Project("test_project")
         pkg = PackageDescription(
             name="openssl",
             version="3.0",
@@ -43,6 +46,7 @@ class TestImportedTarget:
 
     def test_compile_flags(self) -> None:
         """Test getting compile flags."""
+        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/opt/test/include"],
@@ -56,6 +60,7 @@ class TestImportedTarget:
 
     def test_link_flags(self) -> None:
         """Test getting link flags."""
+        Project("test_project")
         pkg = PackageDescription(
             name="test",
             library_dirs=["/opt/test/lib"],
@@ -71,6 +76,7 @@ class TestImportedTarget:
 
     def test_include_dirs_as_paths(self) -> None:
         """Test getting include dirs as Path objects."""
+        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/usr/include", "/opt/include"],
@@ -84,6 +90,7 @@ class TestImportedTarget:
 
     def test_with_components(self) -> None:
         """Test creating with specific components."""
+        Project("test_project")
         pkg = PackageDescription(
             name="boost",
             include_dirs=["/usr/include/boost"],
@@ -103,6 +110,7 @@ class TestImportedTarget:
 
     def test_no_package(self) -> None:
         """Test target with no package returns empty values."""
+        Project("test_project")
         target = ImportedTarget(name="empty")
         assert target.compile_flags == []
         assert target.link_flags == []
@@ -111,6 +119,7 @@ class TestImportedTarget:
 
     def test_repr(self) -> None:
         """Test string representation."""
+        Project("test_project")
         pkg = PackageDescription(name="test", version="1.0")
         target = ImportedTarget.from_package(pkg)
         repr_str = repr(target)
@@ -119,6 +128,7 @@ class TestImportedTarget:
 
     def test_public_requirements_populated(self) -> None:
         """Test that public requirements are populated from package."""
+        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/opt/test/include"],
@@ -141,6 +151,7 @@ class TestImportedTarget:
 
     def test_public_requirements_frameworks_macos(self) -> None:
         """Test that macOS framework flags are populated in public requirements."""
+        Project("test_project")
         pkg = PackageDescription(
             name="CoreFoundation",
             framework_dirs=["/System/Library/Frameworks"],
@@ -158,6 +169,7 @@ class TestImportedTarget:
 
     def test_public_requirements_with_components(self) -> None:
         """Test public requirements include merged component data."""
+        Project("test_project")
         pkg = PackageDescription(
             name="boost",
             include_dirs=["/usr/include/boost"],
@@ -181,6 +193,7 @@ class TestImportedTarget:
 
     def test_empty_package_no_public_requirements(self) -> None:
         """Test that empty package results in empty public requirements."""
+        Project("test_project")
         pkg = PackageDescription(name="empty")
         target = ImportedTarget.from_package(pkg)
 
@@ -199,6 +212,7 @@ class TestImportedTarget:
         """
         from pcons.core.target import Target
 
+        Project("test_project")
         openssl = ImportedTarget.from_package(
             PackageDescription(
                 name="openssl",

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from pcons.core.project import Project
 from pcons.packages.description import ComponentDescription, PackageDescription
 from pcons.packages.imported import ImportedTarget
 

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -13,9 +13,8 @@ from pcons.packages.imported import ImportedTarget
 class TestImportedTarget:
     """Tests for ImportedTarget."""
 
-    def test_create_imported_target(self) -> None:
+    def test_create_imported_target(self, test_project):  # noqa: F811
         """Test creating an imported target directly."""
-        Project("test_project")
         pkg = PackageDescription(
             name="zlib",
             version="1.2.13",
@@ -28,9 +27,8 @@ class TestImportedTarget:
         assert target.is_imported is True
         assert target.package is pkg
 
-    def test_from_package(self) -> None:
+    def test_from_package(self, test_project):  # noqa: F811
         """Test creating from a PackageDescription."""
-        Project("test_project")
         pkg = PackageDescription(
             name="openssl",
             version="3.0",
@@ -44,9 +42,8 @@ class TestImportedTarget:
         assert target.version == "3.0"
         assert target.libraries == ["ssl", "crypto"]
 
-    def test_compile_flags(self) -> None:
+    def test_compile_flags(self, test_project):  # noqa: F811
         """Test getting compile flags."""
-        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/opt/test/include"],
@@ -58,9 +55,8 @@ class TestImportedTarget:
         assert "-I/opt/test/include" in flags
         assert "-DTEST_LIB" in flags
 
-    def test_link_flags(self) -> None:
+    def test_link_flags(self, test_project):  # noqa: F811
         """Test getting link flags."""
-        Project("test_project")
         pkg = PackageDescription(
             name="test",
             library_dirs=["/opt/test/lib"],
@@ -74,9 +70,8 @@ class TestImportedTarget:
         assert "-ltestlib" in flags
         assert "-Wl,-rpath,/opt/test/lib" in flags
 
-    def test_include_dirs_as_paths(self) -> None:
+    def test_include_dirs_as_paths(self, test_project):  # noqa: F811
         """Test getting include dirs as Path objects."""
-        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/usr/include", "/opt/include"],
@@ -88,9 +83,8 @@ class TestImportedTarget:
         assert all(isinstance(d, Path) for d in dirs)
         assert Path("/usr/include") in dirs
 
-    def test_with_components(self) -> None:
+    def test_with_components(self, test_project):  # noqa: F811
         """Test creating with specific components."""
-        Project("test_project")
         pkg = PackageDescription(
             name="boost",
             include_dirs=["/usr/include/boost"],
@@ -108,27 +102,24 @@ class TestImportedTarget:
         assert "boost_system" in target.libraries
         assert "boost_filesystem" in target.libraries
 
-    def test_no_package(self) -> None:
+    def test_no_package(self, test_project):  # noqa: F811
         """Test target with no package returns empty values."""
-        Project("test_project")
         target = ImportedTarget(name="empty")
         assert target.compile_flags == []
         assert target.link_flags == []
         assert target.libraries == []
         assert target.version == ""
 
-    def test_repr(self) -> None:
+    def test_repr(self, test_project):  # noqa: F811
         """Test string representation."""
-        Project("test_project")
         pkg = PackageDescription(name="test", version="1.0")
         target = ImportedTarget.from_package(pkg)
         repr_str = repr(target)
         assert "test" in repr_str
         assert "1.0" in repr_str
 
-    def test_public_requirements_populated(self) -> None:
+    def test_public_requirements_populated(self, test_project):  # noqa: F811
         """Test that public requirements are populated from package."""
-        Project("test_project")
         pkg = PackageDescription(
             name="test",
             include_dirs=["/opt/test/include"],
@@ -149,9 +140,8 @@ class TestImportedTarget:
         assert "-L/opt/test/lib" in target.public.link_flags
         assert "-Wl,-rpath,/opt/test/lib" in target.public.link_flags
 
-    def test_public_requirements_frameworks_macos(self) -> None:
+    def test_public_requirements_frameworks_macos(self, test_project):  # noqa: F811
         """Test that macOS framework flags are populated in public requirements."""
-        Project("test_project")
         pkg = PackageDescription(
             name="CoreFoundation",
             framework_dirs=["/System/Library/Frameworks"],
@@ -167,9 +157,8 @@ class TestImportedTarget:
         assert "CoreFoundation" in target.public.link_flags
         assert "Security" in target.public.link_flags
 
-    def test_public_requirements_with_components(self) -> None:
+    def test_public_requirements_with_components(self, test_project):  # noqa: F811
         """Test public requirements include merged component data."""
-        Project("test_project")
         pkg = PackageDescription(
             name="boost",
             include_dirs=["/usr/include/boost"],
@@ -191,9 +180,8 @@ class TestImportedTarget:
         assert "boost_filesystem" in target.public.link_libs
         assert "BOOST_FILESYSTEM" in target.public.defines
 
-    def test_empty_package_no_public_requirements(self) -> None:
+    def test_empty_package_no_public_requirements(self, test_project):  # noqa: F811
         """Test that empty package results in empty public requirements."""
-        Project("test_project")
         pkg = PackageDescription(name="empty")
         target = ImportedTarget.from_package(pkg)
 
@@ -203,7 +191,7 @@ class TestImportedTarget:
         assert target.public.link_libs == []
         assert target.public.link_flags == []
 
-    def test_imported_link_transitive_propagation(self) -> None:
+    def test_imported_link_transitive_propagation(self, test_project):  # noqa: F811
         """ImportedTarget.link() propagates requirements transitively.
 
         When httplib.link(openssl), anything that links httplib should
@@ -212,7 +200,6 @@ class TestImportedTarget:
         """
         from pcons.core.target import Target
 
-        Project("test_project")
         openssl = ImportedTarget.from_package(
             PackageDescription(
                 name="openssl",

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -395,6 +395,10 @@ def adapt_outputs_for_generator(
     Returns:
         List of adapted output paths.
     """
+    # On macOS shared libraries use .dylib regardless of generator
+    if platform.system().lower() == "darwin":
+        outputs = [o[:-3] + ".dylib" if o.endswith(".so") else o for o in outputs]
+
     if generator == "ninja":
         return outputs
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -57,6 +57,7 @@ def adapt_path_for_windows(path: str) -> str:
         ./build/program -> build\\program.exe
         build/file.o -> build\\file.obj
         build/libfoo.a -> build\\foo.lib
+        build/libfoo.so -> build\\foo.dll
         build/program (no extension) -> build\\program.exe
     """
     # Convert forward slashes to backslashes
@@ -76,6 +77,13 @@ def adapt_path_for_windows(path: str) -> str:
         path = re.sub(r"\\lib([^\\]+)\.a$", r"\\\1.lib", path)
         if path.endswith(".a"):  # Didn't match lib prefix
             path = path[:-2] + ".lib"
+    elif path.endswith(".so"):
+        # Convert libfoo.so to foo.dll
+        import re
+
+        path = re.sub(r"\\lib([^\\]+)\.so$", r"\\\1.dll", path)
+        if path.endswith(".so"):  # Didn't match lib prefix
+            path = path[:-3] + ".dll"
 
     # Add .exe to executables (paths in build/ without extension)
     # Check if it's a build output without an extension

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -526,6 +526,9 @@ def _run_generate(
         variant: Optional variant name (e.g., "debug", "release").
         variables: Optional build variables (KEY=value) for the build script.
     """
+    from pcons import Project
+
+    Project._clear_tree()
     if invocation == "direct":
         from pcons.cli import run_script
 

--- a/tests/toolchains/test_cross_presets.py
+++ b/tests/toolchains/test_cross_presets.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import pytest
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.toolchains.presets import (
     CrossPreset,
     android,

--- a/tests/toolchains/test_cross_presets.py
+++ b/tests/toolchains/test_cross_presets.py
@@ -167,11 +167,10 @@ class TestLinuxCrossPreset:
 class TestCrossPresetApplication:
     """Tests for applying cross-presets to environments via toolchains."""
 
-    def test_unix_apply_triple(self) -> None:
+    def test_unix_apply_triple(self, test_project):  # noqa: F811
         """UnixToolchain should apply --target flag."""
         from pcons.toolchains.llvm import LlvmToolchain
 
-        Project("test_project")
         env = _make_unix_env()
         toolchain = LlvmToolchain()
 
@@ -185,11 +184,10 @@ class TestCrossPresetApplication:
         assert "--target=aarch64-linux-gnu" in env.cc.flags
         assert "--target=aarch64-linux-gnu" in env.cxx.flags
 
-    def test_unix_apply_sysroot(self) -> None:
+    def test_unix_apply_sysroot(self, test_project):  # noqa: F811
         """UnixToolchain should apply --sysroot flag."""
         from pcons.toolchains.llvm import LlvmToolchain
 
-        Project("test_project")
         env = _make_unix_env()
         toolchain = LlvmToolchain()
 
@@ -203,11 +201,10 @@ class TestCrossPresetApplication:
         assert "--sysroot=/opt/sysroot" in env.cc.flags
         assert "--sysroot=/opt/sysroot" in env.link.flags
 
-    def test_unix_apply_extra_flags(self) -> None:
+    def test_unix_apply_extra_flags(self, test_project):  # noqa: F811
         """Extra compile/link flags should be applied."""
         from pcons.toolchains.gcc import GccToolchain
 
-        Project("test_project")
         env = _make_unix_env()
         toolchain = GccToolchain()
 
@@ -222,11 +219,10 @@ class TestCrossPresetApplication:
         assert "-DCUSTOM" in env.cc.flags
         assert "-lcustom" in env.link.flags
 
-    def test_unix_apply_env_vars(self) -> None:
+    def test_unix_apply_env_vars(self, test_project):  # noqa: F811
         """CC/CXX overrides from env_vars should be applied."""
         from pcons.toolchains.gcc import GccToolchain
 
-        Project("test_project")
         env = _make_unix_env()
         toolchain = GccToolchain()
 
@@ -240,11 +236,10 @@ class TestCrossPresetApplication:
         assert env.cc.cmd == "/usr/bin/custom-gcc"
         assert env.cxx.cmd == "/usr/bin/custom-g++"
 
-    def test_msvc_apply_machine(self) -> None:
+    def test_msvc_apply_machine(self, test_project):  # noqa: F811
         """MsvcCompatibleToolchain should apply /MACHINE flags."""
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
-        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.set("cmd", "link.exe")
@@ -264,11 +259,10 @@ class TestCrossPresetApplication:
 
         assert "/MACHINE:ARM64" in env.link.flags
 
-    def test_env_apply_cross_preset_delegates(self) -> None:
+    def test_env_apply_cross_preset_delegates(self, test_project):  # noqa: F811
         """Environment.apply_cross_preset() should delegate to toolchains."""
         from pcons.toolchains.llvm import LlvmToolchain
 
-        Project("test_project")
         env = _make_unix_env()
         env._toolchain = LlvmToolchain()
 

--- a/tests/toolchains/test_cross_presets.py
+++ b/tests/toolchains/test_cross_presets.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import pytest
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.toolchains.presets import (
     CrossPreset,
     android,
@@ -170,6 +171,7 @@ class TestCrossPresetApplication:
         """UnixToolchain should apply --target flag."""
         from pcons.toolchains.llvm import LlvmToolchain
 
+        Project("test_project")
         env = _make_unix_env()
         toolchain = LlvmToolchain()
 
@@ -187,6 +189,7 @@ class TestCrossPresetApplication:
         """UnixToolchain should apply --sysroot flag."""
         from pcons.toolchains.llvm import LlvmToolchain
 
+        Project("test_project")
         env = _make_unix_env()
         toolchain = LlvmToolchain()
 
@@ -204,6 +207,7 @@ class TestCrossPresetApplication:
         """Extra compile/link flags should be applied."""
         from pcons.toolchains.gcc import GccToolchain
 
+        Project("test_project")
         env = _make_unix_env()
         toolchain = GccToolchain()
 
@@ -222,6 +226,7 @@ class TestCrossPresetApplication:
         """CC/CXX overrides from env_vars should be applied."""
         from pcons.toolchains.gcc import GccToolchain
 
+        Project("test_project")
         env = _make_unix_env()
         toolchain = GccToolchain()
 
@@ -239,6 +244,7 @@ class TestCrossPresetApplication:
         """MsvcCompatibleToolchain should apply /MACHINE flags."""
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
+        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.set("cmd", "link.exe")
@@ -262,6 +268,7 @@ class TestCrossPresetApplication:
         """Environment.apply_cross_preset() should delegate to toolchains."""
         from pcons.toolchains.llvm import LlvmToolchain
 
+        Project("test_project")
         env = _make_unix_env()
         env._toolchain = LlvmToolchain()
 

--- a/tests/toolchains/test_cuda.py
+++ b/tests/toolchains/test_cuda.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: MIT
 """Tests for CUDA toolchain."""
 
-from pcons.core.project import Project
 from pcons.toolchains import CudaCompiler, CudaToolchain, find_cuda_toolchain
 from pcons.tools.toolchain import SourceHandler
 

--- a/tests/toolchains/test_cuda.py
+++ b/tests/toolchains/test_cuda.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for CUDA toolchain."""
 
+from pcons.core.project import Project
 from pcons.toolchains import CudaCompiler, CudaToolchain, find_cuda_toolchain
 from pcons.tools.toolchain import SourceHandler
 
@@ -80,6 +81,7 @@ class TestCudaVariants:
         """Debug variant adds debug flags."""
         from pcons.core.environment import Environment
 
+        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True
@@ -103,6 +105,7 @@ class TestCudaVariants:
         """Release variant adds optimization flags."""
         from pcons.core.environment import Environment
 
+        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True
@@ -123,6 +126,7 @@ class TestCudaVariants:
         """Profile variant adds line info for profilers."""
         from pcons.core.environment import Environment
 
+        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True

--- a/tests/toolchains/test_cuda.py
+++ b/tests/toolchains/test_cuda.py
@@ -77,11 +77,10 @@ class TestCudaToolchain:
 class TestCudaVariants:
     """Tests for CUDA variant support."""
 
-    def test_apply_debug_variant(self):
+    def test_apply_debug_variant(self, test_project):  # noqa: F811
         """Debug variant adds debug flags."""
         from pcons.core.environment import Environment
 
-        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True
@@ -101,11 +100,10 @@ class TestCudaVariants:
         assert "-g" in env.cuda.flags
         assert "DEBUG" in env.cuda.defines
 
-    def test_apply_release_variant(self):
+    def test_apply_release_variant(self, test_project):  # noqa: F811
         """Release variant adds optimization flags."""
         from pcons.core.environment import Environment
 
-        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True
@@ -122,11 +120,10 @@ class TestCudaVariants:
         # Should NOT have debug flags
         assert "-G" not in env.cuda.flags
 
-    def test_apply_profile_variant(self):
+    def test_apply_profile_variant(self, test_project):  # noqa: F811
         """Profile variant adds line info for profilers."""
         from pcons.core.environment import Environment
 
-        Project("test_project")
         toolchain = CudaToolchain()
         toolchain._tools = {"cuda": CudaCompiler()}
         toolchain._configured = True

--- a/tests/toolchains/test_frameworks.py
+++ b/tests/toolchains/test_frameworks.py
@@ -2,6 +2,7 @@
 """Tests for macOS Framework linking support."""
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.packages.description import PackageDescription
 from pcons.toolchains.gcc import GccLinker
 from pcons.toolchains.llvm import LlvmLinker
@@ -74,6 +75,7 @@ class TestEnvironmentFramework:
 
     def test_framework_adds_to_link_frameworks(self):
         """Framework() should add to link.frameworks."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -84,6 +86,7 @@ class TestEnvironmentFramework:
 
     def test_framework_multiple(self):
         """Framework() should handle multiple frameworks at once."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -96,6 +99,7 @@ class TestEnvironmentFramework:
 
     def test_framework_with_dirs(self):
         """Framework() should accept custom search directories."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -107,6 +111,7 @@ class TestEnvironmentFramework:
 
     def test_framework_no_duplicates(self):
         """Framework() should not add duplicate frameworks."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -118,6 +123,7 @@ class TestEnvironmentFramework:
 
     def test_framework_without_link_tool(self):
         """Framework() should do nothing if link tool doesn't exist."""
+        Project("test_project")
         env = Environment()
         # Don't add link tool
         env.Framework("Foundation")  # Should not raise
@@ -125,6 +131,7 @@ class TestEnvironmentFramework:
 
     def test_framework_creates_lists_if_missing(self):
         """Framework() should create frameworks/frameworkdirs if they don't exist."""
+        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         # Don't set frameworks/frameworkdirs
@@ -141,6 +148,7 @@ class TestEnvironmentUseWithFrameworks:
 
     def test_use_applies_frameworks(self):
         """use() should apply frameworks from a package."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -159,6 +167,7 @@ class TestEnvironmentUseWithFrameworks:
 
     def test_use_no_duplicate_frameworks(self):
         """use() should not add duplicate frameworks."""
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = ["Foundation"]
@@ -295,6 +304,7 @@ class TestFrameworkSubstitution:
 
     def test_framework_substitution_in_progcmd(self):
         """Framework variables should expand correctly in link commands."""
+        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.cmd = "clang"
@@ -333,6 +343,7 @@ class TestFrameworkSubstitution:
 
     def test_empty_frameworks_no_extra_tokens(self):
         """Empty frameworks should not add extra tokens."""
+        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.cmd = "clang"

--- a/tests/toolchains/test_frameworks.py
+++ b/tests/toolchains/test_frameworks.py
@@ -2,7 +2,6 @@
 """Tests for macOS Framework linking support."""
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.packages.description import PackageDescription
 from pcons.toolchains.gcc import GccLinker
 from pcons.toolchains.llvm import LlvmLinker
@@ -73,9 +72,8 @@ class TestLlvmLinkerFrameworks:
 class TestEnvironmentFramework:
     """Test env.Framework() convenience method."""
 
-    def test_framework_adds_to_link_frameworks(self):
+    def test_framework_adds_to_link_frameworks(self, test_project):  # noqa: F811
         """Framework() should add to link.frameworks."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -84,9 +82,8 @@ class TestEnvironmentFramework:
         env.Framework("Foundation")
         assert "Foundation" in env.link.frameworks
 
-    def test_framework_multiple(self):
+    def test_framework_multiple(self, test_project):  # noqa: F811
         """Framework() should handle multiple frameworks at once."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -97,9 +94,8 @@ class TestEnvironmentFramework:
         assert "CoreFoundation" in env.link.frameworks
         assert "Metal" in env.link.frameworks
 
-    def test_framework_with_dirs(self):
+    def test_framework_with_dirs(self, test_project):  # noqa: F811
         """Framework() should accept custom search directories."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -109,9 +105,8 @@ class TestEnvironmentFramework:
         assert "MyFramework" in env.link.frameworks
         assert "/custom/frameworks" in env.link.frameworkdirs
 
-    def test_framework_no_duplicates(self):
+    def test_framework_no_duplicates(self, test_project):  # noqa: F811
         """Framework() should not add duplicate frameworks."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -121,17 +116,15 @@ class TestEnvironmentFramework:
         env.Framework("Foundation")  # Add again
         assert env.link.frameworks.count("Foundation") == 1
 
-    def test_framework_without_link_tool(self):
+    def test_framework_without_link_tool(self, test_project):  # noqa: F811
         """Framework() should do nothing if link tool doesn't exist."""
-        Project("test_project")
         env = Environment()
         # Don't add link tool
         env.Framework("Foundation")  # Should not raise
         assert not env.has_tool("link")
 
-    def test_framework_creates_lists_if_missing(self):
+    def test_framework_creates_lists_if_missing(self, test_project):  # noqa: F811
         """Framework() should create frameworks/frameworkdirs if they don't exist."""
-        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         # Don't set frameworks/frameworkdirs
@@ -146,9 +139,8 @@ class TestEnvironmentFramework:
 class TestEnvironmentUseWithFrameworks:
     """Test env.use() with packages that have frameworks."""
 
-    def test_use_applies_frameworks(self):
+    def test_use_applies_frameworks(self, test_project):  # noqa: F811
         """use() should apply frameworks from a package."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = []
@@ -165,9 +157,8 @@ class TestEnvironmentUseWithFrameworks:
         assert "Foundation" in env.link.frameworks
         assert "/System/Library/Frameworks" in env.link.frameworkdirs
 
-    def test_use_no_duplicate_frameworks(self):
+    def test_use_no_duplicate_frameworks(self, test_project):  # noqa: F811
         """use() should not add duplicate frameworks."""
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.frameworks = ["Foundation"]
@@ -302,9 +293,8 @@ class TestPairwiseFunction:
 class TestFrameworkSubstitution:
     """Test that framework variables are correctly substituted in linker commands."""
 
-    def test_framework_substitution_in_progcmd(self):
+    def test_framework_substitution_in_progcmd(self, test_project):  # noqa: F811
         """Framework variables should expand correctly in link commands."""
-        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.cmd = "clang"
@@ -341,9 +331,8 @@ class TestFrameworkSubstitution:
         assert "Foundation" in result
         assert "CoreFoundation" in result
 
-    def test_empty_frameworks_no_extra_tokens(self):
+    def test_empty_frameworks_no_extra_tokens(self, test_project):  # noqa: F811
         """Empty frameworks should not add extra tokens."""
-        Project("test_project")
         env = Environment()
         link = env.add_tool("link")
         link.cmd = "clang"

--- a/tests/toolchains/test_install_name.py
+++ b/tests/toolchains/test_install_name.py
@@ -14,24 +14,20 @@ from pcons.toolchains.llvm import LlvmToolchain
 
 
 class TestTargetSetGet:
-    def test_default_is_none(self) -> None:
-        Project("test_project")
+    def test_default_is_none(self, test_project):  # noqa: F811
         t = Target("lib", target_type="shared_library")
         assert t.get_option("install_name") is None
 
-    def test_set_and_get(self) -> None:
-        Project("test_project")
+    def test_set_and_get(self, test_project):  # noqa: F811
         t = Target("lib", target_type="shared_library")
         t.set_option("install_name", "@rpath/libcustom.dylib")
         assert t.get_option("install_name") == "@rpath/libcustom.dylib"
 
-    def test_set_returns_self(self) -> None:
-        Project("test_project")
+    def test_set_returns_self(self, test_project):  # noqa: F811
         t = Target("lib", target_type="shared_library")
         assert t.set_option("install_name", "foo") is t
 
-    def test_get_with_default(self) -> None:
-        Project("test_project")
+    def test_get_with_default(self, test_project):  # noqa: F811
         t = Target("lib", target_type="shared_library")
         assert t.get_option("missing_key", "fallback") == "fallback"
 
@@ -40,13 +36,12 @@ class TestTargetSetGet:
 
 
 def _make_shared_target(name: str = "foo") -> Target:
-    Project("test_project")
     return Target(name, target_type="shared_library")
 
 
 class TestGccInstallName:
     @patch("pcons.toolchains.unix.get_platform")
-    def test_macos_default_install_name(self, mock_platform) -> None:
+    def test_macos_default_install_name(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = True
         mock_platform.return_value.is_linux = False
         tc = GccToolchain()
@@ -55,7 +50,7 @@ class TestGccInstallName:
         assert flags == ["-Wl,-install_name,@rpath/libfoo.dylib"]
 
     @patch("pcons.toolchains.unix.get_platform")
-    def test_macos_explicit_install_name(self, mock_platform) -> None:
+    def test_macos_explicit_install_name(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = True
         mock_platform.return_value.is_linux = False
         tc = GccToolchain()
@@ -65,7 +60,7 @@ class TestGccInstallName:
         assert flags == ["-Wl,-install_name,/usr/local/lib/libfoo.2.dylib"]
 
     @patch("pcons.toolchains.unix.get_platform")
-    def test_macos_disabled_install_name(self, mock_platform) -> None:
+    def test_macos_disabled_install_name(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = True
         mock_platform.return_value.is_linux = False
         tc = GccToolchain()
@@ -75,7 +70,7 @@ class TestGccInstallName:
         assert flags == []
 
     @patch("pcons.toolchains.unix.get_platform")
-    def test_linux_default_soname(self, mock_platform) -> None:
+    def test_linux_default_soname(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = False
         mock_platform.return_value.is_linux = True
         tc = GccToolchain()
@@ -84,7 +79,7 @@ class TestGccInstallName:
         assert flags == ["-Wl,-soname,libfoo.so"]
 
     @patch("pcons.toolchains.unix.get_platform")
-    def test_linux_explicit_soname(self, mock_platform) -> None:
+    def test_linux_explicit_soname(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = False
         mock_platform.return_value.is_linux = True
         tc = GccToolchain()
@@ -94,7 +89,7 @@ class TestGccInstallName:
         assert flags == ["-Wl,-soname,libfoo.so.2"]
 
     @patch("pcons.toolchains.unix.get_platform")
-    def test_linux_disabled_soname(self, mock_platform) -> None:
+    def test_linux_disabled_soname(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = False
         mock_platform.return_value.is_linux = True
         tc = GccToolchain()
@@ -103,15 +98,13 @@ class TestGccInstallName:
         flags = tc.get_link_flags_for_target(target, "libfoo.so", [])
         assert flags == []
 
-    def test_program_gets_no_flags(self) -> None:
-        Project("test_project")
+    def test_program_gets_no_flags(self, test_project):  # noqa: F811
         tc = GccToolchain()
         target = Target("app", target_type="program")
         flags = tc.get_link_flags_for_target(target, "app", [])
         assert flags == []
 
-    def test_static_library_gets_no_flags(self) -> None:
-        Project("test_project")
+    def test_static_library_gets_no_flags(self, test_project):  # noqa: F811
         tc = GccToolchain()
         target = Target("lib", target_type="static_library")
         flags = tc.get_link_flags_for_target(target, "libfoo.a", [])
@@ -120,7 +113,7 @@ class TestGccInstallName:
 
 class TestLlvmInstallName:
     @patch("pcons.toolchains.unix.get_platform")
-    def test_macos_default(self, mock_platform) -> None:
+    def test_macos_default(self, mock_platform, test_project):  # noqa: F811
         mock_platform.return_value.is_macos = True
         mock_platform.return_value.is_linux = False
         tc = LlvmToolchain()

--- a/tests/toolchains/test_install_name.py
+++ b/tests/toolchains/test_install_name.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
-from pcons.core.project import Project
 from pcons.core.target import Target
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain

--- a/tests/toolchains/test_install_name.py
+++ b/tests/toolchains/test_install_name.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from pcons.core.project import Project
 from pcons.core.target import Target
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
@@ -14,19 +15,23 @@ from pcons.toolchains.llvm import LlvmToolchain
 
 class TestTargetSetGet:
     def test_default_is_none(self) -> None:
+        Project("test_project")
         t = Target("lib", target_type="shared_library")
         assert t.get_option("install_name") is None
 
     def test_set_and_get(self) -> None:
+        Project("test_project")
         t = Target("lib", target_type="shared_library")
         t.set_option("install_name", "@rpath/libcustom.dylib")
         assert t.get_option("install_name") == "@rpath/libcustom.dylib"
 
     def test_set_returns_self(self) -> None:
+        Project("test_project")
         t = Target("lib", target_type="shared_library")
         assert t.set_option("install_name", "foo") is t
 
     def test_get_with_default(self) -> None:
+        Project("test_project")
         t = Target("lib", target_type="shared_library")
         assert t.get_option("missing_key", "fallback") == "fallback"
 
@@ -35,6 +40,7 @@ class TestTargetSetGet:
 
 
 def _make_shared_target(name: str = "foo") -> Target:
+    Project("test_project")
     return Target(name, target_type="shared_library")
 
 
@@ -98,12 +104,14 @@ class TestGccInstallName:
         assert flags == []
 
     def test_program_gets_no_flags(self) -> None:
+        Project("test_project")
         tc = GccToolchain()
         target = Target("app", target_type="program")
         flags = tc.get_link_flags_for_target(target, "app", [])
         assert flags == []
 
     def test_static_library_gets_no_flags(self) -> None:
+        Project("test_project")
         tc = GccToolchain()
         target = Target("lib", target_type="static_library")
         flags = tc.get_link_flags_for_target(target, "libfoo.a", [])

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -9,7 +9,6 @@ from pcons.configure.platform import get_platform
 from pcons.core.builder import MultiOutputBuilder, OutputGroup
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode
-from pcons.core.project import Project
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.toolchains.msvc import (
     MsvcAssembler,

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -9,6 +9,7 @@ from pcons.configure.platform import get_platform
 from pcons.core.builder import MultiOutputBuilder, OutputGroup
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode
+from pcons.core.project import Project
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.toolchains.msvc import (
     MsvcAssembler,
@@ -61,6 +62,7 @@ class TestMsvcCompiler:
         builders = cc.builders()
         obj_builder = builders["Object"]
         # Create a mock environment and build a target to check build_info
+        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"
@@ -180,6 +182,7 @@ class TestMsvcLinker:
         builders = link.builders()
         shared_builder = builders["SharedLibrary"]
 
+        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -293,6 +296,7 @@ class TestMsvcResourceCompiler:
         builders = rc.builders()
         res_builder = builders["Resource"]
 
+        Project("test_project")
         env = Environment()
         env.add_tool("rc")
         env.rc.cmd = "rc.exe"
@@ -310,6 +314,7 @@ class TestMsvcResourceCompiler:
         builders = rc.builders()
         res_builder = builders["Resource"]
 
+        Project("test_project")
         env = Environment()
         env.add_tool("rc")
         env.rc.cmd = "rc.exe"
@@ -435,6 +440,7 @@ class TestMsvcAuxiliaryInputHandler:
 
     def test_auxiliary_input_handler_def(self):
         """Test that .def files are recognized as auxiliary inputs."""
+        Project("test_project")
         tc = MsvcToolchain()
         handler = tc.get_auxiliary_input_handler(".def")
         assert handler is not None

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -57,12 +57,11 @@ class TestMsvcCompiler:
         objcmd = vars["objcmd"]
         assert "$cc.depflags" in objcmd
 
-    def test_builder_has_msvc_deps_style(self):
+    def test_builder_has_msvc_deps_style(self, test_project):  # noqa: F811
         cc = MsvcCompiler()
         builders = cc.builders()
         obj_builder = builders["Object"]
         # Create a mock environment and build a target to check build_info
-        Project("test_project")
         env = Environment()
         env.add_tool("cc")
         env.cc.cmd = "cl.exe"
@@ -177,12 +176,11 @@ class TestMsvcLinker:
         assert outputs[2].suffix == ".exp"
         assert outputs[2].implicit is True
 
-    def test_shared_library_returns_output_group(self):
+    def test_shared_library_returns_output_group(self, test_project):  # noqa: F811
         link = MsvcLinker()
         builders = link.builders()
         shared_builder = builders["SharedLibrary"]
 
-        Project("test_project")
         env = Environment()
         env.add_tool("link")
         env.link.cmd = "link.exe"
@@ -291,12 +289,11 @@ class TestMsvcResourceCompiler:
         assert ".rc" in res_builder.src_suffixes
         assert ".res" in res_builder.target_suffixes
 
-    def test_resource_builder_creates_node(self):
+    def test_resource_builder_creates_node(self, test_project):  # noqa: F811
         rc = MsvcResourceCompiler()
         builders = rc.builders()
         res_builder = builders["Resource"]
 
-        Project("test_project")
         env = Environment()
         env.add_tool("rc")
         env.rc.cmd = "rc.exe"
@@ -308,13 +305,12 @@ class TestMsvcResourceCompiler:
         assert isinstance(target, FileNode)
         assert target.path == Path("app.res")
 
-    def test_resource_builder_no_depfile(self):
+    def test_resource_builder_no_depfile(self, test_project):  # noqa: F811
         """Resource compiler doesn't generate depfiles."""
         rc = MsvcResourceCompiler()
         builders = rc.builders()
         res_builder = builders["Resource"]
 
-        Project("test_project")
         env = Environment()
         env.add_tool("rc")
         env.rc.cmd = "rc.exe"
@@ -438,9 +434,8 @@ class TestMsvcLinkerAcceptsRes:
 class TestMsvcAuxiliaryInputHandler:
     """Tests for the AuxiliaryInputHandler support in MSVC toolchain."""
 
-    def test_auxiliary_input_handler_def(self):
+    def test_auxiliary_input_handler_def(self, test_project):  # noqa: F811
         """Test that .def files are recognized as auxiliary inputs."""
-        Project("test_project")
         tc = MsvcToolchain()
         handler = tc.get_auxiliary_input_handler(".def")
         assert handler is not None

--- a/tests/toolchains/test_presets.py
+++ b/tests/toolchains/test_presets.py
@@ -7,7 +7,6 @@ Each toolchain family defines its own flags for each preset.
 from __future__ import annotations
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
 

--- a/tests/toolchains/test_presets.py
+++ b/tests/toolchains/test_presets.py
@@ -7,12 +7,14 @@ Each toolchain family defines its own flags for each preset.
 from __future__ import annotations
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
 
 
 def _make_unix_env() -> Environment:
     """Create an environment with cc, cxx, and link tools."""
+    Project("test_project")
     env = Environment()
     cc = env.add_tool("cc")
     cc.set("cmd", "gcc")
@@ -32,6 +34,7 @@ def _make_unix_env() -> Environment:
 
 def _make_msvc_env() -> Environment:
     """Create an environment with MSVC-style tools."""
+    Project("test_project")
     env = Environment()
     cc = env.add_tool("cc")
     cc.set("cmd", "cl.exe")
@@ -124,6 +127,7 @@ class TestUnixPresets:
 
     def test_preset_without_link_tool(self) -> None:
         """Presets should work even without a link tool."""
+        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("flags", [])

--- a/tests/toolchains/test_presets.py
+++ b/tests/toolchains/test_presets.py
@@ -14,7 +14,6 @@ from pcons.toolchains.llvm import LlvmToolchain
 
 def _make_unix_env() -> Environment:
     """Create an environment with cc, cxx, and link tools."""
-    Project("test_project")
     env = Environment()
     cc = env.add_tool("cc")
     cc.set("cmd", "gcc")
@@ -34,7 +33,6 @@ def _make_unix_env() -> Environment:
 
 def _make_msvc_env() -> Environment:
     """Create an environment with MSVC-style tools."""
-    Project("test_project")
     env = Environment()
     cc = env.add_tool("cc")
     cc.set("cmd", "cl.exe")
@@ -55,7 +53,7 @@ def _make_msvc_env() -> Environment:
 class TestUnixPresets:
     """Tests for Unix (GCC/LLVM) preset application."""
 
-    def test_warnings_preset(self) -> None:
+    def test_warnings_preset(self, test_project):  # noqa: F811
         env = _make_unix_env()
         toolchain = GccToolchain()
         toolchain.apply_preset(env, "warnings")
@@ -66,7 +64,7 @@ class TestUnixPresets:
         assert "-Werror" in env.cc.flags
         assert "-Wall" in env.cxx.flags
 
-    def test_sanitize_preset(self) -> None:
+    def test_sanitize_preset(self, test_project):  # noqa: F811
         env = _make_unix_env()
         toolchain = LlvmToolchain()
         toolchain.apply_preset(env, "sanitize")
@@ -77,7 +75,7 @@ class TestUnixPresets:
         # Link flags too
         assert "-fsanitize=address,undefined" in env.link.flags
 
-    def test_profile_preset(self) -> None:
+    def test_profile_preset(self, test_project):  # noqa: F811
         env = _make_unix_env()
         toolchain = GccToolchain()
         toolchain.apply_preset(env, "profile")
@@ -86,7 +84,7 @@ class TestUnixPresets:
         assert "-g" in env.cc.flags
         assert "-pg" in env.link.flags
 
-    def test_lto_preset(self) -> None:
+    def test_lto_preset(self, test_project):  # noqa: F811
         env = _make_unix_env()
         toolchain = GccToolchain()
         toolchain.apply_preset(env, "lto")
@@ -95,7 +93,7 @@ class TestUnixPresets:
         assert "-flto" in env.cxx.flags
         assert "-flto" in env.link.flags
 
-    def test_hardened_preset(self) -> None:
+    def test_hardened_preset(self, test_project):  # noqa: F811
         env = _make_unix_env()
         toolchain = GccToolchain()
         toolchain.apply_preset(env, "hardened")
@@ -106,7 +104,7 @@ class TestUnixPresets:
         assert "-pie" in env.link.flags
         assert "-Wl,-z,relro,-z,now" in env.link.flags
 
-    def test_unknown_preset_warns(self) -> None:
+    def test_unknown_preset_warns(self, test_project):  # noqa: F811
         """Unknown preset should log a warning but not raise."""
         env = _make_unix_env()
         toolchain = GccToolchain()
@@ -115,7 +113,7 @@ class TestUnixPresets:
         # No flags should be added
         assert len(env.cc.flags) == 0
 
-    def test_multiple_presets_combine(self) -> None:
+    def test_multiple_presets_combine(self, test_project):  # noqa: F811
         """Applying multiple presets should combine flags."""
         env = _make_unix_env()
         toolchain = GccToolchain()
@@ -125,9 +123,8 @@ class TestUnixPresets:
         assert "-Wall" in env.cc.flags
         assert "-fsanitize=address,undefined" in env.cc.flags
 
-    def test_preset_without_link_tool(self) -> None:
+    def test_preset_without_link_tool(self, test_project):  # noqa: F811
         """Presets should work even without a link tool."""
-        Project("test_project")
         env = Environment()
         cc = env.add_tool("cc")
         cc.set("flags", [])
@@ -138,7 +135,7 @@ class TestUnixPresets:
 
         assert "-fsanitize=address,undefined" in env.cc.flags
 
-    def test_preset_via_env_apply_preset(self) -> None:
+    def test_preset_via_env_apply_preset(self, test_project):  # noqa: F811
         """Test the Environment.apply_preset() delegate method."""
         env = _make_unix_env()
         env._toolchain = GccToolchain()
@@ -152,7 +149,7 @@ class TestUnixPresets:
 class TestMsvcPresets:
     """Tests for MSVC-compatible preset application."""
 
-    def test_warnings_preset(self) -> None:
+    def test_warnings_preset(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()
@@ -170,7 +167,7 @@ class TestMsvcPresets:
         assert "/WX" in env.cc.flags
         assert "/W4" in env.cxx.flags
 
-    def test_sanitize_preset(self) -> None:
+    def test_sanitize_preset(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()
@@ -184,7 +181,7 @@ class TestMsvcPresets:
 
         assert "/fsanitize=address" in env.cc.flags
 
-    def test_lto_preset(self) -> None:
+    def test_lto_preset(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()
@@ -199,7 +196,7 @@ class TestMsvcPresets:
         assert "/GL" in env.cc.flags
         assert "/LTCG" in env.link.flags
 
-    def test_hardened_preset(self) -> None:
+    def test_hardened_preset(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()
@@ -216,7 +213,7 @@ class TestMsvcPresets:
         assert "/DYNAMICBASE" in env.link.flags
         assert "/NXCOMPAT" in env.link.flags
 
-    def test_profile_preset(self) -> None:
+    def test_profile_preset(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()
@@ -231,7 +228,7 @@ class TestMsvcPresets:
         # MSVC profile is linker-only
         assert "/PROFILE" in env.link.flags
 
-    def test_unknown_preset_warns(self) -> None:
+    def test_unknown_preset_warns(self, test_project):  # noqa: F811
         from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
 
         env = _make_msvc_env()

--- a/tests/toolchains/test_target_arch.py
+++ b/tests/toolchains/test_target_arch.py
@@ -22,9 +22,8 @@ from pcons.toolchains.msvc import MsvcToolchain
 class TestGccTargetArch:
     """Tests for GCC toolchain target architecture."""
 
-    def test_macos_arm64(self) -> None:
+    def test_macos_arm64(self, test_project):  # noqa: F811
         """Test GCC arm64 target on macOS adds -arch flag."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -57,9 +56,8 @@ class TestGccTargetArch:
         assert "-arch" in link.flags
         assert "arm64" in link.flags
 
-    def test_macos_x86_64(self) -> None:
+    def test_macos_x86_64(self, test_project):  # noqa: F811
         """Test GCC x86_64 target on macOS adds -arch flag."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -84,9 +82,8 @@ class TestGccTargetArch:
         assert "-arch" in link.flags
         assert "x86_64" in link.flags
 
-    def test_linux_no_arch_flags(self) -> None:
+    def test_linux_no_arch_flags(self, test_project):  # noqa: F811
         """Test GCC on Linux doesn't add -arch flags (requires cross-toolchain)."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -114,9 +111,8 @@ class TestGccTargetArch:
 class TestLlvmTargetArch:
     """Tests for LLVM/Clang toolchain target architecture."""
 
-    def test_macos_arm64(self) -> None:
+    def test_macos_arm64(self, test_project):  # noqa: F811
         """Test LLVM arm64 target on macOS adds -arch flag."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -152,9 +148,8 @@ class TestLlvmTargetArch:
 class TestMsvcTargetArch:
     """Tests for MSVC toolchain target architecture."""
 
-    def test_x64_machine_flag(self) -> None:
+    def test_x64_machine_flag(self, test_project):  # noqa: F811
         """Test MSVC x64 target adds /MACHINE:X64."""
-        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -171,9 +166,8 @@ class TestMsvcTargetArch:
         assert "/MACHINE:X64" in link.flags
         assert "/MACHINE:X64" in lib.flags
 
-    def test_arm64_machine_flag(self) -> None:
+    def test_arm64_machine_flag(self, test_project):  # noqa: F811
         """Test MSVC arm64 target adds /MACHINE:ARM64."""
-        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -190,9 +184,8 @@ class TestMsvcTargetArch:
         assert "/MACHINE:ARM64" in link.flags
         assert "/MACHINE:ARM64" in lib.flags
 
-    def test_x86_machine_flag(self) -> None:
+    def test_x86_machine_flag(self, test_project):  # noqa: F811
         """Test MSVC x86 target adds /MACHINE:X86."""
-        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -204,9 +197,8 @@ class TestMsvcTargetArch:
 
         assert "/MACHINE:X86" in link.flags
 
-    def test_arm64ec_machine_flag(self) -> None:
+    def test_arm64ec_machine_flag(self, test_project):  # noqa: F811
         """Test MSVC arm64ec target adds /MACHINE:ARM64EC."""
-        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -218,9 +210,8 @@ class TestMsvcTargetArch:
 
         assert "/MACHINE:ARM64EC" in link.flags
 
-    def test_arch_aliases(self) -> None:
+    def test_arch_aliases(self, test_project):  # noqa: F811
         """Test MSVC architecture aliases are mapped correctly."""
-        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -246,9 +237,8 @@ class TestMsvcTargetArch:
 class TestClangClTargetArch:
     """Tests for Clang-CL toolchain target architecture."""
 
-    def test_x64_target_and_machine(self) -> None:
+    def test_x64_target_and_machine(self, test_project):  # noqa: F811
         """Test Clang-CL x64 target adds --target flag and /MACHINE."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -272,9 +262,8 @@ class TestClangClTargetArch:
         assert "/MACHINE:X64" in link.flags
         assert "/MACHINE:X64" in lib.flags
 
-    def test_arm64_target_and_machine(self) -> None:
+    def test_arm64_target_and_machine(self, test_project):  # noqa: F811
         """Test Clang-CL arm64 target adds --target flag and /MACHINE."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -296,9 +285,8 @@ class TestClangClTargetArch:
         assert "--target=aarch64-pc-windows-msvc" in cxx.flags
         assert "/MACHINE:ARM64" in link.flags
 
-    def test_x86_target_and_machine(self) -> None:
+    def test_x86_target_and_machine(self, test_project):  # noqa: F811
         """Test Clang-CL x86 target adds --target flag and /MACHINE."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -319,18 +307,16 @@ class TestClangClTargetArch:
 class TestEnvironmentSetTargetArch:
     """Tests for Environment.set_target_arch() method."""
 
-    def test_set_target_arch_stores_name(self) -> None:
+    def test_set_target_arch_stores_name(self, test_project):  # noqa: F811
         """Test set_target_arch stores the architecture name."""
-        Project("test_project")
         env = Environment()
 
         env.set_target_arch("arm64")
 
         assert env.target_arch == "arm64"
 
-    def test_set_target_arch_with_toolchain(self) -> None:
+    def test_set_target_arch_with_toolchain(self, test_project):  # noqa: F811
         """Test set_target_arch delegates to toolchain."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -357,9 +343,8 @@ class TestEnvironmentSetTargetArch:
         assert "arm64" in cc.flags
         assert env.target_arch == "arm64"
 
-    def test_orthogonal_to_variant(self) -> None:
+    def test_orthogonal_to_variant(self, test_project):  # noqa: F811
         """Test that set_target_arch is orthogonal to set_variant."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -397,7 +382,7 @@ class TestEnvironmentSetTargetArch:
 class TestBaseToolchainTargetArch:
     """Tests for BaseToolchain default apply_target_arch."""
 
-    def test_base_is_noop(self) -> None:
+    def test_base_is_noop(self, test_project):  # noqa: F811
         """Test base implementation is a no-op (doesn't add flags)."""
         from pcons.tools.toolchain import BaseToolchain
 
@@ -406,7 +391,6 @@ class TestBaseToolchainTargetArch:
             def _configure_tools(self, config: object) -> bool:
                 return True
 
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")

--- a/tests/toolchains/test_target_arch.py
+++ b/tests/toolchains/test_target_arch.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.toolchains.clang_cl import ClangClToolchain
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain

--- a/tests/toolchains/test_target_arch.py
+++ b/tests/toolchains/test_target_arch.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.toolchains.clang_cl import ClangClToolchain
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
@@ -23,6 +24,7 @@ class TestGccTargetArch:
 
     def test_macos_arm64(self) -> None:
         """Test GCC arm64 target on macOS adds -arch flag."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -57,6 +59,7 @@ class TestGccTargetArch:
 
     def test_macos_x86_64(self) -> None:
         """Test GCC x86_64 target on macOS adds -arch flag."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -83,6 +86,7 @@ class TestGccTargetArch:
 
     def test_linux_no_arch_flags(self) -> None:
         """Test GCC on Linux doesn't add -arch flags (requires cross-toolchain)."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -112,6 +116,7 @@ class TestLlvmTargetArch:
 
     def test_macos_arm64(self) -> None:
         """Test LLVM arm64 target on macOS adds -arch flag."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -149,6 +154,7 @@ class TestMsvcTargetArch:
 
     def test_x64_machine_flag(self) -> None:
         """Test MSVC x64 target adds /MACHINE:X64."""
+        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -167,6 +173,7 @@ class TestMsvcTargetArch:
 
     def test_arm64_machine_flag(self) -> None:
         """Test MSVC arm64 target adds /MACHINE:ARM64."""
+        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -185,6 +192,7 @@ class TestMsvcTargetArch:
 
     def test_x86_machine_flag(self) -> None:
         """Test MSVC x86 target adds /MACHINE:X86."""
+        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -198,6 +206,7 @@ class TestMsvcTargetArch:
 
     def test_arm64ec_machine_flag(self) -> None:
         """Test MSVC arm64ec target adds /MACHINE:ARM64EC."""
+        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -211,6 +220,7 @@ class TestMsvcTargetArch:
 
     def test_arch_aliases(self) -> None:
         """Test MSVC architecture aliases are mapped correctly."""
+        Project("test_project")
         env = Environment()
 
         link = env.add_tool("link")
@@ -238,6 +248,7 @@ class TestClangClTargetArch:
 
     def test_x64_target_and_machine(self) -> None:
         """Test Clang-CL x64 target adds --target flag and /MACHINE."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -263,6 +274,7 @@ class TestClangClTargetArch:
 
     def test_arm64_target_and_machine(self) -> None:
         """Test Clang-CL arm64 target adds --target flag and /MACHINE."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -286,6 +298,7 @@ class TestClangClTargetArch:
 
     def test_x86_target_and_machine(self) -> None:
         """Test Clang-CL x86 target adds --target flag and /MACHINE."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -308,6 +321,7 @@ class TestEnvironmentSetTargetArch:
 
     def test_set_target_arch_stores_name(self) -> None:
         """Test set_target_arch stores the architecture name."""
+        Project("test_project")
         env = Environment()
 
         env.set_target_arch("arm64")
@@ -316,6 +330,7 @@ class TestEnvironmentSetTargetArch:
 
     def test_set_target_arch_with_toolchain(self) -> None:
         """Test set_target_arch delegates to toolchain."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -344,6 +359,7 @@ class TestEnvironmentSetTargetArch:
 
     def test_orthogonal_to_variant(self) -> None:
         """Test that set_target_arch is orthogonal to set_variant."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -390,6 +406,7 @@ class TestBaseToolchainTargetArch:
             def _configure_tools(self, config: object) -> bool:
                 return True
 
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")

--- a/tests/toolchains/test_toolchain_variants.py
+++ b/tests/toolchains/test_toolchain_variants.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import pytest
 
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
 

--- a/tests/toolchains/test_toolchain_variants.py
+++ b/tests/toolchains/test_toolchain_variants.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import pytest
 
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.toolchains.gcc import GccToolchain
 from pcons.toolchains.llvm import LlvmToolchain
 
@@ -23,6 +24,7 @@ class TestGccVariants:
 
     def test_debug_variant(self) -> None:
         """Test GCC debug variant applies correct flags."""
+        Project("test_project")
         env = Environment()
 
         # Set up a mock GCC toolchain (just add the tools manually)
@@ -59,6 +61,7 @@ class TestGccVariants:
 
     def test_release_variant(self) -> None:
         """Test GCC release variant applies correct flags."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -77,6 +80,7 @@ class TestGccVariants:
 
     def test_relwithdebinfo_variant(self) -> None:
         """Test GCC relwithdebinfo variant."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -93,6 +97,7 @@ class TestGccVariants:
 
     def test_minsizerel_variant(self) -> None:
         """Test GCC minsizerel variant."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -108,6 +113,7 @@ class TestGccVariants:
 
     def test_extra_flags(self) -> None:
         """Test extra flags are added."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -123,6 +129,7 @@ class TestGccVariants:
 
     def test_extra_defines(self) -> None:
         """Test extra defines are added (without -D prefix)."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -138,6 +145,7 @@ class TestGccVariants:
 
     def test_unknown_variant(self) -> None:
         """Test unknown variant sets name but no flags."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -152,6 +160,7 @@ class TestGccVariants:
 
     def test_case_insensitive(self) -> None:
         """Test variant names are case-insensitive."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -171,6 +180,7 @@ class TestLlvmVariants:
 
     def test_debug_variant(self) -> None:
         """Test LLVM debug variant."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -189,6 +199,7 @@ class TestLlvmVariants:
 
     def test_release_variant(self) -> None:
         """Test LLVM release variant."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -208,6 +219,7 @@ class TestEnvironmentSetVariant:
 
     def test_set_variant_without_toolchain(self) -> None:
         """Test set_variant without toolchain just sets name."""
+        Project("test_project")
         env = Environment()
 
         env.set_variant("debug")
@@ -217,6 +229,7 @@ class TestEnvironmentSetVariant:
     def test_set_variant_with_toolchain(self) -> None:
         """Test set_variant delegates to toolchain."""
         # Create env with tools set up manually
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -237,6 +250,7 @@ class TestEnvironmentSetVariant:
 
     def test_preserves_existing_flags(self) -> None:
         """Test that set_variant preserves existing flags."""
+        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -265,6 +279,7 @@ class TestBaseToolchainVariant:
     def test_base_sets_variant_name(self) -> None:
         """Test base implementation sets variant name."""
 
+        Project("test_project")
         # Can't instantiate abstract class directly, use a concrete one
         # and verify the base behavior (super().apply_variant sets env.variant)
         env = Environment()
@@ -278,6 +293,7 @@ class TestBaseToolchainVariant:
 
     def test_base_rejects_unknown_variant(self) -> None:
         """Test that unknown variant names are rejected with a helpful error."""
+        Project("test_project")
         env = Environment()
 
         toolchain = GccToolchain()

--- a/tests/toolchains/test_toolchain_variants.py
+++ b/tests/toolchains/test_toolchain_variants.py
@@ -22,9 +22,8 @@ from pcons.toolchains.llvm import LlvmToolchain
 class TestGccVariants:
     """Tests for GCC toolchain variants."""
 
-    def test_debug_variant(self) -> None:
+    def test_debug_variant(self, test_project):  # noqa: F811
         """Test GCC debug variant applies correct flags."""
-        Project("test_project")
         env = Environment()
 
         # Set up a mock GCC toolchain (just add the tools manually)
@@ -59,9 +58,8 @@ class TestGccVariants:
         # Check variant name was set
         assert env.variant == "debug"
 
-    def test_release_variant(self) -> None:
+    def test_release_variant(self, test_project):  # noqa: F811
         """Test GCC release variant applies correct flags."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -78,9 +76,8 @@ class TestGccVariants:
         assert "NDEBUG" in cc.defines
         assert env.variant == "release"
 
-    def test_relwithdebinfo_variant(self) -> None:
+    def test_relwithdebinfo_variant(self, test_project):  # noqa: F811
         """Test GCC relwithdebinfo variant."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -95,9 +92,8 @@ class TestGccVariants:
         assert "-g" in cc.flags
         assert "NDEBUG" in cc.defines
 
-    def test_minsizerel_variant(self) -> None:
+    def test_minsizerel_variant(self, test_project):  # noqa: F811
         """Test GCC minsizerel variant."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -111,9 +107,8 @@ class TestGccVariants:
         assert "-Os" in cc.flags
         assert "NDEBUG" in cc.defines
 
-    def test_extra_flags(self) -> None:
+    def test_extra_flags(self, test_project):  # noqa: F811
         """Test extra flags are added."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -127,9 +122,8 @@ class TestGccVariants:
         assert "-Wall" in cc.flags
         assert "-Wextra" in cc.flags
 
-    def test_extra_defines(self) -> None:
+    def test_extra_defines(self, test_project):  # noqa: F811
         """Test extra defines are added (without -D prefix)."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -143,9 +137,8 @@ class TestGccVariants:
 
         assert "MY_FEATURE" in cc.defines
 
-    def test_unknown_variant(self) -> None:
+    def test_unknown_variant(self, test_project):  # noqa: F811
         """Test unknown variant sets name but no flags."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -158,9 +151,8 @@ class TestGccVariants:
         with pytest.raises(ValueError, match="Unknown variant.*custom"):
             toolchain.apply_variant(env, "custom")
 
-    def test_case_insensitive(self) -> None:
+    def test_case_insensitive(self, test_project):  # noqa: F811
         """Test variant names are case-insensitive."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -178,9 +170,8 @@ class TestGccVariants:
 class TestLlvmVariants:
     """Tests for LLVM/Clang toolchain variants."""
 
-    def test_debug_variant(self) -> None:
+    def test_debug_variant(self, test_project):  # noqa: F811
         """Test LLVM debug variant."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -197,9 +188,8 @@ class TestLlvmVariants:
         assert "DEBUG" in cc.defines
         assert env.variant == "debug"
 
-    def test_release_variant(self) -> None:
+    def test_release_variant(self, test_project):  # noqa: F811
         """Test LLVM release variant."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -217,19 +207,17 @@ class TestLlvmVariants:
 class TestEnvironmentSetVariant:
     """Tests for Environment.set_variant() method."""
 
-    def test_set_variant_without_toolchain(self) -> None:
+    def test_set_variant_without_toolchain(self, test_project):  # noqa: F811
         """Test set_variant without toolchain just sets name."""
-        Project("test_project")
         env = Environment()
 
         env.set_variant("debug")
 
         assert env.variant == "debug"
 
-    def test_set_variant_with_toolchain(self) -> None:
+    def test_set_variant_with_toolchain(self, test_project):  # noqa: F811
         """Test set_variant delegates to toolchain."""
         # Create env with tools set up manually
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -248,9 +236,8 @@ class TestEnvironmentSetVariant:
         assert "-g" in cc.flags
         assert env.variant == "debug"
 
-    def test_preserves_existing_flags(self) -> None:
+    def test_preserves_existing_flags(self, test_project):  # noqa: F811
         """Test that set_variant preserves existing flags."""
-        Project("test_project")
         env = Environment()
 
         cc = env.add_tool("cc")
@@ -276,10 +263,9 @@ class TestEnvironmentSetVariant:
 class TestBaseToolchainVariant:
     """Tests for BaseToolchain default apply_variant."""
 
-    def test_base_sets_variant_name(self) -> None:
+    def test_base_sets_variant_name(self, test_project):  # noqa: F811
         """Test base implementation sets variant name."""
 
-        Project("test_project")
         # Can't instantiate abstract class directly, use a concrete one
         # and verify the base behavior (super().apply_variant sets env.variant)
         env = Environment()
@@ -291,9 +277,8 @@ class TestBaseToolchainVariant:
 
         assert env.variant == "debug"
 
-    def test_base_rejects_unknown_variant(self) -> None:
+    def test_base_rejects_unknown_variant(self, test_project):  # noqa: F811
         """Test that unknown variant names are rejected with a helpful error."""
-        Project("test_project")
         env = Environment()
 
         toolchain = GccToolchain()

--- a/tests/tools/test_external_tool.py
+++ b/tests/tools/test_external_tool.py
@@ -17,6 +17,7 @@ import pytest
 
 from pcons.core.builder import CommandBuilder
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.tools.tool import BaseTool
 from pcons.tools.toolchain import BaseToolchain
@@ -142,6 +143,7 @@ class TestExternalTool:
 
     def test_tool_can_setup_environment(self) -> None:
         """Test that the tool can be added to an environment."""
+        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -154,6 +156,7 @@ class TestExternalTool:
 
     def test_tool_builder_attached_to_environment(self) -> None:
         """Test that builders are attached to the tool namespace."""
+        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -163,6 +166,7 @@ class TestExternalTool:
 
     def test_builder_creates_node(self, tmp_path: Path) -> None:
         """Test that the builder creates target nodes."""
+        Project("test_project")
         env = Environment()
         env.build_dir = tmp_path
 
@@ -186,6 +190,7 @@ class TestExternalTool:
 
     def test_tool_variables_can_be_modified(self) -> None:
         """Test that tool variables can be customized."""
+        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -225,6 +230,7 @@ class TestExternalToolchain:
         if not toolchain.configure(None):
             pytest.skip("cat command not available")
 
+        Project("test_project")
         env = Environment(toolchain=toolchain)
 
         # Tool should be available
@@ -237,6 +243,7 @@ class TestMultipleExternalTools:
 
     def test_multiple_tools_in_environment(self) -> None:
         """Test adding multiple custom tools to an environment."""
+        Project("test_project")
         env = Environment()
 
         # Add concat tool
@@ -403,6 +410,7 @@ class TestToolIntegration:
 
     def test_tool_with_variant(self) -> None:
         """Test that external tools work with variants."""
+        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()
@@ -416,6 +424,7 @@ class TestToolIntegration:
 
     def test_tool_environment_clone(self) -> None:
         """Test that cloned environments preserve external tools."""
+        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()
@@ -435,6 +444,7 @@ class TestToolIntegration:
 
     def test_variable_substitution(self) -> None:
         """Test that tool variables work with substitution."""
+        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()

--- a/tests/tools/test_external_tool.py
+++ b/tests/tools/test_external_tool.py
@@ -141,9 +141,8 @@ class TestExternalTool:
         assert defaults["cmd"] == "cat"
         assert "bundlecmd" in defaults
 
-    def test_tool_can_setup_environment(self) -> None:
+    def test_tool_can_setup_environment(self, test_project):  # noqa: F811
         """Test that the tool can be added to an environment."""
-        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -154,9 +153,8 @@ class TestExternalTool:
         # Tool variables should be accessible
         assert env.concat.cmd == "cat"
 
-    def test_tool_builder_attached_to_environment(self) -> None:
+    def test_tool_builder_attached_to_environment(self, test_project):  # noqa: F811
         """Test that builders are attached to the tool namespace."""
-        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -164,9 +162,8 @@ class TestExternalTool:
         # Builder should be callable via tool namespace
         assert hasattr(env.concat, "Bundle")
 
-    def test_builder_creates_node(self, tmp_path: Path) -> None:
+    def test_builder_creates_node(self, tmp_path: Path, test_project):  # noqa: F811
         """Test that the builder creates target nodes."""
-        Project("test_project")
         env = Environment()
         env.build_dir = tmp_path
 
@@ -188,9 +185,8 @@ class TestExternalTool:
         # Should return a node
         assert target is not None
 
-    def test_tool_variables_can_be_modified(self) -> None:
+    def test_tool_variables_can_be_modified(self, test_project):  # noqa: F811
         """Test that tool variables can be customized."""
-        Project("test_project")
         env = Environment()
         tool = ConcatTool()
         tool.setup(env)
@@ -224,13 +220,12 @@ class TestExternalToolchain:
         if result:
             assert "concat" in toolchain.tools
 
-    def test_environment_with_toolchain(self) -> None:
+    def test_environment_with_toolchain(self, test_project):  # noqa: F811
         """Test creating an environment with the toolchain."""
         toolchain = ConcatToolchain()
         if not toolchain.configure(None):
             pytest.skip("cat command not available")
 
-        Project("test_project")
         env = Environment(toolchain=toolchain)
 
         # Tool should be available
@@ -241,9 +236,8 @@ class TestExternalToolchain:
 class TestMultipleExternalTools:
     """Test combining multiple external tools."""
 
-    def test_multiple_tools_in_environment(self) -> None:
+    def test_multiple_tools_in_environment(self, test_project):  # noqa: F811
         """Test adding multiple custom tools to an environment."""
-        Project("test_project")
         env = Environment()
 
         # Add concat tool
@@ -408,9 +402,8 @@ class TestNinjaGeneration:
 class TestToolIntegration:
     """Test that external tools integrate with the rest of pcons."""
 
-    def test_tool_with_variant(self) -> None:
+    def test_tool_with_variant(self, test_project):  # noqa: F811
         """Test that external tools work with variants."""
-        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()
@@ -422,9 +415,8 @@ class TestToolIntegration:
         assert env.concat.cmd == "cat"
         assert env.variant == "release"
 
-    def test_tool_environment_clone(self) -> None:
+    def test_tool_environment_clone(self, test_project):  # noqa: F811
         """Test that cloned environments preserve external tools."""
-        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()
@@ -442,9 +434,8 @@ class TestToolIntegration:
         env2.concat.flags.append("-v")
         assert "-v" not in env.concat.flags
 
-    def test_variable_substitution(self) -> None:
+    def test_variable_substitution(self, test_project):  # noqa: F811
         """Test that tool variables work with substitution."""
-        Project("test_project")
         env = Environment()
 
         concat = ConcatTool()

--- a/tests/tools/test_external_tool.py
+++ b/tests/tools/test_external_tool.py
@@ -264,7 +264,6 @@ class TestNinjaGeneration:
 
     def test_generates_ninja_rule(self, tmp_path: Path) -> None:
         """Test that the tool generates valid ninja rules."""
-        from pcons.core.project import Project
         from pcons.generators.ninja import NinjaGenerator
 
         # Create a project with the concat tool
@@ -320,7 +319,6 @@ class TestNinjaGeneration:
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pytest.skip("ninja not available")
 
-        from pcons.core.project import Project
         from pcons.generators.ninja import NinjaGenerator
 
         # === Step 1: Create source files ===

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -3,6 +3,7 @@
 
 from pcons.core.builder import Builder, CommandBuilder
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.tools.tool import BaseTool, BuilderMethod, Tool
 
 
@@ -57,6 +58,7 @@ class TestBaseTool:
 
     def test_setup_creates_namespace(self):
         tool = MockTool()
+        Project("test_project")
         env = Environment()
 
         tool.setup(env)
@@ -66,6 +68,7 @@ class TestBaseTool:
 
     def test_setup_attaches_builders(self):
         tool = MockTool()
+        Project("test_project")
         env = Environment()
 
         tool.setup(env)
@@ -78,6 +81,7 @@ class TestBaseTool:
 class TestBuilderMethod:
     def test_call_with_string_source(self):
         tool = MockTool()
+        Project("test_project")
         env = Environment()
         tool.setup(env)
 
@@ -87,6 +91,7 @@ class TestBuilderMethod:
 
     def test_call_with_list_sources(self):
         tool = MockTool()
+        Project("test_project")
         env = Environment()
         tool.setup(env)
 
@@ -96,6 +101,7 @@ class TestBuilderMethod:
 
     def test_call_with_no_sources(self):
         tool = MockTool()
+        Project("test_project")
         env = Environment()
         tool.setup(env)
 

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -56,9 +56,8 @@ class TestBaseTool:
         builders = tool.builders()
         assert "Compile" in builders
 
-    def test_setup_creates_namespace(self):
+    def test_setup_creates_namespace(self, test_project):  # noqa: F811
         tool = MockTool()
-        Project("test_project")
         env = Environment()
 
         tool.setup(env)
@@ -66,9 +65,8 @@ class TestBaseTool:
         assert env.has_tool("mock")
         assert env.mock.cmd == "mock-compiler"
 
-    def test_setup_attaches_builders(self):
+    def test_setup_attaches_builders(self, test_project):  # noqa: F811
         tool = MockTool()
-        Project("test_project")
         env = Environment()
 
         tool.setup(env)
@@ -79,9 +77,8 @@ class TestBaseTool:
 
 
 class TestBuilderMethod:
-    def test_call_with_string_source(self):
+    def test_call_with_string_source(self, test_project):  # noqa: F811
         tool = MockTool()
-        Project("test_project")
         env = Environment()
         tool.setup(env)
 
@@ -89,9 +86,8 @@ class TestBuilderMethod:
 
         assert len(result) == 1
 
-    def test_call_with_list_sources(self):
+    def test_call_with_list_sources(self, test_project):  # noqa: F811
         tool = MockTool()
-        Project("test_project")
         env = Environment()
         tool.setup(env)
 
@@ -99,9 +95,8 @@ class TestBuilderMethod:
 
         assert len(result) == 2
 
-    def test_call_with_no_sources(self):
+    def test_call_with_no_sources(self, test_project):  # noqa: F811
         tool = MockTool()
-        Project("test_project")
         env = Environment()
         tool.setup(env)
 

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -3,7 +3,6 @@
 
 from pcons.core.builder import Builder, CommandBuilder
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.tools.tool import BaseTool, BuilderMethod, Tool
 
 

--- a/tests/tools/test_toolchain.py
+++ b/tests/tools/test_toolchain.py
@@ -3,6 +3,7 @@
 
 from pcons.core.builder import Builder
 from pcons.core.environment import Environment
+from pcons.core.project import Project
 from pcons.tools.tool import BaseTool, Tool
 from pcons.tools.toolchain import BaseToolchain, Toolchain
 
@@ -63,6 +64,7 @@ class TestBaseToolchain:
         tc = MockToolchain()
         tc.configure(None)
 
+        Project("test_project")
         env = Environment()
         tc.setup(env)
 

--- a/tests/tools/test_toolchain.py
+++ b/tests/tools/test_toolchain.py
@@ -3,7 +3,6 @@
 
 from pcons.core.builder import Builder
 from pcons.core.environment import Environment
-from pcons.core.project import Project
 from pcons.tools.tool import BaseTool, Tool
 from pcons.tools.toolchain import BaseToolchain, Toolchain
 

--- a/tests/tools/test_toolchain.py
+++ b/tests/tools/test_toolchain.py
@@ -60,11 +60,10 @@ class TestBaseToolchain:
         assert "cc" in tc.tools
         assert "cxx" in tc.tools
 
-    def test_setup(self):
+    def test_setup(self, test_project):  # noqa: F811
         tc = MockToolchain()
         tc.configure(None)
 
-        Project("test_project")
         env = Environment()
         tc.setup(env)
 

--- a/tests/util/test_add_subdirectory.py
+++ b/tests/util/test_add_subdirectory.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: MIT
+"""Tests for pcons.util.add_subdirectory."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from pcons.core.project import Project
+from pcons.util.add_subdirectory import add_subdirectory
+
+
+def _make_subdir(parent: Path | Project, name: str, content: str) -> Path:
+    """Create a subdirectory with a pcons-build.py script."""
+    parent = parent.root_dir if isinstance(parent, Project) else parent
+    subdir = parent / name
+    subdir.mkdir(parents=True, exist_ok=True)
+    (subdir / "pcons-build.py").write_text(content)
+    return subdir
+
+
+class TestAddSubdirectory:
+    def test_returns_namespace_with_exported_names(self, test_project: Project) -> None:
+        _make_subdir(test_project, "child", "result = 42\n")
+
+        ns = add_subdirectory("child")
+
+        assert isinstance(ns, SimpleNamespace)
+        assert ns.result == 42
+
+    def test_pick_returns_tuple(self, test_project: Project) -> None:
+        _make_subdir(test_project, "child", "a = 1\nb = 2\nc = 3\n")
+
+        values = add_subdirectory("child", pick=["a", "c"])
+
+        assert values == (1, 3)
+
+    def test_subdirectory_script_runs_in_project_context(
+        self, test_project: Project
+    ) -> None:
+        """Scripts in subdirs see the same Project via Project.current()."""
+        Project("root", root_dir=test_project.root_dir)
+        script = (
+            "from pcons.core.project import Project\n"
+            "found = Project.current() is not None\n"
+        )
+        _make_subdir(test_project, "child", script)
+
+        ns = add_subdirectory("child")
+
+        assert ns.found is True
+
+    def test_current_dir_set_correctly_inside_subdir(self, test_project: Project):
+        script = (
+            "from pcons.core.project import Project\n"
+            "import pathlib\n"
+            "cdir = Project.current().current_dir\n"
+        )
+        _make_subdir(test_project, "child", script)
+
+        ns = add_subdirectory("child")
+
+        assert ns.cdir == test_project.root_dir / "child"
+
+    def test_current_dir_restored_after_subdir(self, test_project: Project):
+        _make_subdir(test_project, "child", "x = 1\n")
+
+        add_subdirectory("child")
+
+        assert test_project.current_dir == test_project.root_dir
+
+    def test_missing_pcons_build_raises(self, test_project: Project) -> None:
+        (test_project.root_dir / "empty").mkdir()
+
+        with pytest.raises(FileNotFoundError, match="pcons-build.py"):
+            add_subdirectory("empty")
+
+    def test_no_active_project_raises(self, tmp_path: Path) -> None:
+        _make_subdir(tmp_path, "child", "x = 1\n")
+        # No Project created, so Project.current() raises ValueError
+        with pytest.raises(ValueError, match="no project is currently active"):
+            add_subdirectory(tmp_path / "child")
+
+    def test_nested_subdirectory(self, test_project: Project) -> None:
+        """Two levels of nesting: root -> a -> aa."""
+        aa_script = "from pcons.core.project import Project\ncdir = Project.current().current_dir\n"
+        _make_subdir(test_project, "a/aa", aa_script)
+        a_script = (
+            "from pcons.util.add_subdirectory import add_subdirectory\n"
+            "inner = add_subdirectory('aa')\n"
+        )
+        _make_subdir(test_project, "a", a_script)
+
+        ns = add_subdirectory("a")
+
+        assert ns.inner.cdir == test_project.root_dir / "a" / "aa"

--- a/tests/util/test_macos.py
+++ b/tests/util/test_macos.py
@@ -130,7 +130,6 @@ class TestCreateUniversalBinary:
     def test_creates_lipo_command(self, test_project):
         """Test that create_universal_binary creates a lipo command target."""
         from pcons.core.node import FileNode
-        from pcons.core.project import Project
         from pcons.core.target import Target
 
         # Create mock input nodes
@@ -159,7 +158,6 @@ class TestCreateUniversalBinary:
 
     def test_accepts_path_inputs(self, test_project):
         """Test that create_universal_binary accepts Path inputs."""
-        from pcons.core.project import Project
         from pcons.core.target import Target
 
         # Create using Path inputs
@@ -179,7 +177,6 @@ class TestCreateUniversalBinary:
 
     def test_raises_on_empty_inputs(self, test_project):
         """Test that create_universal_binary raises on empty inputs."""
-        from pcons.core.project import Project
 
         with pytest.raises(ValueError, match="requires at least one input"):
             create_universal_binary(

--- a/tests/util/test_macos.py
+++ b/tests/util/test_macos.py
@@ -127,13 +127,11 @@ class TestFixDylibReferences:
 class TestCreateUniversalBinary:
     """Tests for create_universal_binary function."""
 
-    def test_creates_lipo_command(self):
+    def test_creates_lipo_command(self, test_project):
         """Test that create_universal_binary creates a lipo command target."""
         from pcons.core.node import FileNode
         from pcons.core.project import Project
         from pcons.core.target import Target
-
-        project = Project("test_project")
 
         # Create mock input nodes
         input1 = FileNode(Path("build/arm64/libtest.a"))
@@ -141,7 +139,7 @@ class TestCreateUniversalBinary:
 
         # Create universal binary
         result = create_universal_binary(
-            project,
+            test_project,
             "test_universal",
             inputs=[input1, input2],
             output="build/universal/libtest.a",
@@ -159,16 +157,14 @@ class TestCreateUniversalBinary:
         assert len(result.output_nodes) > 0
         assert result.output_nodes[0].path == Path("build/universal/libtest.a")
 
-    def test_accepts_path_inputs(self):
+    def test_accepts_path_inputs(self, test_project):
         """Test that create_universal_binary accepts Path inputs."""
         from pcons.core.project import Project
         from pcons.core.target import Target
 
-        project = Project("test_project")
-
         # Create using Path inputs
         result = create_universal_binary(
-            project,
+            test_project,
             "test_universal",
             inputs=[
                 Path("build/arm64/libtest.a"),
@@ -181,27 +177,22 @@ class TestCreateUniversalBinary:
         assert len(result.output_nodes) > 0
         assert result.output_nodes[0].path == Path("build/universal/libtest.a")
 
-    def test_raises_on_empty_inputs(self):
+    def test_raises_on_empty_inputs(self, test_project):
         """Test that create_universal_binary raises on empty inputs."""
         from pcons.core.project import Project
 
-        project = Project("test_project")
-
         with pytest.raises(ValueError, match="requires at least one input"):
             create_universal_binary(
-                project,
+                test_project,
                 "test_universal",
                 inputs=[],
                 output="build/universal/libtest.a",
             )
 
-    def test_accepts_target_inputs(self):
+    def test_accepts_target_inputs(self, test_project):
         """Test that create_universal_binary accepts Target inputs."""
         from pcons.core.node import FileNode
-        from pcons.core.project import Project
         from pcons.core.target import Target
-
-        project = Project("test_project")
 
         # Create mock targets with output nodes
         target1 = Target(
@@ -219,7 +210,7 @@ class TestCreateUniversalBinary:
         target2.output_nodes.append(output2)
 
         result = create_universal_binary(
-            project,
+            test_project,
             "test_universal",
             inputs=[target1, target2],
             output="build/universal/libtest.a",


### PR DESCRIPTION
### Summary :memo:
Introduces `add_subdirectory()`, a new helper that allows build scripts to include subdirectory build scripts and have targets, sources, and object paths resolved relative to the owning subdirectory. This also makes `Project` mandatory as the root of any build graph, ensuring every `Target` and `Environment` is always associated with a project.

### Details
1. **Add `add_subdirectory` function** (`pcons/util/add_subdirectory.py`): resolves relative include, source, and object paths against the subdirectory's location; `Project.current` is automatically restored after the call exits.
2. **Allow nested projects**: a new `Project` can now be declared inside a subdirectory (e.g. `libfoo` in example 13). `Project` is now mandatory — any `Target` or `Environment` must belong to a project.
3. **Add global context** (`pcons/core/context.py`): exposes a `pcons.context` object for retrieving the current project and environment without passing them explicitly.
4. **Automatic generation**: `project.generate()` no longer needs to be called explicitly in `pcons-build.py` scripts.
5. **Remove `_normalize_sources` from `compile.py`**: unifies behaviour between `Target(..., sources=[...])` and `target.add_sources(...)`.
6. **Add `get_target` / `get_targets` helpers** on `Project`, with an overload that returns `None` instead of raising `KeyError` when a target is not found.
7. **Add example `36_cxx_modules_multi_level_subdirs`**: demonstrates multi-level subdirectory layouts with C++ modules.
8. **Update example `05_multi_library`**: uses helpers instead of project-based builders; `libphysics` is now a shared library.
9. **Update all tests**: add `clear_project_tree` automatic fixture; ensure every test using `Target` or `Environment` declares a `Project` first.


### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
