### PR TITLE
Fix/gcc mixed mod header tracking

### DIFF
--- a/examples/01_hello_c/pcons-build.py
+++ b/examples/01_hello_c/pcons-build.py
@@ -8,10 +8,14 @@ This example demonstrates:
 - Automatic resolution and generation
 """
 
-from pcons import Project, find_c_toolchain
+from pcons import Project, find_c_toolchain, get_var
 
 project = Project("hello_c")
-env = project.Environment(toolchain=find_c_toolchain())
+if (preferred_toolchain := get_var("TOOLCHAIN")) is not None:
+    preferred_toolchain = [preferred_toolchain]
+else:
+    preferred_toolchain = None
+env = project.Environment(toolchain=find_c_toolchain(prefer=preferred_toolchain))
 
 project.Program("hello", env, sources=["src/hello.c"])
 

--- a/examples/01_hello_c/test.toml
+++ b/examples/01_hello_c/test.toml
@@ -11,6 +11,11 @@ expected_outputs = [
     "build/hello",
 ]
 
+[toolchains]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+windows = ["msvc", "gcc"]
+
 [verify]
 # Run the built program and check output
 # Commands are Unix-style; automatically adapted for Windows

--- a/examples/35_cxx_modules_deps/test.toml
+++ b/examples/35_cxx_modules_deps/test.toml
@@ -13,7 +13,7 @@ expected_outputs = [
 [toolchains]
 linux = ["gcc", "llvm"]
 darwin = ["llvm"]
-windows = ["msvc"]
+windows = ["msvc", "gcc"]
 
 [verify]
 commands = [{ run = "./build/hello", expect_exit_code = 0 }]

--- a/examples/37_cxx_import_std_header_deps/pcons-build.py
+++ b/examples/37_cxx_import_std_header_deps/pcons-build.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Reproducer for missing header-triggered rebuild on regular .cpp in modules mode."""
+
+from pcons import Project, get_var
+from pcons.toolchains import find_c_toolchain
+
+project = Project("cxx_import_std_header_deps")
+
+toolchain_override = get_var("TOOLCHAIN")
+if toolchain_override:
+    toolchain = find_c_toolchain(prefer=[toolchain_override])
+else:
+    toolchain = find_c_toolchain(prefer=["gcc", "llvm", "msvc"])
+
+env = project.Environment(toolchain=toolchain)
+
+if toolchain.name == "msvc":
+    env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
+elif toolchain.name == "llvm":
+    env.cxx.flags.extend(["-std=c++23", "-stdlib=libc++"])
+    env.link.libs.append("c++")
+else:
+    env.cxx.flags.append("-std=c++23")
+
+project.Program(
+    "hello",
+    env,
+    sources=["src/Greet.cppm", "src/main.cpp"],
+)
+
+project.generate()

--- a/examples/37_cxx_import_std_header_deps/src/Greet.cppm
+++ b/examples/37_cxx_import_std_header_deps/src/Greet.cppm
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+export module Greet;
+
+import std;
+
+export auto greet(std::string_view who) -> std::string
+{
+    return std::format("Hello, {}!", who);
+}

--- a/examples/37_cxx_import_std_header_deps/src/local.hpp
+++ b/examples/37_cxx_import_std_header_deps/src/local.hpp
@@ -1,0 +1,6 @@
+#pragma once
+
+inline int local_value()
+{
+    return 7;
+}

--- a/examples/37_cxx_import_std_header_deps/src/main.cpp
+++ b/examples/37_cxx_import_std_header_deps/src/main.cpp
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+#include "local.hpp"
+
+import std;
+import Greet;
+
+int main()
+{
+    std::println("{}", greet("modules"));
+    return local_value() == 7 ? 0 : 1;
+}

--- a/examples/37_cxx_import_std_header_deps/test.toml
+++ b/examples/37_cxx_import_std_header_deps/test.toml
@@ -1,0 +1,34 @@
+# Test configuration for a header-rebuild regression in C++ modules mode
+
+[test]
+description = "Header touch should rebuild regular .cpp object even when modules mode is enabled"
+
+expected_outputs = [
+    "build/obj.hello/src/Greet.cppm.o",
+    "build/obj.hello/src/main.cpp.o",
+    "build/hello",
+]
+
+[toolchains]
+linux = ["gcc"]
+
+[verify]
+commands = [
+    { run = "./build/hello", expect_exit_code = 0 },
+]
+
+[[rebuild]]
+description = "Touching local.hpp rebuilds main.cpp.o and hello"
+touch = "src/local.hpp"
+expect_rebuild = [
+    "obj.hello/src/main.cpp.o",
+    "hello",
+]
+
+[[rebuild]]
+description = "Rebuild should not rebuild anything when nothing changed"
+expect_no_work = true
+
+[skip]
+generators = ["xcode", "make"]
+requires_cxx_std_module = true

