### PR TITLE
Feature/multi generator

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,10 +76,10 @@ jobs:
           EOF
       - name: Run unit tests (Windows)
         if: runner.os == 'Windows'
-        run: uv run pytest --cov=pcons --cov-report=xml --ignore=tests/test_examples.py -k "not 21_msvcup_hello"
+        run: uv run pytest -n auto --cov=pcons --cov-report=xml --ignore=tests/test_examples.py -k "not 21_msvcup_hello"
       - name: Run tests (non-Windows)
         if: runner.os != 'Windows'
-        run: uv run pytest --cov=pcons --cov-report=xml -k "not 21_msvcup_hello"
+        run: uv run pytest -n auto --cov=pcons --cov-report=xml -k "not 21_msvcup_hello"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ lint:             ## Run ruff and ty linters.
 
 .PHONY: test
 test:             ## Run tests.
-	uv run pytest
+	uv run pytest -n auto
 
 .PHONY: test-cov
 test-cov:         ## Run tests with coverage report.

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -28,6 +28,7 @@ from pcons.core.flags import FlagPair  # noqa: E402
 from pcons.core.project import Project  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
 from pcons.core.test import set_test_properties, set_test_property  # noqa: E402
+from pcons.generators.generator import MultiGenerator  # noqa: E402
 from pcons.generators.makefile import MakefileGenerator  # noqa: E402
 from pcons.generators.metadata import MetadataGenerator  # noqa: E402
 from pcons.generators.ninja import NinjaGenerator  # noqa: E402
@@ -158,31 +159,42 @@ GENERATORS = {
 
 def Generator(
     default: str = "ninja",
-) -> NinjaGenerator | MakefileGenerator | MetadataGenerator | XcodeGenerator:
+) -> (
+    NinjaGenerator
+    | MakefileGenerator
+    | MetadataGenerator
+    | XcodeGenerator
+    | MultiGenerator
+):
     """Get a generator instance based on CLI option or environment.
 
     The generator can be set with:
-        pcons --generator=make
         pcons -G ninja
+        pcons -G ninja -G metadata
         pcons -G xcode
 
     Or when running directly:
         GENERATOR=make python pcons-build.py
+        PCONS_GENERATOR=ninja:metadata python pcons-build.py
 
     Precedence (highest to lowest):
         1. PCONS_GENERATOR (set by pcons CLI)
         2. GENERATOR environment variable
         3. default parameter
 
+    Multiple generators can be specified with colon-separated names
+    (e.g., ``PCONS_GENERATOR=ninja:metadata``). Each generator runs
+    in order on the same project.
+
     Args:
         default: Default generator name if not set ("ninja", "make", "metadata", or "xcode").
 
     Returns:
-        A generator instance (NinjaGenerator, MakefileGenerator,
-        MetadataGenerator, or XcodeGenerator).
+        A generator instance. When multiple names are given, a MultiGenerator
+        that runs each in sequence.
 
     Raises:
-        ValueError: If the generator name is not recognized.
+        ValueError: If any generator name is not recognized.
 
     Example:
         from pcons import Project, Generator
@@ -191,14 +203,18 @@ def Generator(
         # ... configure project ...
         Generator().generate(project)
     """
-    name = os.environ.get("PCONS_GENERATOR") or os.environ.get("GENERATOR") or default
-    name = name.lower()
+    spec = os.environ.get("PCONS_GENERATOR") or os.environ.get("GENERATOR") or default
+    names = [n.strip().lower() for n in spec.split(":") if n.strip()]
 
-    if name not in GENERATORS:
-        valid = ", ".join(sorted(set(GENERATORS.keys())))
-        raise ValueError(f"Unknown generator '{name}'. Valid options: {valid}")
+    valid = ", ".join(sorted(set(GENERATORS.keys())))
+    for name in names:
+        if name not in GENERATORS:
+            raise ValueError(f"Unknown generator '{name}'. Valid options: {valid}")
 
-    return GENERATORS[name]()
+    instances = [GENERATORS[name]() for name in names]
+    if len(instances) == 1:
+        return instances[0]
+    return MultiGenerator(instances)
 
 
 # Public API exports
