### PR TITLE
Fix compile_commands generator to collect environment flags

### DIFF
--- a/pcons/generators/compile_commands.py
+++ b/pcons/generators/compile_commands.py
@@ -224,6 +224,7 @@ class CompileCommandsGenerator(BaseGenerator):
 
         # Get the actual compiler command from the environment
         tool_cmd = tool_name
+        flags = []
         if build_info:
             env = build_info.get("env")
             if env is not None:
@@ -232,13 +233,17 @@ class CompileCommandsGenerator(BaseGenerator):
                     cmd = getattr(tool_config, "cmd", None)
                     if cmd:
                         tool_cmd = str(cmd)
+                    if hasattr(tool_config, "flags"):
+                        # Collect flags
+                        flags.extend(str(f) for f in tool_config.flags)
+
         # Fallback to generic names if no env available
         if tool_cmd == "cc":
             tool_cmd = "cc"
         elif tool_cmd == "cxx":
             tool_cmd = "c++"
 
-        parts: list[str] = [tool_cmd, "-c"]
+        parts: list[str] = [tool_cmd, "-c", *flags]
 
         # Add effective requirements from context
         if build_info:


### PR DESCRIPTION
### Summary :memo:
Currently "compile_commands" generator does not include environment's flags, this PR fixes it.

### Details
1. Collect tool_config.flags in "compile_commands" generator and add it the the generated command.

### Bugfixes :bug:
- Environment flags not present in generated compile_commands.json

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
