### PR TITLE
Fix: `pcons build` does not propagate subsystem error code

### DIFF
--- a/pcons/__main__.py
+++ b/pcons/__main__.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: MIT
 """Entry point for `python -m pcons`."""
 
+import sys
+
 from pcons.cli import main
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -661,6 +661,16 @@ print("hello")
         assert result.returncode != 0
         assert "No build files found" in result.stderr
 
+    def test_main_entry_point_propagates_exit_code(self, tmp_path: Path) -> None:
+        """__main__.py must call sys.exit(main()) so build failures propagate."""
+        result = subprocess.run(
+            [sys.executable, "-m", "pcons", "build"],
+            capture_output=True,
+            text=True,
+            cwd=tmp_path,
+        )
+        assert result.returncode != 0
+
     def test_pcons_clean_no_ninja(self, tmp_path: Path) -> None:
         """Test pcons clean without build.ninja (should succeed)."""
         result = subprocess.run(

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -626,6 +626,16 @@ def run_example(
     if invocation == "cli" and test_config.get("build_command"):
         pytest.skip("CLI invocation requires ninja; this example uses custom build")
 
+    # CLI invocation with xcode generator runs xcodebuild automatically, which is macOS-only
+    if (
+        invocation == "cli"
+        and generator == "xcode"
+        and platform.system().lower() != "darwin"
+    ):
+        pytest.skip(
+            "CLI invocation with xcode generator requires xcodebuild (macOS only)"
+        )
+
     # Copy example to temp directory (so we don't pollute the source tree)
     work_dir = tmp_path / example_dir.name
     shutil.copytree(


### PR DESCRIPTION
### Summary :memo:
Subsystem error code is currently not propagated.

### Details
1. Change `main()` to `sys.exit(main())` so subsystem (ie.: ninja) error code is propagated correctly.


### Bugfixes :bug: (delete if dind't have any)
 -  `pcons build` does not propagate subsystem error code
### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