@@ -223,6 +239,7 @@ __all__ = [
     "PackageDescription",
     "Project",
     # Generators
+    # Intentionally not exposing MultiGenerator as it's an implementation detail
     "Generator",
     "NinjaGenerator",
     "MakefileGenerator",

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -224,13 +224,13 @@ def run_script(
         }
         exec(code, namespace)
 
-        # generate
+        # Execute any deferred generate requests registered by the build script
         try:
             from pcons import Project
+            from pcons.generators.generator import BaseGenerator
 
-            top_level_project = Project.top_level()
-            top_level_project.generate()
-
+            top_level = Project.top_level()
+            BaseGenerator._generate_pending(top_level)
             return 0, pcons.get_registered_projects()
         except ValueError:
             logger.error("No Project created in build script")

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -137,7 +137,7 @@ def run_script(
     build_dir: Path,
     variables: dict[str, str] | None = None,
     variant: str | None = None,
-    generator: str | None = None,
+    generator: list[str] | str | None = None,
     reconfigure: bool = False,
     extra_env: dict[str, str] | None = None,
 ) -> tuple[int, list[Project]]:
@@ -187,7 +187,8 @@ def run_script(
         set_env_var("PCONS_VARIANT", variant)
 
     if generator:
-        set_env_var("PCONS_GENERATOR", generator)
+        gen_spec = ":".join(generator) if isinstance(generator, list) else generator
+        set_env_var("PCONS_GENERATOR", gen_spec)
 
     if reconfigure:
         set_env_var("PCONS_RECONFIGURE", "1")
@@ -204,7 +205,7 @@ def run_script(
     if variant:
         logger.debug("  PCONS_VARIANT=%s", variant)
     if generator:
-        logger.debug("  PCONS_GENERATOR=%s", generator)
+        logger.debug("  PCONS_GENERATOR=%s", os.environ["PCONS_GENERATOR"])
 
     # Save and modify sys.path and cwd for script imports
     old_cwd = os.getcwd()
@@ -986,8 +987,9 @@ def add_generate_args(parser: argparse.ArgumentParser) -> None:
         "-G",
         "--generator",
         metavar="NAME",
+        action="append",
         choices=["ninja", "make", "makefile", "metadata", "xcode"],
-        help="Generator to use (ninja, make, metadata, xcode). Default: ninja",
+        help="Generator to use (ninja, make, metadata, xcode). Repeatable. Default: ninja",
     )
     parser.add_argument(
         "--reconfigure",

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -87,6 +87,7 @@ class Project(_ProjectBuilders):
         "_parent",
         "_children",
         "_subdir",
+        "__generated",
     )
 
     __current: Project | None = None
@@ -144,6 +145,7 @@ class Project(_ProjectBuilders):
         self.defined_at = defined_at or get_caller_location()
         self._subdir = None
         self._children: list[Project] = []
+        self.__generated = False
 
         # Auto-register with global registry (for CLI access)
         from pcons import _register_project
@@ -759,6 +761,16 @@ class Project(_ProjectBuilders):
             gen.generate(self)
             logger.info("Wrote %s graph to %s", format_name, output_path_str)
 
+    def _mark_generated(self):
+        """Mark the project build's generation have been requested.
+
+        This is called by generators that produce build files (e.g., Ninja)
+        to indicate that generation has been requested. It prevents multiple
+        generators from running on the same project and allows generate() to
+        be a no-op after the first generation.
+        """
+        self.__generated = True
+
     def generate(self) -> None:
         """Generate build files (convenience method).
 
@@ -769,9 +781,10 @@ class Project(_ProjectBuilders):
         For advanced usage (e.g., disabling compile_commands.json),
         use ``Generator().generate(project)`` directly.
         """
-        from pcons import Generator
+        if not self.__generated:
+            from pcons import Generator
 
-        Generator().generate(self)
+            Generator().generate(self)
 
     def generate_pc_file(
         self,

--- a/pcons/generators/generator.py
+++ b/pcons/generators/generator.py
@@ -18,6 +18,7 @@ See ``pcons/__init__.py`` for the factory implementation.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -156,3 +157,21 @@ class BaseGenerator:
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}({self.name!r})"
+
+
+class MultiGenerator:
+    """Runs multiple generators in sequence."""
+
+    def __init__(self, generators: Sequence[Generator]) -> None:
+        self._generators = list(generators)
+
+    @property
+    def name(self) -> str:
+        return ":".join(g.name for g in self._generators)
+
+    def generate(self, project: Project) -> None:
+        for gen in self._generators:
+            gen.generate(project)
+
+    def __repr__(self) -> str:
+        return f"MultiGenerator({self.name!r})"

--- a/pcons/generators/generator.py
+++ b/pcons/generators/generator.py
@@ -4,21 +4,22 @@
 Generators take a configured Project and produce build system files
 (e.g., Ninja, Makefiles, IDE project files).
 
-NOTE: Build scripts should use the ``Generator()`` factory from the
-top-level ``pcons`` package, NOT this Protocol directly::
+NOTE: Build scripts may use the ``Generator()`` factory from the
+top-level ``pcons`` package to register which generator(s) to use::
 
     from pcons import Generator, Project
     project = Project("myapp", build_dir="build")
     # ... define targets ...
-    Generator().generate(project)   # generates Ninja by default
+    Generator().generate(project)   # requests Ninja by default
 
-``Generator()`` auto-resolves the project and defaults to Ninja.
-See ``pcons/__init__.py`` for the factory implementation.
+Actual generation is deferred: it runs when ``BaseGenerator._generate_pending()``
+is called — either by the CLI after executing the build script, or via the
+atexit handler when the script is run directly with ``python pcons-build.py``.
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -58,6 +59,17 @@ class BaseGenerator:
 
     _supports_compile_commands: bool = False
 
+    _is_build_generator: bool = False
+    """Whether this generator produces build files (vs. auxiliary files like compile_commands.json).
+    Used to determine whether to mark project as generated.
+    """
+
+    __pending = dict[int, list[Callable[[], None]]]()
+    """Pending generate requests"""
+
+    __atexit_registered = False
+    """Whether the atexit handler has been registered"""
+
     def __init__(self, name: str) -> None:
         """Initialize a generator.
 
@@ -71,39 +83,96 @@ class BaseGenerator:
         return self._name
 
     def generate(self, project: Project, *, compile_commands: bool = True) -> None:
-        """Generate build files.
+        """Register a deferred generate for this project.
 
-        Auto-resolves the project if not already resolved, then
-        calls _generate_impl() which subclasses must implement.
-        The output directory is computed from project.build_dir.
+        Enqueues the generation work to run later — either when
+        ``_generate_pending()`` is called by the CLI, or at process exit
+        via the atexit handler when the script is run directly.
+
+        The output directory is computed from ``project.build_dir``. The
+        project is auto-resolved if not already resolved at the time the
+        generation actually runs.
 
         For build generators (Ninja, Make, Xcode), also auto-generates
-        compile_commands.json for IDE integration unless disabled.
+        ``compile_commands.json`` for IDE integration unless disabled.
 
         Args:
             project: The configured project to generate for.
             compile_commands: If True (default) and this generator supports
-                it, automatically generate compile_commands.json alongside
+                it, automatically generate ``compile_commands.json`` alongside
                 the build files.
         """
-        if not project._resolved:
-            project.resolve()
-        output_dir = self._resolve_output_dir(project)
-        self._generate_impl(project, output_dir)
 
-        if compile_commands and self._supports_compile_commands:
-            from pcons.generators.compile_commands import (
-                CompileCommandsGenerator,
-            )
+        def _generate_later():
+            if not project._resolved:
+                project.resolve()
+            output_dir = self._resolve_output_dir(project)
+            self._generate_impl(project, output_dir)
 
-            CompileCommandsGenerator().generate(project)
+            if compile_commands and self._supports_compile_commands:
+                from pcons.generators.compile_commands import (
+                    CompileCommandsGenerator,
+                )
 
-        # Write the test manifest if the project declares any tests.
-        # Generator-agnostic: every backend gets it for free. Skipped
-        # silently when there are no Test targets.
-        from pcons.core.test import write_test_manifest
+                cc_gen = CompileCommandsGenerator()
+                cc_gen._generate_impl(project, cc_gen._resolve_output_dir(project))
 
-        write_test_manifest(project, output_dir)
+            # Write the test manifest if the project declares any tests.
+            # Generator-agnostic: every backend gets it for free. Skipped
+            # silently when there are no Test targets.
+            from pcons.core.test import write_test_manifest
+
+            write_test_manifest(project, output_dir)
+
+        # Register the actual generation, will be actually executed either by CLI or atexit
+        BaseGenerator.__pending.setdefault(id(project), []).append(_generate_later)
+
+        if self._is_build_generator:
+            # Mark project as generated when a build generator is registered
+            project._mark_generated()
+
+        if not BaseGenerator.__atexit_registered:
+            # Register the atexit handler to run pending generates
+            import atexit
+
+            atexit.register(BaseGenerator._generate_pending)
+            BaseGenerator.__atexit_registered = True
+
+    @staticmethod
+    def _clear_pending() -> None:
+        """Clear all pending generates (for testing)."""
+        BaseGenerator.__pending.clear()
+
+    @staticmethod
+    def _generate_pending(project: Project | None = None) -> None:
+        """Execute and clear pending generate requests for a project.
+
+        If *project* is ``None``, the top-level project is used.  Raises
+        ``ValueError`` if no top-level project exists and *project* was not
+        supplied.  Safe to call when nothing is pending (no-op).
+
+        Args:
+            project: The project whose pending generate requests should be executed.
+                     Defaults to ``Project.top_level()``.
+        """
+        if project is None:
+            from pcons.core.project import Project as _Project
+
+            project = _Project.top_level()
+
+        # ensure project generation is pending, no-op if already marked as generated
+        project.generate()
+
+        pending = BaseGenerator.__pending.pop(id(project), [])
+        for func in pending:
+            func()
+
+        if BaseGenerator.__atexit_registered:
+            # Unregister the atexit handler if there are no more pending generates to avoid running it unnecessarily at exit
+            import atexit
+
+            atexit.unregister(BaseGenerator._generate_pending)
+            BaseGenerator.__atexit_registered = False
 
     def _resolve_output_dir(self, project: Project) -> Path:
         """Compute the output directory from the project.

--- a/pcons/generators/generator.py
+++ b/pcons/generators/generator.py
@@ -135,7 +135,7 @@ class BaseGenerator:
             # Register the atexit handler to run pending generates
             import atexit
 
-            atexit.register(BaseGenerator._generate_pending)
+            atexit.register(BaseGenerator._generate_pending, _is_atexit=True)
             BaseGenerator.__atexit_registered = True
 
     @staticmethod
@@ -144,7 +144,9 @@ class BaseGenerator:
         BaseGenerator.__pending.clear()
 
     @staticmethod
-    def _generate_pending(project: Project | None = None) -> None:
+    def _generate_pending(
+        project: Project | None = None, *, _is_atexit: bool = False
+    ) -> None:
         """Execute and clear pending generate requests for a project.
 
         If *project* is ``None``, the top-level project is used.  Raises
@@ -155,24 +157,37 @@ class BaseGenerator:
             project: The project whose pending generate requests should be executed.
                      Defaults to ``Project.top_level()``.
         """
-        if project is None:
-            from pcons.core.project import Project as _Project
+        try:
+            if project is None:
+                from pcons.core.project import Project as _Project
 
-            project = _Project.top_level()
+                project = _Project.top_level()
 
-        # ensure project generation is pending, no-op if already marked as generated
-        project.generate()
+            # ensure project generation is pending, no-op if already marked as generated
+            project.generate()
 
-        pending = BaseGenerator.__pending.pop(id(project), [])
-        for func in pending:
-            func()
+            pending = BaseGenerator.__pending.pop(id(project), [])
+            for func in pending:
+                func()
 
-        if BaseGenerator.__atexit_registered:
-            # Unregister the atexit handler if there are no more pending generates to avoid running it unnecessarily at exit
-            import atexit
+            if BaseGenerator.__atexit_registered:
+                # Unregister the atexit handler if there are no more pending generates to avoid running it unnecessarily at exit
+                import atexit
 
-            atexit.unregister(BaseGenerator._generate_pending)
-            BaseGenerator.__atexit_registered = False
+                atexit.unregister(BaseGenerator._generate_pending)
+                BaseGenerator.__atexit_registered = False
+        except Exception as e:
+            import sys
+            import traceback
+
+            if _is_atexit:
+                print(
+                    f"Error during generator execution at exit: {e}\n"
+                    "Traceback (most recent call last):",
+                    file=sys.stderr,
+                )
+                traceback.print_exc()
+            raise
 
     def _resolve_output_dir(self, project: Project) -> Path:
         """Compute the output directory from the project.

--- a/pcons/generators/makefile.py
+++ b/pcons/generators/makefile.py
@@ -45,6 +45,7 @@ class MakefileGenerator(BaseGenerator):
     """
 
     _supports_compile_commands = True
+    _is_build_generator = True
 
     # Characters that need escaping in Makefiles
     # $ -> $$, # -> \#, spaces in targets need escaping

--- a/pcons/generators/ninja.py
+++ b/pcons/generators/ninja.py
@@ -52,6 +52,7 @@ class NinjaGenerator(BaseGenerator):
     """
 
     _supports_compile_commands = True
+    _is_build_generator = True
 
     # Characters that need escaping in Ninja
     ESCAPE_CHARS = re.compile(r"([$:\s])")

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -79,6 +79,7 @@ class XcodeGenerator(BaseGenerator):
     """
 
     _supports_compile_commands = True
+    _is_build_generator = True
 
     def __init__(self) -> None:
         super().__init__("xcode")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ packages = ["pcons"]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=4.0",
+    "pytest-xdist>=3.8",
     "mypy>=1.0",
     "ruff>=0.4",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@
 import pytest
 
 from pcons.core.project import Project
+from pcons.generators.generator import BaseGenerator
 from pcons.toolchains.gcc import (
     GccArchiver,
     GccCCompiler,
@@ -60,14 +61,12 @@ int main(void) {
 
 @pytest.fixture(autouse=True)
 def clear_project_tree():
-    """Ensure global Project state is cleared for each test.
-
-    Calls `Project._clear_tree()` before the test and again after to
-    guarantee a clean project registry and avoid cross-test leakage.
-    """
+    """Ensure global Project and generator state is cleared for each test."""
     Project._clear_tree()
+    BaseGenerator._clear_pending()
     yield
     Project._clear_tree()
+    BaseGenerator._clear_pending()
 
 
 @pytest.fixture

--- a/tests/core/test_build_context.py
+++ b/tests/core/test_build_context.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from pcons.generators.generator import BaseGenerator
 from pcons.toolchains.build_context import CompileLinkContext, MsvcCompileLinkContext
 
 
@@ -361,6 +362,7 @@ class TestNinjaQuoting:
         build_dir = tmp_path / "build"
         generator = NinjaGenerator()
         generator.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Read ninja file
         ninja_content = (build_dir / "build.ninja").read_text()
@@ -474,6 +476,7 @@ class TestCompileCommandsQuoting:
         build_dir = tmp_path / "build"
         generator = CompileCommandsGenerator()
         generator.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Read and parse
         cc_file = build_dir / "compile_commands.json"
@@ -548,6 +551,7 @@ class TestEndToEndSpacesInPaths:
         # Generate and verify ninja
         build_dir = tmp_path / "build"
         NinjaGenerator().generate(project)
+        BaseGenerator._generate_pending(project)
 
         ninja = (build_dir / "build.ninja").read_text()
 

--- a/tests/core/test_command.py
+++ b/tests/core/test_command.py
@@ -9,6 +9,7 @@ from pcons.core.builder import GenericCommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.node import FileNode
 from pcons.core.project import Project
+from pcons.generators.generator import BaseGenerator
 
 
 class TestGenericCommandBuilder:
@@ -242,6 +243,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         # Should have a command rule
@@ -263,6 +265,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "build output.txt:" in content
@@ -284,6 +287,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         # Build statement should list all sources
@@ -304,6 +308,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         # Build statement should list multiple outputs
@@ -322,6 +327,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "process $in" in content
@@ -340,6 +346,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "> $out" in content
@@ -362,6 +369,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "cat $in > $out" in content
@@ -382,6 +390,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "$source_0" in content
@@ -406,6 +415,7 @@ class TestGenericCommandNinja:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "$target_0" in content
@@ -600,6 +610,7 @@ class TestTargetAsSources:
         # Generate and verify ninja output
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
 
@@ -661,6 +672,7 @@ class TestCommandDepends:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "build.ninja").read_text()
         # The dep should appear after | (implicit deps section)

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -6,6 +6,7 @@ import pytest
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 
 
 class TestInstall:
@@ -275,6 +276,7 @@ class TestInstallWithNinja:
         # Generate ninja file
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Read the generated file
         ninja_file = tmp_path / "build" / "build.ninja"

--- a/tests/generators/test_compile_commands.py
+++ b/tests/generators/test_compile_commands.py
@@ -10,6 +10,7 @@ from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
 from pcons.generators.compile_commands import CompileCommandsGenerator
+from pcons.generators.generator import BaseGenerator
 
 
 def normalize_path(p: str) -> str:
@@ -27,6 +28,7 @@ class TestCompileCommandsGenerator:
         gen = CompileCommandsGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output_file = tmp_path / "compile_commands.json"
         assert output_file.exists()
@@ -36,6 +38,7 @@ class TestCompileCommandsGenerator:
         gen = CompileCommandsGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert content == []
@@ -69,6 +72,7 @@ class TestCompileCommandsEntries:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert len(content) == 1
@@ -102,6 +106,7 @@ class TestCompileCommandsEntries:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert len(content) == 1
@@ -125,6 +130,7 @@ class TestCompileCommandsEntries:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert len(content) == 0
@@ -154,6 +160,7 @@ class TestCompileCommandsEntries:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert content[0]["directory"] == str(tmp_path.absolute())
@@ -183,6 +190,7 @@ class TestCompileCommandsEntries:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert "command" in content[0]
@@ -197,6 +205,7 @@ class TestCompileCommandsSymlink:
         gen = CompileCommandsGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         link_path = tmp_path / "compile_commands.json"
         assert link_path.is_symlink()
@@ -209,6 +218,7 @@ class TestCompileCommandsSymlink:
         gen = CompileCommandsGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         link_path = tmp_path / "compile_commands.json"
         target = os.readlink(link_path)
@@ -221,7 +231,9 @@ class TestCompileCommandsSymlink:
         gen = CompileCommandsGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
         gen.generate(project)  # Second call should not fail
+        BaseGenerator._generate_pending(project)
 
         link_path = tmp_path / "compile_commands.json"
         assert link_path.is_symlink()
@@ -236,6 +248,7 @@ class TestCompileCommandsSymlink:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Should not have been replaced
         assert not regular_file.is_symlink()
@@ -251,6 +264,7 @@ class TestCompileCommandsSymlink:
 
         gen = CompileCommandsGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Should have been updated
         target = os.readlink(link_path)
@@ -265,6 +279,7 @@ class TestAutoCompileCommands:
         gen = NinjaGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         assert (tmp_path / "compile_commands.json").exists()
 
@@ -275,6 +290,7 @@ class TestAutoCompileCommands:
         gen = NinjaGenerator()
 
         gen.generate(project, compile_commands=False)
+        BaseGenerator._generate_pending(project)
 
         assert not (tmp_path / "compile_commands.json").exists()
 
@@ -286,3 +302,4 @@ class TestAutoCompileCommands:
 
         # Should not recurse
         gen.generate(project)
+        BaseGenerator._generate_pending(project)

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -2,7 +2,7 @@
 """Tests for pcons.generators.generator."""
 
 from pcons.core.project import Project
-from pcons.generators.generator import BaseGenerator, Generator
+from pcons.generators.generator import BaseGenerator, Generator, MultiGenerator
 
 
 class MockGenerator(BaseGenerator):
@@ -42,3 +42,49 @@ class TestBaseGenerator:
         gen = MockGenerator()
         assert "MockGenerator" in repr(gen)
         assert "mock" in repr(gen)
+
+
+class TestMultiGenerator:
+    def test_name_is_colon_joined(self):
+        a = MockGenerator()
+        b = MockGenerator()
+        multi = MultiGenerator([a, b])
+        assert multi.name == "mock:mock"
+
+    def test_generate_calls_all(self):
+        a = MockGenerator()
+        b = MockGenerator()
+        multi = MultiGenerator([a, b])
+        project = Project("test")
+
+        multi.generate(project)
+
+        assert a.generated
+        assert b.generated
+        assert a.last_project is project
+        assert b.last_project is project
+
+    def test_generate_order(self):
+        call_order: list[str] = []
+
+        class OrderedGen(BaseGenerator):
+            def __init__(self, tag: str) -> None:
+                super().__init__(tag)
+                self._tag = tag
+
+            def generate(self, project: Project) -> None:
+                call_order.append(self._tag)
+
+        multi = MultiGenerator([OrderedGen("first"), OrderedGen("second")])
+        multi.generate(Project("test"))
+
+        assert call_order == ["first", "second"]
+
+    def test_is_generator_protocol(self):
+        multi = MultiGenerator([MockGenerator()])
+        assert isinstance(multi, Generator)
+
+    def test_repr(self):
+        multi = MultiGenerator([MockGenerator(), MockGenerator()])
+        assert "MultiGenerator" in repr(multi)
+        assert "mock:mock" in repr(multi)

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -6,16 +6,30 @@ from pcons.generators.generator import BaseGenerator, Generator, MultiGenerator
 
 
 class MockGenerator(BaseGenerator):
-    """A mock generator for testing."""
+    """Mock that overrides generate() directly — for protocol tests."""
 
     def __init__(self) -> None:
         super().__init__("mock")
         self.generated = False
         self.last_project: Project | None = None
 
-    def generate(self, project: Project) -> None:
+    def generate(self, project: Project) -> None:  # type: ignore[override]
         self.generated = True
         self.last_project = project
+
+    def _generate_impl(self, _project: Project, _output_dir: object) -> None:  # type: ignore[override]
+        pass
+
+
+class DeferredMockGenerator(BaseGenerator):
+    """Mock that uses _generate_impl — for deferred-execution tests."""
+
+    def __init__(self) -> None:
+        super().__init__("mock")
+        self.executed = False
+
+    def _generate_impl(self, _project: Project, _output_dir: object) -> None:  # type: ignore[override]
+        self.executed = True
 
 
 class TestGeneratorProtocol:
@@ -29,7 +43,7 @@ class TestBaseGenerator:
         gen = MockGenerator()
         assert gen.name == "mock"
 
-    def test_generate_called(self, tmp_path):
+    def test_generate_called(self):
         gen = MockGenerator()
         project = Project("test")
 
@@ -42,6 +56,45 @@ class TestBaseGenerator:
         gen = MockGenerator()
         assert "MockGenerator" in repr(gen)
         assert "mock" in repr(gen)
+
+
+class TestDeferredGenerate:
+    def test_generate_defers_execution(self, tmp_path):
+        gen = DeferredMockGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        gen.generate(project)
+
+        assert not gen.executed
+
+    def test_generate_pending_executes(self, tmp_path):
+        gen = DeferredMockGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        assert gen.executed
+
+    def test_generate_pending_clears_queue(self, tmp_path):
+        gen = DeferredMockGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+        gen.executed = False
+        BaseGenerator._generate_pending(project)
+
+        assert not gen.executed
+
+    def test_generate_pending_uses_top_level_when_no_project_arg(self, tmp_path):
+        gen = DeferredMockGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        gen.generate(project)
+        BaseGenerator._generate_pending()  # no arg → resolves top-level project
+
+        assert gen.executed
 
 
 class TestMultiGenerator:
@@ -72,8 +125,11 @@ class TestMultiGenerator:
                 super().__init__(tag)
                 self._tag = tag
 
-            def generate(self, project: Project) -> None:
+            def generate(self, project: Project) -> None:  # type: ignore[override]
                 call_order.append(self._tag)
+
+            def _generate_impl(self, _project: Project, _output_dir: object) -> None:  # type: ignore[override]
+                pass
 
         multi = MultiGenerator([OrderedGen("first"), OrderedGen("second")])
         multi.generate(Project("test"))

--- a/tests/generators/test_generator.py
+++ b/tests/generators/test_generator.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.generators.generator."""
 
+import pytest
+
 from pcons.core.project import Project
 from pcons.generators.generator import BaseGenerator, Generator, MultiGenerator
 
@@ -95,6 +97,38 @@ class TestDeferredGenerate:
         BaseGenerator._generate_pending()  # no arg → resolves top-level project
 
         assert gen.executed
+
+    def test_generate_pending_reraises_on_error(self, tmp_path):
+        class FailingGenerator(BaseGenerator):
+            def __init__(self) -> None:
+                super().__init__("failing")
+
+            def _generate_impl(self, _project: Project, _output_dir: object) -> None:  # type: ignore[override]
+                raise RuntimeError("generation failed")
+
+        gen = FailingGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        gen.generate(project)
+
+        with pytest.raises(RuntimeError, match="generation failed"):
+            BaseGenerator._generate_pending(project)
+
+    def test_generate_pending_prints_to_stderr_on_atexit_error(self, tmp_path, capsys):
+        class FailingGenerator(BaseGenerator):
+            def __init__(self) -> None:
+                super().__init__("failing")
+
+            def _generate_impl(self, _project: Project, _output_dir: object) -> None:  # type: ignore[override]
+                raise RuntimeError("atexit failure")
+
+        gen = FailingGenerator()
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        gen.generate(project)
+
+        with pytest.raises(RuntimeError, match="atexit failure"):
+            BaseGenerator._generate_pending(project, _is_atexit=True)
+
+        assert "atexit failure" in capsys.readouterr().err
 
 
 class TestMultiGenerator:

--- a/tests/generators/test_makefile.py
+++ b/tests/generators/test_makefile.py
@@ -5,6 +5,7 @@ from pcons.core.builder import CommandBuilder
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.makefile import MakefileGenerator
 
 
@@ -23,6 +24,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         makefile = tmp_path / "Makefile"
         assert makefile.exists()
@@ -32,6 +34,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "Makefile").read_text()
         assert "myproject" in content
@@ -41,6 +44,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "out" / "Makefile").read_text()
         # Build dir should be the absolute path