--- a/examples/37_cxx_import_std_header_deps/test.toml
+++ b/examples/37_cxx_import_std_header_deps/test.toml
@@ -10,7 +10,10 @@ expected_outputs = [
 ]
 
 [toolchains]
-linux = ["gcc"]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+# GCC on windows (mingw32) does not support 'import std;' yet, so skip it for now
+windows = ["msvc"]
 
 [verify]
 commands = [

--- a/pcons/generators/ninja.py
+++ b/pcons/generators/ninja.py
@@ -189,13 +189,24 @@ class NinjaGenerator(BaseGenerator):
 
         # Resolve the command string
         command_raw = build_info.get("command")
+        extra_command_flags = build_info.get("extra_command_flags") or []
+
         if command_raw is None:
             command = self._expand_command_fallback(node, build_info, env)
         elif isinstance(command_raw, list):
-            relativized_tokens = self._relativize_command_tokens(command_raw)
+            command_tokens = list(command_raw)
+            for flag in extra_command_flags:
+                if flag not in command_tokens:
+                    command_tokens.append(flag)
+            relativized_tokens = self._relativize_command_tokens(
+                cast(list[str], command_tokens)
+            )
             command = to_shell_command(relativized_tokens, shell="ninja")
         else:
             command = command_raw
+            for flag in extra_command_flags:
+                if f" {flag}" not in command:
+                    command = f"{command} {flag}"
 
         # Append post-build commands
         post_build_suffix = self._get_post_build_suffix(node, target)
@@ -206,7 +217,27 @@ class NinjaGenerator(BaseGenerator):
         if custom_rule_name:
             rule_key = custom_rule_name
         else:
-            cmd_hash = hashlib.md5(command.encode()).hexdigest()[:8]
+            # Rule behavior is affected not only by command text but also by
+            # dependency parsing mode/restat. If we dedupe solely by command,
+            # a module object (no depfile/deps) can accidentally share a rule
+            # with a regular C++ object (gcc depfile), dropping headers tracking.
+            depfile = build_info.get("depfile")
+            deps_style = build_info.get("deps_style")
+            restat = bool(build_info.get("restat"))
+
+            dep_sig = "none"
+            if deps_style == "msvc":
+                dep_sig = "msvc"
+            elif deps_style == "gcc":
+                from pcons.core.subst import PathToken
+
+                if isinstance(depfile, PathToken):
+                    dep_sig = f"gcc:{depfile.suffix}"
+                else:
+                    dep_sig = "gcc"
+
+            hash_body = f"{command}\n{dep_sig}\nrestat:{int(restat)}"
+            cmd_hash = hashlib.md5(hash_body.encode()).hexdigest()[:8]
             rule_key = f"{tool_name}_{command_var}_{cmd_hash}"
 
         return rule_key, command

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -614,10 +614,11 @@ class GccToolchain(UnixToolchain):
         cxx_tool = getattr(first_env, "cxx", None) if first_env else None
         compiler_cmd = str(getattr(cxx_tool, "cmd", "g++") or "g++")
         base_flags = list(getattr(cxx_tool, "flags", None) or [])
+        module_src_paths = {src for src, _ in cxx_module_pairs}
 
         # Enable modules for all participating C++ TUs.
         modules_flag = "-fmodules"
-        for _, obj_node in all_cxx_pairs:
+        for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             if bi is None:
                 continue
@@ -625,16 +626,15 @@ class GccToolchain(UnixToolchain):
             if context is not None and hasattr(context, "flags"):
                 if modules_flag not in context.flags:
                     context.flags.append(modules_flag)
-            # Let dyndep drive module dependencies for these TUs. GCC depfiles
-            # conflict with module implicit outputs on Ninja for these edges.
-            bi["deps_style"] = None
-            bi["depfile"] = None
+            # Keep header depfiles for regular C++ TUs. For module interfaces,
+            # let dyndep drive module dependencies to avoid depfile conflicts.
+            if src in module_src_paths:
+                bi["deps_style"] = None
+                bi["depfile"] = None
 
         # Build per-TU scan specs and run GCC p1689 scanning.
         specs: list[TuScanSpec] = []
         spec_to_obj: dict[int, FileNode] = {}
-        module_src_paths = {src for src, _ in cxx_module_pairs}
-
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
@@ -731,10 +731,14 @@ class GccToolchain(UnixToolchain):
         logger.debug("Wrote GCC C++ module dyndep to %s", dyndep_path)
 
         dyndep_node = project.node(dyndep_path)
-        for _, obj_node in all_cxx_pairs:
+        for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             if bi is not None:
                 bi["dyndep"] = dyndep_rel
+                if src not in module_src_paths:
+                    extra = bi.setdefault("extra_command_flags", [])
+                    if "-Mno-modules" not in extra:
+                        extra.append("-Mno-modules")
             if dyndep_node not in obj_node.implicit_deps:
                 obj_node.implicit_deps.append(dyndep_node)
         for std_obj_node in std_obj_nodes.values():

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -503,13 +503,25 @@ def _build_scan_node(
         if not rel_src.startswith("../") and not rel_src.startswith("./"):
             rel_src = f"$topdir/{rel_src}"
 
-    # Build scan command
-    scan_cmd = (
-        # generate the depfile
-        f"{compiler_cmd} -MM -MT {scan_rel} -MF {depfile_rel} "
-        + " ".join(normalized_flags)
-        + f" {rel_src} && touch {scan_rel}"
-    )
+    # Build scan command — two steps: generate depfile, then create stamp file.
+    # On Windows, Ninja spawns processes via CreateProcess without a shell, so
+    # && and touch are not available.  Wrap with cmd /c and use "type nul >"
+    # as the cross-platform stamp-creation equivalent.
+    platform_info = get_platform()
+    flags_str = " ".join(normalized_flags)
+    if platform_info.is_windows:
+        # Back-slash the stamp path for cmd.exe
+        scan_rel_win = scan_rel.replace("/", "\\")
+        scan_cmd = (
+            f'cmd /c "{compiler_cmd} -MM -MT {scan_rel} -MF {depfile_rel}'
+            f" {flags_str} {rel_src}"
+            f' && type nul > {scan_rel_win}"'
+        )
+    else:
+        scan_cmd = (
+            f"{compiler_cmd} -MM -MT {scan_rel} -MF {depfile_rel}"
+            f" {flags_str} {rel_src} && touch {scan_rel}"
+        )
 
     from pcons.core.node import BuildInfo
 

--- a/tests/generators/test_ninja.py
+++ b/tests/generators/test_ninja.py
@@ -310,6 +310,71 @@ class TestNinjaPostBuild:
 
 
 class TestNinjaDepsDirectives:
+    def test_same_command_but_different_dep_modes_use_distinct_rules(self, tmp_path):
+        """Commands with the same command line but different deps_style should get different rules with correct deps directives."""
+        project = Project("test", root_dir=tmp_path, build_dir=".")
+
+        from pcons.core.subst import PathToken, TargetPath
+
+        target = Target("app")
+
+        module_obj = FileNode("build/mod.cppm.o")
+        module_src = FileNode("src/mod.cppm")
+        module_obj._build_info = {
+            "tool": "cxx",
+            "command_var": "objcmd",
+            "language": "cxx_module",
+            "sources": [module_src],
+            "command": "g++ -c -o $out $in",
+            "depfile": None,
+            "deps_style": None,
+        }
+        module_obj.builder = CommandBuilder(
+            "Object",
+            "cxx",
+            "objcmd",
+            src_suffixes=[".cppm"],
+            target_suffixes=[".o"],
+        )
+
+        regular_obj = FileNode("build/main.cpp.o")
+        regular_src = FileNode("src/main.cpp")
+        regular_obj._build_info = {
+            "tool": "cxx",
+            "command_var": "objcmd",
+            "language": "cxx",
+            "sources": [regular_src],
+            "command": "g++ -c -o $out $in",
+            "depfile": PathToken(
+                path="build/main.cpp.o", path_type="build", suffix=".d"
+            ),
+            "deps_style": "gcc",
+        }
+        regular_obj.builder = CommandBuilder(
+            "Object",
+            "cxx",
+            "objcmd",
+            src_suffixes=[".cpp"],
+            target_suffixes=[".o"],
+            depfile=TargetPath(suffix=".d"),
+            deps_style="gcc",
+        )
+
+        target.intermediate_nodes.extend([module_obj, regular_obj])
+
+        gen = NinjaGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "build.ninja").read_text()
+
+        rule_headers = [
+            line for line in content.splitlines() if line.startswith("rule cxx_objcmd_")
+        ]
+        assert len(rule_headers) == 2, content
+        assert "depfile = $out.d" in content
+        assert "deps = gcc" in content
+
     def test_gcc_deps_style_emits_depfile_and_deps(self, tmp_path):
         project = Project("test", root_dir=tmp_path, build_dir=".")
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -50,12 +50,12 @@ def _find_ninja() -> list[str] | None:
 GENERATORS = ["ninja", "make", "xcode"]
 
 
-def adapt_path_for_windows(path: str) -> str:
+def adapt_path_for_windows(path: str, gcc_toolchain: bool = False) -> str:
     """Adapt a Unix-style path for Windows.
 
     Converts:
         ./build/program -> build\\program.exe
-        build/file.o -> build\\file.obj
+        build/file.o -> build\\file.obj (not with gcc_toolchain==True, as GCC on Windows still uses .o)
         build/libfoo.a -> build\\foo.lib
         build/libfoo.so -> build\\foo.dll
         build/program (no extension) -> build\\program.exe
@@ -68,7 +68,7 @@ def adapt_path_for_windows(path: str) -> str:
         path = path[2:]
 
     # Convert extensions
-    if path.endswith(".o"):
+    if path.endswith(".o") and not gcc_toolchain:
         path = path[:-2] + ".obj"
     elif path.endswith(".a"):
         # Convert libfoo.a to foo.lib
@@ -480,6 +480,7 @@ def get_platform_value(
     key: str,
     default: Any = None,
     adapt_for_windows: bool = False,
+    gcc_toolchain: bool = False,
 ) -> Any:
     """Get a platform-specific value from config.
 
@@ -495,7 +496,7 @@ def get_platform_value(
         default: Default value if key not found
         adapt_for_windows: If True and on Windows without a platform-specific
             override, automatically adapt Unix paths/commands
-
+        gcc_toolchain: If True and using GCC toolchain, apply GCC-specific adaptations
     Returns the platform-specific value if available, otherwise the base value.
     """
     current_platform = platform.system().lower()
@@ -511,9 +512,12 @@ def get_platform_value(
     # Optionally adapt for Windows when no override exists
     if adapt_for_windows and IS_WINDOWS and value is not None:
         if isinstance(value, list):
-            return [adapt_path_for_windows(str(v)) for v in value]
+            return [
+                adapt_path_for_windows(str(v), gcc_toolchain=gcc_toolchain)
+                for v in value
+            ]
         elif isinstance(value, str):
-            return adapt_path_for_windows(value)
+            return adapt_path_for_windows(value, gcc_toolchain=gcc_toolchain)
 
     return value
 
@@ -786,7 +790,11 @@ def run_example(
 
     # Check expected outputs exist (auto-adapts for Windows if no override)
     expected_outputs = get_platform_value(
-        test_config, "expected_outputs", [], adapt_for_windows=True
+        test_config,
+        "expected_outputs",
+        [],
+        adapt_for_windows=True,
+        gcc_toolchain=toolchain == "gcc",
     )
     # Adapt expected outputs for the generator being used
     # For xcode, get project name from any generated .xcodeproj

--- a/tests/toolchains/test_gcc.py
+++ b/tests/toolchains/test_gcc.py
@@ -2,10 +2,14 @@
 """Tests for pcons.toolchains.gcc."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from pcons.configure.platform import Platform
+from pcons.core.node import FileNode
+from pcons.core.project import Project
+from pcons.core.subst import PathToken
 from pcons.toolchains.gcc import (
     GccArchiver,
     GccCCompiler,
@@ -318,7 +322,70 @@ class TestGccModuleInterfaceSourceHandler:
         assert handler.language == "cxx_module"
         assert handler.object_suffix == ".o"
         assert handler.depfile == TargetPath(suffix=".d")
-        assert handler.deps_style == "gcc"
+
+
+class TestGccModulesDepsTracking:
+    def test_after_resolve_keeps_depfile_for_non_module_cpp(self, tmp_path, monkeypatch):
+        """Non-module C++ TUs must keep depfile/deps_style for #include tracking."""
+        tc = GccToolchain()
+        project = Project("test", root_dir=tmp_path, build_dir="build")
+
+        env = SimpleNamespace(
+            cxx=SimpleNamespace(cmd="g++", flags=[]),
+            register_node=lambda _node: None,
+        )
+
+        cxx_obj = FileNode("build/obj/main.cpp.o")
+        cxx_obj._build_info = {
+            "env": env,
+            "context": SimpleNamespace(flags=[], includes=[], defines=[]),
+            "depfile": PathToken(path="build/obj/main.cpp.o", path_type="build", suffix=".d"),
+            "deps_style": "gcc",
+        }
+
+        source_obj_by_language = {
+            "cxx": [(tmp_path / "src" / "main.cpp", cxx_obj)],
+        }
+
+        def fake_select_modules_scope(_source_obj_by_language):
+            # Simulate modules mode where regular C++ TUs are processed even without
+            # an explicit module-interface unit in this particular list.
+            return ([], source_obj_by_language["cxx"])
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.select_modules_scope",
+            fake_select_modules_scope,
+        )
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.scan_translation_units",
+            lambda specs, scanner, scanner_style: [
+                SimpleNamespace(
+                    required_logical_names=set(),
+                    is_module_provider=False,
+                )
+                for _ in specs
+            ],
+        )
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.build_module_map",
+            lambda _results, _mod_dir, _ext: {},
+        )
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.write_dyndep_from_results",
+            lambda _results, _module_map, _out: None,
+        )
+        monkeypatch.setattr(
+            tc,
+            "_inject_gcc_std_module_builds",
+            lambda *_args, **_kwargs: {},
+        )
+
+        tc.after_resolve(project, source_obj_by_language)
+
+        build_info = cxx_obj._build_info
+        assert build_info is not None
+        assert build_info["depfile"] is not None
+        assert build_info["deps_style"] == "gcc"
 
     def test_regular_cpp_not_cxx_module(self) -> None:
         tc = GccToolchain()