@@ -51,6 +55,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "Makefile").read_text()
         assert ".SUFFIXES:" in content
@@ -61,6 +66,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "Makefile").read_text()
         assert ".PHONY:" in content
@@ -72,6 +78,7 @@ class TestMakefileGenerator:
         gen = MakefileGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "Makefile").read_text()
         assert "clean:" in content
@@ -103,6 +110,7 @@ class TestMakefileBuildStatements:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "Makefile").read_text())
         # Check that a build rule exists for the output
@@ -128,6 +136,7 @@ class TestMakefileBuildStatements:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "Makefile").read_text())
         # Directory rule should exist
@@ -152,6 +161,7 @@ class TestMakefileBuildStatements:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "Makefile").read_text())
         # Order-only prerequisite syntax: target: prereqs | order-only
@@ -172,6 +182,7 @@ class TestMakefileAliases:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "Makefile").read_text()
         assert "all_libs:" in content
@@ -188,6 +199,7 @@ class TestMakefileDefaultTarget:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "Makefile").read_text()
         assert ".DEFAULT_GOAL" in content
@@ -225,6 +237,7 @@ class TestMakefileDepfiles:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "Makefile").read_text()
         # Should include .d files for incremental builds
@@ -256,6 +269,7 @@ class TestMakefileImplicitDeps:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "Makefile").read_text())
         # Implicit dep should be in prerequisites
@@ -300,6 +314,7 @@ class TestMakefilePostBuild:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "Makefile").read_text()
         # Post-build commands should be chained with &&
@@ -324,6 +339,7 @@ class TestMakefileSrcDir:
 
         gen = MakefileGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "Makefile").read_text())
         # $SRCDIR should become the absolute project root path

--- a/tests/generators/test_mermaid.py
+++ b/tests/generators/test_mermaid.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.mermaid import MermaidGenerator
 
 
@@ -38,6 +39,7 @@ class TestMermaidGeneratorGraph:
         gen = MermaidGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         assert "flowchart LR" in output
@@ -59,6 +61,7 @@ class TestMermaidGeneratorGraph:
 
         gen = MermaidGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         assert "build_myapp" in output
@@ -100,6 +103,7 @@ class TestMermaidGeneratorGraph:
 
         gen = MermaidGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         assert "build_libmath_a" in output
@@ -131,6 +135,7 @@ class TestMermaidGeneratorGraph:
 
         gen = MermaidGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         # Static library: rectangle [name]
@@ -151,6 +156,7 @@ class TestMermaidGeneratorDirection:
         project = Project("lr", build_dir=tmp_path)
         gen = MermaidGenerator(direction="LR")
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         assert "flowchart LR" in output
@@ -160,6 +166,7 @@ class TestMermaidGeneratorDirection:
         project = Project("tb", build_dir=tmp_path)
         gen = MermaidGenerator(direction="TB")
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
         assert "flowchart TB" in output