--- a/tests/toolchains/test_gcc.py
+++ b/tests/toolchains/test_gcc.py
@@ -325,7 +325,9 @@ class TestGccModuleInterfaceSourceHandler:
 
 
 class TestGccModulesDepsTracking:
-    def test_after_resolve_keeps_depfile_for_non_module_cpp(self, tmp_path, monkeypatch):
+    def test_after_resolve_keeps_depfile_for_non_module_cpp(
+        self, tmp_path, monkeypatch
+    ):
         """Non-module C++ TUs must keep depfile/deps_style for #include tracking."""
         tc = GccToolchain()
         project = Project("test", root_dir=tmp_path, build_dir="build")
@@ -339,7 +341,9 @@ class TestGccModulesDepsTracking:
         cxx_obj._build_info = {
             "env": env,
             "context": SimpleNamespace(flags=[], includes=[], defines=[]),
-            "depfile": PathToken(path="build/obj/main.cpp.o", path_type="build", suffix=".d"),
+            "depfile": PathToken(
+                path="build/obj/main.cpp.o", path_type="build", suffix=".d"
+            ),
             "deps_style": "gcc",
         }
 


### PR DESCRIPTION
### Summary :memo:
Fixes a bug where `#include`d header changes did not trigger rebuilds for regular `.cpp` files in targets that also contain C++ module interfaces (`.cppm`). Also removes compiler-specific knowledge from the Ninja generator by moving GCC flag decisions into the GCC toolchain.