@@ -218,6 +225,7 @@ class TestMermaidGeneratorIntegration:
 
         gen = MermaidGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
 
@@ -262,6 +270,7 @@ class TestMermaidGeneratorIntegration:
 
         gen = MermaidGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         output = (tmp_path / "deps.mmd").read_text()
 

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -6,6 +6,7 @@ import json
 from pcons.core.node import FileNode, Node
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.metadata import MetadataGenerator
 from pcons.util.source_location import SourceLocation
 
@@ -21,6 +22,7 @@ class TestMetadataGenerator:
         gen = MetadataGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         assert gen.name == "metadata"
         assert (tmp_path / "pcons_metadata.json").exists()
@@ -30,6 +32,7 @@ class TestMetadataGenerator:
         gen = MetadataGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "pcons_metadata.json").read_text())
         assert content["schema_version"] == 2
@@ -62,6 +65,7 @@ class TestMetadataGenerator:
 
         gen = MetadataGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
 
@@ -97,6 +101,7 @@ class TestMetadataGenerator:
         app.output_nodes.append(FileNode("build/app"))
 
         MetadataGenerator().generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
         by_name = {t["name"]: t for t in content["projects"][0]["targets"]}
@@ -111,6 +116,7 @@ class TestMetadataGenerator:
             lib.output_nodes.append(FileNode("build/lib/libmylib.a"))
 
         MetadataGenerator().generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
         by_name = {t["name"]: t for t in content["projects"][0]["targets"]}
@@ -123,6 +129,7 @@ class TestMetadataGenerator:
         Project("child", root_dir=tmp_path / "sub")
 
         MetadataGenerator().generate(parent)
+        BaseGenerator._generate_pending(parent)
 
         content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
         assert len(content["projects"]) == 2
@@ -148,6 +155,7 @@ class TestMetadataGenerator:
         )
 
         MetadataGenerator().generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
         by_name = {t["name"]: t for t in content["projects"][0]["targets"]}

--- a/tests/generators/test_ninja.py
+++ b/tests/generators/test_ninja.py
@@ -9,6 +9,7 @@ from pcons.core.builder import CommandBuilder
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.ninja import NinjaGenerator
 
 
@@ -27,6 +28,7 @@ class TestNinjaGenerator:
         gen = NinjaGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         ninja_file = tmp_path / "build.ninja"
         assert ninja_file.exists()
@@ -36,6 +38,7 @@ class TestNinjaGenerator:
         gen = NinjaGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "myproject" in content
@@ -45,6 +48,7 @@ class TestNinjaGenerator:
         gen = NinjaGenerator()
 
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "out" / "build.ninja").read_text()
         # builddir is always "." since the ninja file is inside the build directory
@@ -77,6 +81,7 @@ class TestNinjaBuildStatements:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         assert "build build/app.o:" in content
@@ -104,6 +109,7 @@ class TestNinjaBuildStatements:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "rule cc_cmdline" in content
@@ -123,6 +129,7 @@ class TestNinjaAliases:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         assert "build libs: phony" in content
@@ -142,6 +149,7 @@ class TestNinjaDefaults:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         # Check for 'all' phony target and user-specified default
@@ -194,6 +202,7 @@ class TestNinjaPostBuild:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         # Post-build commands are now baked directly into the rule's command line
@@ -231,6 +240,7 @@ class TestNinjaPostBuild:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         # Post-build commands are baked into the rule's command line
@@ -262,6 +272,7 @@ class TestNinjaPostBuild:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
         # $out and $in are left as literals for ninja to expand at build time