### Details
1. **`gcc.py`** - `after_resolve` now only clears `depfile`/`deps_style` for actual module interface files (those in `module_src_paths`). Regular `.cpp` TUs keep their GCC `-MD` header tracking. Additionally, when the dyndep file is assigned, regular C++ TUs receive `extra_command_flags = ["-Mno-modules"]` so GCC's depfile output stays clean when `-fmodules` is active.
2. **`ninja.py`** - Removed the `auto_extra_flags` block that injected `-Mno-modules` by inspecting tool name, dep style, dyndep presence, and source file suffixes. The generator now simply appends whatever `extra_command_flags` the build info already carries - no compiler-specific knowledge required.
3. **`ninja.py` rule hashing** - The rule key hash now includes `deps_style`, `depfile` suffix, and `restat` in addition to command text. This prevents two nodes with identical compile commands but different dep modes (e.g. a module interface and a regular `.cpp`) from sharing a Ninja rule and silently losing `depfile`/`deps = gcc` directives.
4. **New example** (`examples/37_cxx_import_std_header_deps`) - Reproducer and regression test: a target mixing a `.cppm` module interface and a regular `.cpp` that `#include`s a local header. The test verifies that touching the header triggers a rebuild of the `.cpp` object.
5. **New unit tests** - `test_gcc.py` verifies depfile is preserved for non-module TUs after `after_resolve`, `test_ninja.py` verifies identical commands with different dep modes produce distinct rules.

### Bugfixes :bug:
- Regular `.cpp` files in a C++ modules target no longer lose header-triggered rebuilds (`#include` changes go undetected).
- Ninja rule deduplication no longer silently drops `depfile`/`deps = gcc` when a module object shares a command hash with a regular object.


### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