@@ -291,6 +302,7 @@ class TestNinjaPostBuild:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         # Should not have post_build variable
@@ -329,6 +341,7 @@ class TestNinjaDepsDirectives:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "depfile = $out.d" in content
@@ -362,6 +375,7 @@ class TestNinjaDepsDirectives:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         assert "deps = msvc" in content
@@ -391,6 +405,7 @@ class TestNinjaDepsDirectives:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
         # Should not have any deps directives for linker
@@ -415,6 +430,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "build.ninja").read_text()
         # $SRCDIR should become $topdir in the ninja file
@@ -442,6 +458,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "build.ninja").read_text())
         # Both deps should appear after | in the build statement,
@@ -485,6 +502,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "build.ninja").read_text())
         for line in content.splitlines():
@@ -511,6 +529,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "build.ninja").read_text()
         assert "--config=$topdir/my.cfg" in content
@@ -531,6 +550,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "build.ninja").read_text()
         # Find the rule block and verify restat is present
@@ -561,6 +581,7 @@ class TestNinjaSrcDir:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build" / "build.ninja").read_text()
         assert "restat" not in content
@@ -588,6 +609,7 @@ class TestNinjaSrcDir:
         project.resolve()
         ninja_gen = NinjaGenerator()
         ninja_gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build" / "build.ninja").read_text())
         lines = content.splitlines()

--- a/tests/generators/test_ninja_multi_output.py
+++ b/tests/generators/test_ninja_multi_output.py
@@ -7,6 +7,7 @@ from pcons.core.builder import MultiOutputBuilder, OutputSpec
 from pcons.core.node import FileNode
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.ninja import NinjaGenerator
 
 
@@ -82,6 +83,7 @@ class TestNinjaMultiOutput:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
 
@@ -137,6 +139,7 @@ class TestNinjaMultiOutput:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
 
@@ -192,6 +195,7 @@ class TestNinjaMultiOutput:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
 
@@ -239,6 +243,7 @@ class TestNinjaSingleOutput:
 
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = normalize_path((tmp_path / "build.ninja").read_text())
 

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.xcode import XcodeGenerator
 
 
@@ -25,6 +26,7 @@ class TestXcodeGeneratorBasic:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         xcodeproj_path = tmp_path / "myapp.xcodeproj"
         assert xcodeproj_path.exists()
@@ -37,6 +39,7 @@ class TestXcodeGeneratorBasic:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         pbxproj_path = tmp_path / "myapp.xcodeproj" / "project.pbxproj"
         assert pbxproj_path.exists()
@@ -58,6 +61,7 @@ class TestXcodeGeneratorTargets:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "com.apple.product-type.tool" in content
@@ -70,6 +74,7 @@ class TestXcodeGeneratorTargets:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "mylib.xcodeproj" / "project.pbxproj").read_text()
         assert "com.apple.product-type.library.static" in content
@@ -82,6 +87,7 @@ class TestXcodeGeneratorTargets:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "mylib.xcodeproj" / "project.pbxproj").read_text()
         assert "com.apple.product-type.library.dynamic" in content
@@ -94,6 +100,7 @@ class TestXcodeGeneratorTargets:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Interface-only projects don't create .xcodeproj
         xcodeproj_path = tmp_path / "mylib.xcodeproj"
@@ -115,6 +122,7 @@ class TestXcodeGeneratorBuildSettings:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "HEADER_SEARCH_PATHS" in content
@@ -128,6 +136,7 @@ class TestXcodeGeneratorBuildSettings:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "GCC_PREPROCESSOR_DEFINITIONS" in content
@@ -140,6 +149,7 @@ class TestXcodeGeneratorBuildSettings:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "OTHER_CFLAGS" in content
@@ -161,6 +171,7 @@ class TestXcodeGeneratorBuildSettings:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (
             tmp_path / "build" / "myapp.xcodeproj" / "project.pbxproj"
@@ -186,6 +197,7 @@ class TestXcodeGeneratorDependencies:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         # Should have both targets
@@ -205,6 +217,7 @@ class TestXcodeGeneratorDependencies:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         # A PBXBuildFile referencing the library product must exist
@@ -232,6 +245,7 @@ class TestXcodeGeneratorBuildPhases:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "PBXSourcesBuildPhase" in content
@@ -243,6 +257,7 @@ class TestXcodeGeneratorBuildPhases:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "PBXFrameworksBuildPhase" in content
@@ -258,6 +273,7 @@ class TestXcodeGeneratorConfigurations:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "name = Debug" in content
@@ -269,6 +285,7 @@ class TestXcodeGeneratorConfigurations:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "name = Release" in content
@@ -284,6 +301,7 @@ class TestXcodeGeneratorGroups:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "name = Products" in content
@@ -295,6 +313,7 @@ class TestXcodeGeneratorGroups:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
         assert "name = Sources" in content
@@ -317,6 +336,7 @@ class TestXcodeGeneratorMultiTarget:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "multi.xcodeproj" / "project.pbxproj").read_text()
 
@@ -362,6 +382,7 @@ class TestXcodeGeneratorInstall:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "install_test.xcodeproj" / "project.pbxproj").read_text()
 
@@ -400,6 +421,7 @@ class TestXcodeGeneratorInstall:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (
             tmp_path / "install_script.xcodeproj" / "project.pbxproj"
@@ -441,6 +463,7 @@ class TestXcodeGeneratorInstallDir:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (
             tmp_path / "install_dir_test.xcodeproj" / "project.pbxproj"
@@ -491,6 +514,7 @@ class TestXcodeGeneratorArchive:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "archive_test.xcodeproj" / "project.pbxproj").read_text()
 
@@ -534,6 +558,7 @@ class TestXcodeGeneratorArchive:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "zip_test.xcodeproj" / "project.pbxproj").read_text()
 
@@ -580,6 +605,7 @@ class TestXcodeGeneratorInstallDependencies:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "dep_test.xcodeproj" / "project.pbxproj").read_text()
 
@@ -626,6 +652,7 @@ class TestXcodeGeneratorInstallDependencies:
 
         gen = XcodeGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (
             tmp_path / "archive_dep_test.xcodeproj" / "project.pbxproj"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -15,6 +15,7 @@ from pcons import (
     Generator,
     MakefileGenerator,
     MetadataGenerator,
+    MultiGenerator,
     NinjaGenerator,
     get_var,
     get_variant,
@@ -222,6 +223,33 @@ class TestGenerator:
         with pytest.raises(ValueError, match="Unknown generator 'unknown'"):
             Generator()
 
+    def test_generator_multi_via_env(self, monkeypatch) -> None:
+        """Test colon-separated PCONS_GENERATOR returns MultiGenerator."""
+        monkeypatch.setenv("PCONS_GENERATOR", "ninja:metadata")
+        monkeypatch.delenv("GENERATOR", raising=False)
+
+        gen = Generator()
+        assert isinstance(gen, MultiGenerator)
+        assert gen.name == "ninja:metadata"
+        assert isinstance(gen._generators[0], NinjaGenerator)
+        assert isinstance(gen._generators[1], MetadataGenerator)
+
+    def test_generator_multi_invalid_raises(self, monkeypatch) -> None:
+        """Test colon-separated PCONS_GENERATOR raises for unknown name."""
+        monkeypatch.setenv("PCONS_GENERATOR", "ninja:unknown")
+
+        with pytest.raises(ValueError, match="Unknown generator 'unknown'"):
+            Generator()
+
+    def test_generator_single_not_wrapped(self, monkeypatch) -> None:
+        """Test a single-name PCONS_GENERATOR is not wrapped in MultiGenerator."""
+        monkeypatch.setenv("PCONS_GENERATOR", "ninja")
+        monkeypatch.delenv("GENERATOR", raising=False)
+
+        gen = Generator()
+        assert not isinstance(gen, MultiGenerator)
+        assert isinstance(gen, NinjaGenerator)
+
 
 class TestParseVariables:
     """Tests for parse_variables function."""
@@ -351,6 +379,29 @@ class TestRunScriptEnvironment:
         assert os.environ["PCONS_GENERATOR"] == "original-generator"
         assert os.environ["CUSTOM_ENV"] == "original-custom"
         assert "PCONS_VARS" not in os.environ
+
+    def test_run_script_generator_list_joins_with_colon(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """run_script with a list of generators sets PCONS_GENERATOR as colon-joined."""
+        import pcons
+
+        script = tmp_path / "pcons-build.py"
+        script.write_text(
+            "import os\n"
+            "from pcons import Project\n"
+            "val = os.environ.get('PCONS_GENERATOR', '')\n"
+            "assert val == 'ninja:metadata', f'Got {val!r}'\n"
+            "Project('demo')\n"
+        )
+
+        monkeypatch.delenv("PCONS_GENERATOR", raising=False)
+        pcons._cli_vars = None
+
+        exit_code, _ = run_script(
+            script, tmp_path / "build", generator=["ninja", "metadata"]
+        )
+        assert exit_code == 0
 
     def test_run_script_cleans_up_new_environment_keys(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch

--- a/tests/test_user_errors.py
+++ b/tests/test_user_errors.py
@@ -215,9 +215,12 @@ class TestWrongApiOrder:
         Currently silently generates an empty build file. At minimum
         this should log a warning.
         """
+        from pcons.generators.generator import BaseGenerator
+
         project, env = project_env
         # This succeeds but produces a useless empty build file
         project.generate()
+        BaseGenerator._generate_pending(project)
         # Verify it didn't crash -- the question is whether it SHOULD warn
         assert project._resolved
 

--- a/tests/tools/test_archive.py
+++ b/tests/tools/test_archive.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 from pcons.core.project import Project
 from pcons.core.target import Target
+from pcons.generators.generator import BaseGenerator
 from pcons.generators.ninja import NinjaGenerator
 
 
@@ -261,6 +262,7 @@ class TestArchiveNinjaGeneration:
         project.resolve()
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
 
@@ -294,6 +296,7 @@ class TestArchiveNinjaGeneration:
         project.resolve()
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
 
@@ -324,6 +327,7 @@ class TestArchiveNinjaGeneration:
         project.resolve()
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
 
@@ -356,6 +360,7 @@ class TestArchiveNinjaGeneration:
         project.resolve()
         gen = NinjaGenerator()
         gen.generate(project)
+        BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "build.ninja").read_text()
 

--- a/tests/tools/test_external_tool.py
+++ b/tests/tools/test_external_tool.py
@@ -19,6 +19,7 @@ from pcons.core.builder import CommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.project import Project
 from pcons.core.subst import SourcePath, TargetPath
+from pcons.generators.generator import BaseGenerator
 from pcons.tools.tool import BaseTool
 from pcons.tools.toolchain import BaseToolchain
 
@@ -288,6 +289,7 @@ class TestNinjaGeneration:
         # Generate ninja file
         generator = NinjaGenerator()
         generator.generate(project)
+        BaseGenerator._generate_pending(project)
 
         # Check that ninja file was created
         ninja_file = tmp_path / "build.ninja"
@@ -352,6 +354,7 @@ class TestNinjaGeneration:
         # === Step 3: Generate ninja file ===
         generator = NinjaGenerator()
         generator.generate(project)
+        BaseGenerator._generate_pending(project)
 
         ninja_file = build_dir / "build.ninja"
         assert ninja_file.exists(), "build.ninja should be generated"

--- a/uv.lock
+++ b/uv.lock
@@ -227,6 +227,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -614,6 +623,7 @@ dev = [
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -636,6 +646,7 @@ dev = [
     { name = "mypy", specifier = ">=1.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=4.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.4" },
 ]
 
@@ -707,6 +718,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Summary :memo:
This PR aims to allow requesting multiple generators by command-line.

```bash
pcons generate -G ninja -G metadata # Both generators invoked
# or
PCONS_GENERATOR=ninja:metadata pcons generate
```

### Details
1. Add new MultiGenerator class to run multiple generators sequentially.
2. Call to `generator.generate(...)` now only register a "request for generation" that is triggered later, either:
    -  by the CLI, or
    - in a registered `atexit` handler.
3. Update CLI to support list input for generators.
4. Update tests accordingly.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
