### PR TITLE
Feature/install out of build directory

### DIFF
--- a/examples/01_hello_c/pcons-build.py
+++ b/examples/01_hello_c/pcons-build.py
@@ -17,6 +17,15 @@ else:
     preferred_toolchain = None
 env = project.Environment(toolchain=find_c_toolchain(prefer=preferred_toolchain))
 
-project.Program("hello", env, sources=["src/hello.c"])
+hello = project.Program("hello", env, sources=["src/hello.c"])
+
+# Install target: copy binary to $PCONS_INSTALL_PREFIX/bin directory
+bins = project.Install("bin", [hello])
+
+# Resolve so output_nodes are populated for Alias
+project.resolve()
+
+# Create alias after resolve() so output_nodes are populated
+project.Alias("install", bins)
 
 project.generate()

--- a/examples/01_hello_c/pcons-build.py
+++ b/examples/01_hello_c/pcons-build.py
@@ -11,7 +11,7 @@ This example demonstrates:
 from pcons import Project, find_c_toolchain, get_var
 
 project = Project("hello_c")
-if (preferred_toolchain := get_var("TOOLCHAIN")) is not None:
+if (preferred_toolchain := get_var("TOOLCHAIN", None)) is not None:
     preferred_toolchain = [preferred_toolchain]
 else:
     preferred_toolchain = None
@@ -20,7 +20,7 @@ env = project.Environment(toolchain=find_c_toolchain(prefer=preferred_toolchain)
 hello = project.Program("hello", env, sources=["src/hello.c"])
 
 # Install target: copy binary to $PCONS_INSTALL_PREFIX/bin directory
-bins = project.Install("bin", [hello])
+bins = project.Install(get_var("BINARY_INSTALL_DIR"), [hello], name="install-hello")
 
 # Resolve so output_nodes are populated for Alias
 project.resolve()

--- a/examples/01_hello_c/pcons-build.py
+++ b/examples/01_hello_c/pcons-build.py
@@ -8,7 +8,7 @@ This example demonstrates:
 - Automatic resolution and generation
 """
 
-from pcons import Project, find_c_toolchain, get_var
+from pcons import Project, find_c_toolchain, get_var, install_dir
 
 project = Project("hello_c")
 if (preferred_toolchain := get_var("TOOLCHAIN", None)) is not None:
@@ -19,8 +19,9 @@ env = project.Environment(toolchain=find_c_toolchain(prefer=preferred_toolchain)
 
 hello = project.Program("hello", env, sources=["src/hello.c"])
 
-# Install target: copy binary to $PCONS_INSTALL_PREFIX/bin directory
-bins = project.Install(get_var("BINARY_INSTALL_DIR"), [hello], name="install-hello")
+# Install target: copy binary to $PCONS_INSTALL_PREFIX/bin directory.
+# install_dir() picks the conventional subdir ("bin") from the toolchain.
+bins = project.Install(install_dir(env, "program"), [hello], name="install-hello")
 
 # Create alias after resolve() so output_nodes are populated
 project.Alias("install", bins)

--- a/examples/01_hello_c/pcons-build.py
+++ b/examples/01_hello_c/pcons-build.py
@@ -22,9 +22,6 @@ hello = project.Program("hello", env, sources=["src/hello.c"])
 # Install target: copy binary to $PCONS_INSTALL_PREFIX/bin directory
 bins = project.Install(get_var("BINARY_INSTALL_DIR"), [hello], name="install-hello")
 
-# Resolve so output_nodes are populated for Alias
-project.resolve()
-
 # Create alias after resolve() so output_nodes are populated
 project.Alias("install", bins)
 

--- a/examples/01_hello_c/test.toml
+++ b/examples/01_hello_c/test.toml
@@ -11,6 +11,10 @@ expected_outputs = [
     "build/hello",
 ]
 
+expected_install_outputs = [
+    "bin/hello",
+]
+
 [toolchains]
 linux = ["gcc", "llvm"]
 darwin = ["llvm"]

--- a/examples/01_hello_c/test.toml
+++ b/examples/01_hello_c/test.toml
@@ -12,7 +12,7 @@ expected_outputs = [
 ]
 
 expected_install_outputs = [
-    "bin/hello",
+    "${BINARY_INSTALL_DIR}/hello",
 ]
 
 [toolchains]

--- a/examples/01_hello_c/test.toml
+++ b/examples/01_hello_c/test.toml
@@ -12,7 +12,7 @@ expected_outputs = [
 ]
 
 expected_install_outputs = [
-    "${BINARY_INSTALL_DIR}/hello",
+    "${BINARY_INSTALL_DIR}/hello${BINARY_EXT}",
 ]
 
 [toolchains]

--- a/examples/06_archive_install/.gitignore
+++ b/examples/06_archive_install/.gitignore
@@ -1,0 +1,1 @@
+Installers/

--- a/examples/06_archive_install/pcons-build.py
+++ b/examples/06_archive_install/pcons-build.py
@@ -45,7 +45,6 @@ project.Default(hello)
 # --- Installer targets (not built by default) ---
 
 # Tarball of source files and headers
-# Note: output paths are relative to build_dir (consistent with Install, InstallDir)
 src_tarball = project.Tarfile(
     env,
     output="hello-src.tar.gz",
@@ -62,7 +61,9 @@ bin_tarball = project.Tarfile(
 )
 
 # Install target: copy tarballs to ./Installers directory
-install_target = project.Install("Installers", [src_tarball, bin_tarball])
+install_target = project.Install(
+    project.root_dir / "Installers", [src_tarball, bin_tarball]
+)
 
 # Resolve so output_nodes are populated for Alias
 project.resolve()

--- a/examples/06_archive_install/pcons-build.py
+++ b/examples/06_archive_install/pcons-build.py
@@ -62,7 +62,9 @@ bin_tarball = project.Tarfile(
 
 # Install target: copy tarballs to ./Installers directory
 install_target = project.Install(
-    project.root_dir / "Installers", [src_tarball, bin_tarball]
+    project.root_dir / "Installers",
+    [src_tarball, bin_tarball],
+    name="install-tarballs",
 )
 
 # Resolve so output_nodes are populated for Alias

--- a/examples/06_archive_install/pcons-build.py
+++ b/examples/06_archive_install/pcons-build.py
@@ -67,9 +67,6 @@ install_target = project.Install(
     name="install-tarballs",
 )
 
-# Resolve so output_nodes are populated for Alias
-project.resolve()
-
 # Create alias after resolve() so output_nodes are populated
 project.Alias("install", install_target)
 

--- a/examples/06_archive_install/test.toml
+++ b/examples/06_archive_install/test.toml
@@ -15,9 +15,9 @@ commands = [
     { run = "./build/hello", expect_stdout = "Hello from pcons!" },
     # Test the install alias - builds tarballs and copies to Installers/
     { run = "ninja -C build install" },
-    # Verify the installed tarballs exist (inside build dir since ninja -C build)
-    { run = "test -f build/Installers/hello-src.tar.gz" },
-    { run = "test -f build/Installers/hello-bin.tar.gz" },
+    # Verify the installed tarballs exist (inside ./Installers directory)
+    { run = "test -f Installers/hello-src.tar.gz" },
+    { run = "test -f Installers/hello-bin.tar.gz" },
 ]
 
 [skip]

--- a/examples/07_conan_example/pcons-build.py
+++ b/examples/07_conan_example/pcons-build.py
@@ -102,8 +102,6 @@ project.Default(hello)
 # Generate build files
 # =============================================================================
 
-project.resolve()
-
 Generator().generate(project)
 
 print(f"Generated {build_dir}")

--- a/examples/09_makefile/pcons-build.py
+++ b/examples/09_makefile/pcons-build.py
@@ -27,9 +27,6 @@ hello = project.Program("hello", env)
 hello.add_sources([src_dir / "hello.c"])
 hello.private.compile_flags.extend(["-Wall", "-Wextra"])
 
-# Resolve targets (computes effective requirements, creates nodes)
-project.resolve()
-
 # Generate Makefile (instead of Ninja)
 generator = MakefileGenerator()
 generator.generate(project)

--- a/examples/14_install_dir/pcons-build.py
+++ b/examples/14_install_dir/pcons-build.py
@@ -25,7 +25,11 @@ build_dir = project.build_dir
 
 # Install the assets directory to the build output
 # This copies the entire 'assets' directory tree to 'PCONS_INSTALL_PREFIX/assets'
-installed_assets = project.InstallDir(".", src_dir / "assets")
+installed_assets = project.InstallDir(
+    ".",
+    src_dir / "assets",
+    name="install-assets",
+)
 
 # Set as default target
 project.Default(installed_assets)

--- a/examples/14_install_dir/pcons-build.py
+++ b/examples/14_install_dir/pcons-build.py
@@ -34,9 +34,6 @@ installed_assets = project.InstallDir(
 # Set as default target
 project.Default(installed_assets)
 
-# Resolve so output_nodes are populated for Alias
-project.resolve()
-
 # Create alias after resolve() so output_nodes are populated
 project.Alias("install", installed_assets)
 

--- a/examples/14_install_dir/pcons-build.py
+++ b/examples/14_install_dir/pcons-build.py
@@ -24,12 +24,17 @@ src_dir = project.root_dir
 build_dir = project.build_dir
 
 # Install the assets directory to the build output
-# This copies the entire 'assets' directory tree to 'build/dist/assets'
-# Note: destination is relative to build_dir, so "dist" becomes "build/dist"
-installed_assets = project.InstallDir("dist", src_dir / "assets")
+# This copies the entire 'assets' directory tree to 'PCONS_INSTALL_PREFIX/assets'
+installed_assets = project.InstallDir(".", src_dir / "assets")
 
 # Set as default target
 project.Default(installed_assets)
+
+# Resolve so output_nodes are populated for Alias
+project.resolve()
+
+# Create alias after resolve() so output_nodes are populated
+project.Alias("install", installed_assets)
 
 project.generate()
 

--- a/examples/14_install_dir/test.toml
+++ b/examples/14_install_dir/test.toml
@@ -6,17 +6,13 @@ description = "InstallDir for recursive directory copying"
 
 # The stamp file is in .stamps/; actual files are in the directory
 expected_outputs = [
-    "build/.stamps/dist_assets.stamp",
+    "build/.stamps/_*_assets.stamp",
 ]
 
-[verify]
-# Verify the copied files exist and have correct content
-commands = [
-    { run = "test -f build/dist/assets/data.txt" },
-    { run = "test -f build/dist/assets/config.json" },
-    { run = "test -f build/dist/assets/subdir/nested.txt" },
-    { run = "cat build/dist/assets/data.txt", expect_stdout = "Sample data file" },
-    { run = "cat build/dist/assets/subdir/nested.txt", expect_stdout = "subdirectory" },
+expected_install_outputs = [
+    ["assets/data.txt", "Sample data file"],
+    "assets/config.json",
+    ["assets/subdir/nested.txt", "subdirectory"],
 ]
 
 [skip]
@@ -35,4 +31,4 @@ expect_no_work = true
 [[rebuild]]
 description = "Touching a source file triggers reinstall"
 touch = "assets/data.txt"
-expect_rebuild = [".stamps/dist_assets.stamp"]
+expect_rebuild = [".stamps/_*_assets.stamp"]

--- a/examples/17_object_sources/pcons-build.py
+++ b/examples/17_object_sources/pcons-build.py
@@ -49,7 +49,7 @@ prog.add_sources(
     ]
 )
 
-# Resolve to inspect resolved state
+# Resolve to inspect resolved state (debug purposes only)
 project.resolve()
 
 # Check what happened

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -12,7 +12,7 @@ Expected: core.h is found via public include propagation,
 and core_value() from static lib is available in shared lib.
 """
 
-from pcons import Project, find_c_toolchain, get_var
+from pcons import Project, find_c_toolchain, install_dir
 
 # Create project
 project = Project("static_into_shared")
@@ -36,18 +36,21 @@ wrapper_lib.link(core_lib)
 prog = project.Program("demo", env, sources=[src_dir / "main.c"])
 prog.link(wrapper_lib)
 
+# install_dir() resolves the conventional subdir from the env's toolchain:
+# shared libs land in "lib" (or "bin" on DLL platforms), archives in "lib",
+# programs in "bin".
 installed_libs = project.Install(
-    get_var("LIBRARY_INSTALL_DIR"),
+    install_dir(env, "shared_library"),
     [wrapper_lib],
     name="install-libraries",
 )
 installed_archives = project.Install(
-    get_var("ARCHIVE_INSTALL_DIR"),
+    install_dir(env, "static_library"),
     [core_lib],
     name="install-archives",
 )
 installed_bins = project.Install(
-    get_var("BINARY_INSTALL_DIR"),
+    install_dir(env, "program"),
     [prog],
     name="install-binaries",
 )

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -36,8 +36,13 @@ wrapper_lib.link(core_lib)
 prog = project.Program("demo", env, sources=[src_dir / "main.c"])
 prog.link(wrapper_lib)
 
+installed_libs = project.Install("lib", [core_lib, wrapper_lib])
+installed_bins = project.Install("bin", [prog])
+
 # Resolve to inspect resolved state
 project.resolve()
+
+project.Alias("install", [installed_libs, installed_bins])
 
 # Debug output
 print(f"core_lib output_nodes: {core_lib.output_nodes}")

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -12,7 +12,7 @@ Expected: core.h is found via public include propagation,
 and core_value() from static lib is available in shared lib.
 """
 
-from pcons import Project, find_c_toolchain
+from pcons import Project, find_c_toolchain, get_var
 
 # Create project
 project = Project("static_into_shared")
@@ -36,13 +36,26 @@ wrapper_lib.link(core_lib)
 prog = project.Program("demo", env, sources=[src_dir / "main.c"])
 prog.link(wrapper_lib)
 
-installed_libs = project.Install("lib", [core_lib, wrapper_lib])
-installed_bins = project.Install("bin", [prog])
+installed_libs = project.Install(
+    get_var("LIBRARY_INSTALL_DIR"),
+    [wrapper_lib],
+    name="install-libraries",
+)
+installed_archives = project.Install(
+    get_var("ARCHIVE_INSTALL_DIR"),
+    [core_lib],
+    name="install-archives",
+)
+installed_bins = project.Install(
+    get_var("BINARY_INSTALL_DIR"),
+    [prog],
+    name="install-binaries",
+)
 
 # Resolve to inspect resolved state
 project.resolve()
 
-project.Alias("install", [installed_libs, installed_bins])
+project.Alias("install", [installed_libs, installed_archives, installed_bins])
 
 # Debug output
 print(f"core_lib output_nodes: {core_lib.output_nodes}")

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -52,10 +52,10 @@ installed_bins = project.Install(
     name="install-binaries",
 )
 
-# Resolve to inspect resolved state
-project.resolve()
-
 project.Alias("install", [installed_libs, installed_archives, installed_bins])
+
+# Resolve to inspect resolved state (debug purposes only)
+project.resolve()
 
 # Debug output
 print(f"core_lib output_nodes: {core_lib.output_nodes}")

--- a/examples/18_static_into_shared/test.toml
+++ b/examples/18_static_into_shared/test.toml
@@ -11,9 +11,9 @@ expected_outputs = [
 
 # Files that should exist after install
 expected_install_outputs = [
-    "bin/demo",
-    "lib/libcore.a",
-    "lib/libwrapper.so",
+    "${BINARY_INSTALL_DIR}/demo",
+    "${ARCHIVE_INSTALL_DIR}/libcore.a",
+    "${LIBRARY_INSTALL_DIR}/libwrapper.so",
 ]
 
 [verify]

--- a/examples/18_static_into_shared/test.toml
+++ b/examples/18_static_into_shared/test.toml
@@ -6,14 +6,14 @@ description = "Tests linking a static library into a shared library"
 
 # Files that should exist after the build
 expected_outputs = [
-    "build/demo",
+    "build/demo${BINARY_EXT}",
 ]
 
 # Files that should exist after install
 expected_install_outputs = [
-    "${BINARY_INSTALL_DIR}/demo",
-    "${ARCHIVE_INSTALL_DIR}/libcore.a",
-    "${LIBRARY_INSTALL_DIR}/libwrapper.so",
+    "${BINARY_INSTALL_DIR}/demo${BINARY_EXT}",
+    "${ARCHIVE_INSTALL_DIR}/${LIBRARY_PREFIX}core${ARCHIVE_EXT}",
+    "${LIBRARY_INSTALL_DIR}/${LIBRARY_PREFIX}wrapper${LIBRARY_EXT}",
 ]
 
 [verify]

--- a/examples/18_static_into_shared/test.toml
+++ b/examples/18_static_into_shared/test.toml
@@ -9,6 +9,13 @@ expected_outputs = [
     "build/demo",
 ]
 
+# Files that should exist after install
+expected_install_outputs = [
+    "bin/demo",
+    "lib/libcore.a",
+    "lib/libwrapper.so",
+]
+
 [verify]
 # Run the built program and check output
 # core_value() returns 42, wrapper multiplies by 2 = 84

--- a/examples/32_cxx_import_std/pcons-build.py
+++ b/examples/32_cxx_import_std/pcons-build.py
@@ -24,7 +24,7 @@ from pcons.toolchains import find_c_toolchain
 project = Project("cxx_import_std")
 
 # Optional override: pcons build TOOLCHAIN=gcc|llvm|msvc
-toolchain_override = get_var("TOOLCHAIN")
+toolchain_override = get_var("TOOLCHAIN", None)
 if toolchain_override:
     toolchain = find_c_toolchain(prefer=[toolchain_override])
 else:

--- a/examples/35_cxx_modules_deps/pcons-build.py
+++ b/examples/35_cxx_modules_deps/pcons-build.py
@@ -11,7 +11,7 @@ Demonstrates:
 from pcons import Project, get_var
 from pcons.toolchains import find_c_toolchain
 
-toolchain = find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"])
+toolchain = find_c_toolchain(prefer=[get_var("TOOLCHAIN", None) or "gcc"])
 project = Project("cxx_modules")
 env = project.Environment(toolchain=toolchain)
 

--- a/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/pcons-build.py
@@ -7,7 +7,7 @@ from pcons import Project, add_subdirectory, find_c_toolchain, get_var
 # Create the main project
 project = Project("subdirs_example")
 env = project.Environment(
-    toolchain=(toolchain := find_c_toolchain(prefer=[get_var("TOOLCHAIN") or "gcc"]))
+    toolchain=(toolchain := find_c_toolchain(prefer=[get_var("TOOLCHAIN", "gcc")]))
 )
 
 if toolchain.name == "msvc":

--- a/examples/37_cxx_import_std_header_deps/pcons-build.py
+++ b/examples/37_cxx_import_std_header_deps/pcons-build.py
@@ -7,7 +7,7 @@ from pcons.toolchains import find_c_toolchain
 
 project = Project("cxx_import_std_header_deps")
 
-toolchain_override = get_var("TOOLCHAIN")
+toolchain_override = get_var("TOOLCHAIN", None)
 if toolchain_override:
     toolchain = find_c_toolchain(prefer=[toolchain_override])
 else:

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, overload
 
 if TYPE_CHECKING:
     from pcons.core.project import Project
@@ -72,6 +72,14 @@ def get_registered_projects() -> list[Project]:
 def _clear_registered_projects() -> None:
     """Clear the registry (called by CLI before running a script)."""
     _registered_projects.clear()
+
+
+@overload
+def get_var(name: str) -> str | None: ...
+
+
+@overload
+def get_var(name: str, default: str) -> str: ...
 
 
 def get_var(name: str, default: str | None = None) -> str | None:

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -43,6 +43,7 @@ from pcons.toolchains import (
     find_fortran_toolchain,
     find_wasi_toolchain,
 )  # noqa: E402
+from pcons.tools.install import install_dir  # noqa: E402
 from pcons.util.add_subdirectory import add_subdirectory  # noqa: E402
 
 register_builtin_builders()
@@ -148,6 +149,8 @@ __all__ = [
     # CLI variable access
     "get_var",
     "get_variant",
+    # Install helpers
+    "install_dir",
     # Project registry (for CLI use)
     "get_registered_projects",
     "_register_project",

--- a/pcons/__init__.py
+++ b/pcons/__init__.py
@@ -8,9 +8,8 @@ for build configuration and generates Ninja (or Makefile) build files.
 
 from __future__ import annotations
 
-import json
 import os
-from typing import TYPE_CHECKING, overload
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pcons.core.project import Project
@@ -28,6 +27,7 @@ from pcons.core.flags import FlagPair  # noqa: E402
 from pcons.core.project import Project  # noqa: E402, F811
 from pcons.core.subst import PathToken  # noqa: E402
 from pcons.core.test import set_test_properties, set_test_property  # noqa: E402
+from pcons.core.vars import get_var, get_variant  # noqa: E402
 from pcons.generators.generator import MultiGenerator  # noqa: E402
 from pcons.generators.makefile import MakefileGenerator  # noqa: E402
 from pcons.generators.metadata import MetadataGenerator  # noqa: E402
@@ -52,9 +52,6 @@ from pcons import modules as modules  # noqa: E402, F401
 
 __version__ = "0.18.0"
 
-# Internal storage for CLI variables
-_cli_vars: dict[str, str] | None = None
-
 # Global registry for Project instances
 _registered_projects: list[Project] = []
 
@@ -72,87 +69,6 @@ def get_registered_projects() -> list[Project]:
 def _clear_registered_projects() -> None:
     """Clear the registry (called by CLI before running a script)."""
     _registered_projects.clear()
-
-
-@overload
-def get_var(name: str) -> str | None: ...
-
-
-@overload
-def get_var(name: str, default: str) -> str: ...
-
-
-def get_var(name: str, default: str | None = None) -> str | None:
-    """Get a build variable set on the command line or from environment.
-
-    Variables can be set when invoking pcons:
-        pcons PORT=ofx USE_CUDA=1
-
-    In your pcons-build.py, access them with:
-        port = get_var('PORT', default='ofx')
-        use_cuda = get_var('USE_CUDA', default='0') == '1'
-
-    Precedence (highest to lowest):
-        1. Command line: pcons VAR=value
-        2. Environment variable: VAR=value pcons
-
-    Args:
-        name: Variable name.
-        default: Default value if not set.
-
-    Returns:
-        The variable value, or default if not set.
-    """
-    global _cli_vars
-
-    # Lazy-load CLI vars from environment on first access
-    if _cli_vars is None:
-        pcons_vars = os.environ.get("PCONS_VARS")
-        if pcons_vars:
-            try:
-                _cli_vars = json.loads(pcons_vars)
-            except json.JSONDecodeError as e:
-                import warnings
-
-                warnings.warn(
-                    f"PCONS_VARS environment variable contains invalid JSON: {e}. "
-                    "All CLI variable overrides will be ignored.",
-                    stacklevel=2,
-                )
-                _cli_vars = {}
-        else:
-            _cli_vars = {}
-
-    # Check CLI vars first
-    assert _cli_vars is not None
-    if name in _cli_vars:
-        return _cli_vars[name]
-
-    # Fall back to environment
-    return os.environ.get(name, default)
-
-
-def get_variant(default: str = "release") -> str:
-    """Get the build variant (debug, release, etc.).
-
-    The variant can be set with:
-        pcons --variant=debug
-
-    Or when running directly:
-        VARIANT=debug python pcons-build.py
-
-    Precedence (highest to lowest):
-        1. PCONS_VARIANT (set by pcons CLI)
-        2. VARIANT environment variable
-        3. default parameter
-
-    Args:
-        default: Default variant if not set.
-
-    Returns:
-        The variant name.
-    """
-    return os.environ.get("PCONS_VARIANT") or os.environ.get("VARIANT") or default
 
 
 # Valid generator names for CLI and Generator()

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -159,6 +159,7 @@ def run_script(
         Tuple of (exit_code, list of registered Projects).
     """
     import pcons
+    import pcons.core.vars
 
     sentinel = object()
     previous_env: dict[str, str | object] = {}
@@ -174,7 +175,7 @@ def run_script(
     pcons._clear_registered_projects()
 
     # Also clear cached CLI vars so they get re-read
-    pcons._cli_vars = None
+    pcons.core.vars._clear_cli_vars()
 
     # Set environment variables (scripts still read these)
     set_env_var("PCONS_BUILD_DIR", str(build_dir.absolute()))

--- a/pcons/contrib/installers/macos.py
+++ b/pcons/contrib/installers/macos.py
@@ -161,8 +161,8 @@ def create_component_pkg(
     # Stage files to a temporary directory (rel paths are relative to build_dir)
     staging_rel = Path(".pkg_staging") / identifier / "payload"
 
-    # Stage source files (Install auto-detects directory sources after resolve)
-    stage_target = project.Install(staging_rel, sources)
+    # Stage source files into build dir
+    stage_target = project.Install(staging_rel, sources, no_prefix=True)
 
     # Build pkgbuild command (paths relative to build_dir where ninja/make run)
     pkgbuild_args = [
@@ -274,8 +274,13 @@ def create_pkg(
     pkg_rel = staging_base_rel / "packages"
     resources_rel = staging_base_rel / "resources"
 
-    # Stage source files (Install auto-detects directory sources after resolve)
-    stage_target = project.Install(payload_rel, sources, name=f"pkg_payload_{name}")
+    # Stage source files into build dir
+    stage_target = project.Install(
+        payload_rel,
+        sources,
+        name=f"pkg_payload_{name}",
+        no_prefix=True,
+    )
 
     # Check if any source is a .app bundle (needs component plist)
     def is_bundle_source(src: Target | FileNode | Path | str) -> bool:
@@ -376,7 +381,10 @@ def create_pkg(
     ):
         if res_file is not None:
             res_target = project.Install(
-                resources_rel, [res_file], name=f"pkg_resource_{name}_{res_name}"
+                resources_rel,
+                [res_file],
+                name=f"pkg_resource_{name}_{res_name}",
+                no_prefix=True,
             )
             productbuild_deps.append(res_target)
 
@@ -459,8 +467,8 @@ def create_dmg(
     # Stage files to a temporary directory (path relative to build_dir)
     staging_rel = Path(".dmg_staging") / name
 
-    # Stage source files (Install auto-detects directory sources after resolve)
-    stage_target = project.Install(staging_rel, sources)
+    # Stage source files into build dir
+    stage_target = project.Install(staging_rel, sources, no_prefix=True)
 
     # Build hdiutil command (with optional symlink creation)
     # Paths are relative to build_dir where ninja/make run

--- a/pcons/contrib/installers/macos.py
+++ b/pcons/contrib/installers/macos.py
@@ -40,13 +40,17 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pcons.contrib.installers._helpers import check_tool
-
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
     from pcons.core.node import FileNode
     from pcons.core.project import Project
     from pcons.core.target import Target
+
+
+def _check_tool(tool: str, hint: str | None = None) -> str:
+    from pcons.contrib.installers._helpers import check_tool
+
+    return check_tool(tool, hint)
 
 
 # Reserved staging directory prefixes for installer generation.
@@ -144,7 +148,7 @@ def create_component_pkg(
         ToolNotFoundError: If pkgbuild is not found.
         ValueError: If staging path conflicts with existing build outputs.
     """
-    check_tool("pkgbuild", "Install Xcode Command Line Tools: xcode-select --install")
+    _check_tool("pkgbuild", "Install Xcode Command Line Tools: xcode-select --install")
 
     if output is None:
         output = Path(f"{identifier}-{version}.pkg")
@@ -247,8 +251,8 @@ def create_pkg(
         ToolNotFoundError: If pkgbuild or productbuild is not found.
         ValueError: If staging path conflicts with existing build outputs.
     """
-    check_tool("pkgbuild", "Install Xcode Command Line Tools: xcode-select --install")
-    check_tool(
+    _check_tool("pkgbuild", "Install Xcode Command Line Tools: xcode-select --install")
+    _check_tool(
         "productbuild", "Install Xcode Command Line Tools: xcode-select --install"
     )
 
@@ -441,7 +445,7 @@ def create_dmg(
         ToolNotFoundError: If hdiutil is not found.
         ValueError: If staging path conflicts with existing build outputs.
     """
-    check_tool("hdiutil", "hdiutil should be available on macOS")
+    _check_tool("hdiutil", "hdiutil should be available on macOS")
 
     volume_name = volume_name or name
     if output is None:
@@ -500,7 +504,7 @@ def sign_pkg(pkg_path: Path, identity: str) -> list[str]:
     Returns:
         Command list for productsign.
     """
-    check_tool(
+    _check_tool(
         "productsign", "Install Xcode Command Line Tools: xcode-select --install"
     )
 
@@ -539,7 +543,7 @@ def notarize_cmd(
     Returns:
         Command list for notarization.
     """
-    check_tool("xcrun", "Install Xcode Command Line Tools: xcode-select --install")
+    _check_tool("xcrun", "Install Xcode Command Line Tools: xcode-select --install")
 
     if password_keychain_item:
         return [

--- a/pcons/contrib/installers/windows.py
+++ b/pcons/contrib/installers/windows.py
@@ -30,8 +30,6 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pcons.contrib.installers._helpers import ToolNotFoundError
-
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
     from pcons.core.node import FileNode
@@ -124,6 +122,8 @@ def create_msix(
     """
     makeappx = _find_sdk_tool("MakeAppx.exe")
     if makeappx is None:
+        from pcons.contrib.installers._helpers import ToolNotFoundError
+
         raise ToolNotFoundError(
             "MakeAppx.exe",
             "Install Windows SDK: https://developer.microsoft.com/windows/downloads/windows-sdk/",
@@ -229,6 +229,8 @@ def create_msix(
     if sign_cert is not None:
         signtool = _find_sdk_tool("SignTool.exe")
         if signtool is None:
+            from pcons.contrib.installers._helpers import ToolNotFoundError
+
             raise ToolNotFoundError(
                 "SignTool.exe",
                 "Install Windows SDK for code signing support",

--- a/pcons/contrib/installers/windows.py
+++ b/pcons/contrib/installers/windows.py
@@ -162,8 +162,8 @@ def create_msix(
     staging_rel = Path(".msix_staging") / name
     manifest_rel = staging_rel / "AppxManifest.xml"
 
-    # Stage source files (Install auto-detects directory sources after resolve)
-    stage_target = project.Install(staging_rel, sources)
+    # Stage source files into build dir
+    stage_target = project.Install(staging_rel, sources, no_prefix=True)
 
     # Generate AppxManifest.xml (use relative path for target)
     manifest_target = env.Command(

--- a/pcons/core/_project_builder_stubs.py
+++ b/pcons/core/_project_builder_stubs.py
@@ -121,6 +121,7 @@ if TYPE_CHECKING:
             sources: Sequence[Target | FileNode | Path | str],
             *,
             name: str | None = None,
+            no_prefix: bool = False,
         ) -> Target:
             """Install files to a destination directory."""
             ...
@@ -131,6 +132,7 @@ if TYPE_CHECKING:
             source: Target | FileNode | Path | str,
             *,
             name: str | None = None,
+            no_prefix: bool = False,
         ) -> Target:
             """Install a file to a specific destination path."""
             ...
@@ -141,6 +143,7 @@ if TYPE_CHECKING:
             source: Target | FileNode | Path | str,
             *,
             name: str | None = None,
+            no_prefix: bool = False,
         ) -> Target:
             """Install a directory tree to a destination."""
             ...

--- a/pcons/core/node.py
+++ b/pcons/core/node.py
@@ -17,7 +17,7 @@ import logging
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, TypedDict
 
 from pcons.util.source_location import SourceLocation, get_caller_location
 
@@ -185,6 +185,26 @@ class Node(ABC):
         return f"{self.__class__.__name__}({self.name!r})"
 
 
+PathRole = Literal["source", "build_output", "install_output"]
+"""Tells generators how to render a node's path.
+
+The three roles make the source / build / external trichotomy explicit:
+
+- ``"source"``: an input file, relative to the project root (emitted via
+  ``$topdir`` so it resolves from the build directory).
+- ``"build_output"``: produced under the build directory (emitted relative
+  to it).
+- ``"install_output"``: produced *outside* the build directory, e.g.
+  ``<root>/dist/bin/app``. Emitted like a source (``$topdir``-relative, or
+  absolute only when it falls outside the project root) so build files stay
+  relocatable instead of baking in an absolute install path.
+
+Currently only ``"install_output"`` is set explicitly. A node with role
+``None`` is classified implicitly from whether it has a builder: no builder
+means a source, a builder means a build output.
+"""
+
+
 class FileNode(Node):
     """A node representing a file in the filesystem.
 
@@ -193,26 +213,36 @@ class FileNode(Node):
 
     Attributes:
         path: The path to the file.
+        role: Optional path role. ``None`` (the default) means the node is a
+              normal source or build output, distinguished by whether it has
+              a builder. ``"install_output"`` marks a build output whose path
+              lives outside the build directory (e.g. ``<root>/dist/bin/x``);
+              generators render it relative to the project root (the source
+              relativization) rather than the build directory, so build files
+              stay relocatable.
         _build_info: Builder-specific information for code generation.
                     See BuildInfo TypedDict for documented fields.
     """
 
-    __slots__ = ("path", "_build_info")
+    __slots__ = ("path", "role", "_build_info")
 
     def __init__(
         self,
         path: Path | str,
         *,
+        role: PathRole | None = None,
         defined_at: SourceLocation | None = None,
     ) -> None:
         """Create a file node.
 
         Args:
             path: Path to the file (will be converted to Path).
+            role: Optional path role, ``None`` by default.
             defined_at: Source location where this node was created.
         """
         super().__init__(defined_at=defined_at)
         self.path = Path(path) if isinstance(path, str) else path
+        self.role: PathRole | None = role
         self._build_info: BuildInfo | None = None
 
     @property
@@ -274,22 +304,25 @@ class DirNode(Node):
         members: Files that belong to this directory (when used as target).
     """
 
-    __slots__ = ("path", "members")
+    __slots__ = ("path", "role", "members")
 
     def __init__(
         self,
         path: Path | str,
         *,
+        role: PathRole | None = None,
         defined_at: SourceLocation | None = None,
     ) -> None:
         """Create a directory node.
 
         Args:
             path: Path to the directory.
+            role: Optional path role, ``None`` by default.
             defined_at: Source location where this node was created.
         """
         super().__init__(defined_at=defined_at)
         self.path = Path(path) if isinstance(path, str) else path
+        self.role: PathRole | None = role
         self.members: list[FileNode] = []
 
     @property

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -22,7 +22,7 @@ from pcons.core.graph import (
     detect_cycles_in_targets,
     topological_sort_targets,
 )
-from pcons.core.node import AliasNode, DirNode, FileNode, Node
+from pcons.core.node import AliasNode, DirNode, FileNode, Node, PathRole
 from pcons.core.paths import PathResolver
 from pcons.core.target import Target, split_qualified_name
 from pcons.util.source_location import SourceLocation, get_caller_location
@@ -302,7 +302,7 @@ class Project(_ProjectBuilders):
                 return path  # External path
         return Path(os.path.normpath(path))
 
-    def node(self, path: Path | str, canonicalize=True) -> FileNode:
+    def node(self, path: Path | str, *, role: PathRole | None = None) -> FileNode:
         """Get or create a file node for a path.
 
         This provides node deduplication - the same path always
@@ -310,46 +310,50 @@ class Project(_ProjectBuilders):
 
         Args:
             path: Path to the file.
-            canonicalize: Whether to canonicalize the path (default: True). If False, the path is used as-is for deduplication.
+            role: Optional path role recorded on the node (see FileNode).
+                ``"install_output"`` marks a build output that lives outside
+                the build directory so generators render it relocatably.
 
         Returns:
             FileNode for the path.
         """
-        if canonicalize:
-            path = self._canonicalize_path(Path(path))
-        else:
-            path = Path(path)
+        path = self._canonicalize_path(Path(path))
 
         if path not in self._nodes:
-            self._nodes[path] = FileNode(path, defined_at=get_caller_location())
+            self._nodes[path] = FileNode(
+                path, role=role, defined_at=get_caller_location()
+            )
         node = self._nodes[path]
         if not isinstance(node, FileNode):
             raise TypeError(
                 f"Path {path} is registered as {type(node).__name__}, not FileNode"
             )
+        if role is not None:
+            node.role = role
         return node
 
-    def dir_node(self, path: Path | str, canonicalize=True) -> DirNode:
+    def dir_node(self, path: Path | str, *, role: PathRole | None = None) -> DirNode:
         """Get or create a directory node for a path.
 
         Args:
             path: Path to the directory.
-            canonicalize: Whether to canonicalize the path (default: True). If False, the path is used as-is for deduplication.
+            role: Optional path role recorded on the node (see FileNode).
 
         Returns:
             DirNode for the path.
         """
-        if canonicalize:
-            path = self._canonicalize_path(Path(path))
-        else:
-            path = Path(path)
+        path = self._canonicalize_path(Path(path))
         if path not in self._nodes:
-            self._nodes[path] = DirNode(path, defined_at=get_caller_location())
+            self._nodes[path] = DirNode(
+                path, role=role, defined_at=get_caller_location()
+            )
         node = self._nodes[path]
         if not isinstance(node, DirNode):
             raise TypeError(
                 f"Path {path} is registered as {type(node).__name__}, not DirNode"
             )
+        if role is not None:
+            node.role = role
         return node
 
     def _add_target(self, target: Target) -> None:

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -302,7 +302,7 @@ class Project(_ProjectBuilders):
                 return path  # External path
         return Path(os.path.normpath(path))
 
-    def node(self, path: Path | str) -> FileNode:
+    def node(self, path: Path | str, canonicalize=True) -> FileNode:
         """Get or create a file node for a path.
 
         This provides node deduplication - the same path always
@@ -310,11 +310,16 @@ class Project(_ProjectBuilders):
 
         Args:
             path: Path to the file.
+            canonicalize: Whether to canonicalize the path (default: True). If False, the path is used as-is for deduplication.
 
         Returns:
             FileNode for the path.
         """
-        path = self._canonicalize_path(Path(path))
+        if canonicalize:
+            path = self._canonicalize_path(Path(path))
+        else:
+            path = Path(path)
+
         if path not in self._nodes:
             self._nodes[path] = FileNode(path, defined_at=get_caller_location())
         node = self._nodes[path]
@@ -324,16 +329,20 @@ class Project(_ProjectBuilders):
             )
         return node
 
-    def dir_node(self, path: Path | str) -> DirNode:
+    def dir_node(self, path: Path | str, canonicalize=True) -> DirNode:
         """Get or create a directory node for a path.
 
         Args:
             path: Path to the directory.
+            canonicalize: Whether to canonicalize the path (default: True). If False, the path is used as-is for deduplication.
 
         Returns:
             DirNode for the path.
         """
-        path = self._canonicalize_path(Path(path))
+        if canonicalize:
+            path = self._canonicalize_path(Path(path))
+        else:
+            path = Path(path)
         if path not in self._nodes:
             self._nodes[path] = DirNode(path, defined_at=get_caller_location())
         node = self._nodes[path]

--- a/pcons/core/vars.py
+++ b/pcons/core/vars.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: MIT
+"""Variable management for pcons.
+
+This module provides functions for managing variables passed via the command line or environment.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import overload
+
+# Internal storage for CLI variables
+_cli_vars: dict[str, str] | None = None
+
+
+def _clear_cli_vars() -> None:
+    """Clear the cached CLI variables. Used for testing purposes."""
+    global _cli_vars
+    _cli_vars = None
+
+
+def _posix_specific_vars() -> dict[str, str]:
+    """Get POSIX-specific variables to inject into the build environment."""
+    return {
+        "BINARY_EXT": "",
+        "LIBRARY_EXT": ".so",
+        "OBJECT_EXT": ".o",
+        "LIBRARY_PREFIX": "lib",
+        "ARCHIVE_SUFFIX": ".a",
+        "PATHSEP": ":",
+        "LIBRARY_INSTALL_DIR": "lib",
+        "ARCHIVE_INSTALL_DIR": "lib",
+        "BINARY_INSTALL_DIR": "bin",
+    }
+
+
+def _platform_specific_vars() -> dict[str, str]:
+    """Get platform-specific variables to inject into the build environment."""
+    import platform
+
+    vars = {}
+    system = platform.system()
+    if system == "Windows":
+        vars["PLATFORM"] = "windows"
+        vars["BINARY_EXT"] = ".exe"
+        vars["LIBRARY_EXT"] = ".dll"
+        vars["OBJECT_EXT"] = ".obj"
+        vars["LIBRARY_EXT"] = ".dll"
+        vars["LIBRARY_PREFIX"] = ""
+        vars["ARCHIVE_SUFFIX"] = ".lib"
+        vars["PATHSEP"] = ";"
+        vars["LIBRARY_INSTALL_DIR"] = "bin"
+        vars["ARCHIVE_INSTALL_DIR"] = "lib"
+        vars["BINARY_INSTALL_DIR"] = "bin"
+    elif system == "Darwin":
+        vars.update(_posix_specific_vars())
+        vars["PLATFORM"] = "macos"
+        vars["LIBRARY_EXT"] = ".dylib"
+    elif system == "Linux":
+        vars.update(_posix_specific_vars())
+        vars["PLATFORM"] = "linux"
+    else:
+        # Fallback to UNIX-style for unknown platforms
+        vars["PLATFORM"] = system.lower()
+        vars.update(_posix_specific_vars())
+
+    vars["HOST_ARCH"] = platform.machine()
+    vars["HOST_OS"] = system.lower()
+
+    # apply environment overrides for platform vars
+    for key in vars.keys():
+        env_value = os.environ.get(key)
+        if env_value is not None:
+            vars[key] = env_value
+
+    return vars
+
+
+_platform_vars = _platform_specific_vars()
+
+
+def get_cli_var(name: str, default: str | None = None) -> str | None:
+    """Get a build variable set on the command line or from environment.
+
+    Variables can be set when invoking pcons:
+        pcons PORT=ofx USE_CUDA=1
+
+    In your pcons-build.py, access them with:
+        port = get_var('PORT', default='ofx')
+        use_cuda = get_var('USE_CUDA', default='0') == '1'
+
+    Precedence (highest to lowest):
+        1. Command line: pcons VAR=value
+        2. Environment variable: VAR=value pcons
+
+    Args:
+        name: Variable name.
+        default: Default value if not set.
+
+    Returns:
+        The variable value, or default if not set.
+    """
+    global _cli_vars
+
+    # Lazy-load CLI vars from environment on first access
+    if _cli_vars is None:
+        pcons_vars = os.environ.get("PCONS_VARS")
+        if pcons_vars:
+            try:
+                _cli_vars = json.loads(pcons_vars)
+            except json.JSONDecodeError as e:  # noqa: F821
+                import warnings
+
+                warnings.warn(
+                    f"PCONS_VARS environment variable contains invalid JSON: {e}. "
+                    "All CLI variable overrides will be ignored.",
+                    stacklevel=2,
+                )
+                _cli_vars = {}
+        else:
+            _cli_vars = {}
+
+    # Check CLI vars first
+    assert _cli_vars is not None
+    if name in _cli_vars:
+        return _cli_vars[name]
+
+    # Fall back to environment
+    return os.environ.get(name, default)
+
+
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+@overload
+def get_var(name: str) -> str: ...
+
+
+@overload
+def get_var(name: str, default: None) -> str | None: ...
+
+
+@overload
+def get_var(name: str, default: str) -> str: ...
+
+
+def get_var(name: str, default: str | None | _Missing = _MISSING) -> str | None:
+    """Get a build variable set on the command line, environment, or platform specific defaults.
+
+    Raises ValueError if the variable is not found and no default is provided.
+    """
+    cli_value = get_cli_var(name)
+    if cli_value is not None:
+        return cli_value
+    value = _platform_vars.get(name, _MISSING)
+    if isinstance(value, _Missing):
+        if isinstance(default, _Missing):
+            raise ValueError(f"Build variable {name!r} is not set")
+        return default  # type: ignore[return-value]  # narrowed: str | None
+    assert isinstance(value, str)
+    return value
+
+
+def get_variant(default: str = "release") -> str:
+    """Get the build variant (debug, release, etc.).
+
+    The variant can be set with:
+        pcons --variant=debug
+
+    Or when running directly:
+        VARIANT=debug python pcons-build.py
+
+    Precedence (highest to lowest):
+        1. PCONS_VARIANT (set by pcons CLI)
+        2. VARIANT environment variable
+        3. default parameter
+
+    Args:
+        default: Default variant if not set.
+
+    Returns:
+        The variant name.
+    """
+    return os.environ.get("PCONS_VARIANT") or os.environ.get("VARIANT") or default

--- a/pcons/core/vars.py
+++ b/pcons/core/vars.py
@@ -26,8 +26,8 @@ def _posix_specific_vars() -> dict[str, str]:
         "BINARY_EXT": "",
         "LIBRARY_EXT": ".so",
         "OBJECT_EXT": ".o",
+        "ARCHIVE_EXT": ".a",
         "LIBRARY_PREFIX": "lib",
-        "ARCHIVE_SUFFIX": ".a",
         "PATHSEP": ":",
         "LIBRARY_INSTALL_DIR": "lib",
         "ARCHIVE_INSTALL_DIR": "lib",
@@ -47,8 +47,8 @@ def _platform_specific_vars() -> dict[str, str]:
         vars["LIBRARY_EXT"] = ".dll"
         vars["OBJECT_EXT"] = ".obj"
         vars["LIBRARY_EXT"] = ".dll"
+        vars["ARCHIVE_EXT"] = ".lib"
         vars["LIBRARY_PREFIX"] = ""
-        vars["ARCHIVE_SUFFIX"] = ".lib"
         vars["PATHSEP"] = ";"
         vars["LIBRARY_INSTALL_DIR"] = "bin"
         vars["ARCHIVE_INSTALL_DIR"] = "lib"

--- a/pcons/core/vars.py
+++ b/pcons/core/vars.py
@@ -20,71 +20,19 @@ def _clear_cli_vars() -> None:
     _cli_vars = None
 
 
-def _posix_specific_vars() -> dict[str, str]:
-    """Get POSIX-specific variables to inject into the build environment."""
-    return {
-        "BINARY_EXT": "",
-        "LIBRARY_EXT": ".so",
-        "OBJECT_EXT": ".o",
-        "ARCHIVE_EXT": ".a",
-        "LIBRARY_PREFIX": "lib",
-        "PATHSEP": ":",
-        "LIBRARY_INSTALL_DIR": "lib",
-        "ARCHIVE_INSTALL_DIR": "lib",
-        "BINARY_INSTALL_DIR": "bin",
-    }
+@overload
+def get_var(name: str) -> str | None: ...
 
 
-def _platform_specific_vars() -> dict[str, str]:
-    """Get platform-specific variables to inject into the build environment."""
-    import platform
-
-    vars = {}
-    system = platform.system()
-    if system == "Windows":
-        vars["PLATFORM"] = "windows"
-        vars["BINARY_EXT"] = ".exe"
-        vars["LIBRARY_EXT"] = ".dll"
-        vars["OBJECT_EXT"] = ".obj"
-        vars["LIBRARY_EXT"] = ".dll"
-        vars["ARCHIVE_EXT"] = ".lib"
-        vars["LIBRARY_PREFIX"] = ""
-        vars["PATHSEP"] = ";"
-        vars["LIBRARY_INSTALL_DIR"] = "bin"
-        vars["ARCHIVE_INSTALL_DIR"] = "lib"
-        vars["BINARY_INSTALL_DIR"] = "bin"
-    elif system == "Darwin":
-        vars.update(_posix_specific_vars())
-        vars["PLATFORM"] = "macos"
-        vars["LIBRARY_EXT"] = ".dylib"
-    elif system == "Linux":
-        vars.update(_posix_specific_vars())
-        vars["PLATFORM"] = "linux"
-    else:
-        # Fallback to UNIX-style for unknown platforms
-        vars["PLATFORM"] = system.lower()
-        vars.update(_posix_specific_vars())
-
-    vars["HOST_ARCH"] = platform.machine()
-    vars["HOST_OS"] = system.lower()
-
-    # apply environment overrides for platform vars
-    for key in vars.keys():
-        env_value = os.environ.get(key)
-        if env_value is not None:
-            vars[key] = env_value
-
-    return vars
+@overload
+def get_var(name: str, default: str) -> str: ...
 
 
-_platform_vars = _platform_specific_vars()
+@overload
+def get_var(name: str, default: None) -> str | None: ...
 
-def _reload_platform_vars() -> None:
-    """Reload platform-specific variables. Used for testing purposes."""
-    global _platform_vars
-    _platform_vars = _platform_specific_vars()
 
-def get_cli_var(name: str, default: str | None = None) -> str | None:
+def get_var(name: str, default: str | None = None) -> str | None:
     """Get a build variable set on the command line or from environment.
 
     Variables can be set when invoking pcons:
@@ -132,42 +80,6 @@ def get_cli_var(name: str, default: str | None = None) -> str | None:
 
     # Fall back to environment
     return os.environ.get(name, default)
-
-
-class _Missing:
-    pass
-
-
-_MISSING = _Missing()
-
-
-@overload
-def get_var(name: str) -> str: ...
-
-
-@overload
-def get_var(name: str, default: None) -> str | None: ...
-
-
-@overload
-def get_var(name: str, default: str) -> str: ...
-
-
-def get_var(name: str, default: str | None | _Missing = _MISSING) -> str | None:
-    """Get a build variable set on the command line, environment, or platform specific defaults.
-
-    Raises ValueError if the variable is not found and no default is provided.
-    """
-    cli_value = get_cli_var(name)
-    if cli_value is not None:
-        return cli_value
-    value = _platform_vars.get(name, _MISSING)
-    if isinstance(value, _Missing):
-        if isinstance(default, _Missing):
-            raise ValueError(f"Build variable {name!r} is not set")
-        return default  # type: ignore[return-value]  # narrowed: str | None
-    assert isinstance(value, str)
-    return value
 
 
 def get_variant(default: str = "release") -> str:

--- a/pcons/core/vars.py
+++ b/pcons/core/vars.py
@@ -79,6 +79,10 @@ def _platform_specific_vars() -> dict[str, str]:
 
 _platform_vars = _platform_specific_vars()
 
+def _reload_platform_vars() -> None:
+    """Reload platform-specific variables. Used for testing purposes."""
+    global _platform_vars
+    _platform_vars = _platform_specific_vars()
 
 def get_cli_var(name: str, default: str | None = None) -> str | None:
     """Get a build variable set on the command line or from environment.

--- a/pcons/generators/makefile.py
+++ b/pcons/generators/makefile.py
@@ -217,13 +217,16 @@ class MakefileGenerator(BaseGenerator):
             ]
             output = " ".join(all_outputs)
         else:
-            output = self._make_build_relative_path(node.path)
+            output = self._node_path(node)
 
         # Get source paths - use PathResolver for consistent handling
         # Make runs from build directory (via make -C), so:
         # - Build outputs: strip build_dir prefix
         # - Source files: use absolute paths to work from any directory
         def get_source_path(s: FileNode) -> str:
+            # Install outputs live outside the build dir.
+            if getattr(s, "role", None) == "install_output":
+                return self._node_path(s)
             # Build outputs need build_dir prefix stripped
             if getattr(s, "_build_info", None) is not None or s.is_target:
                 return self._make_build_relative_path(s.path)
@@ -259,7 +262,14 @@ class MakefileGenerator(BaseGenerator):
         order_only: list[str] = []
         output_dir = node.path.parent
         if output_dir != Path(".") and output_dir != Path(""):
-            order_only.append(self._make_build_relative_path(output_dir))
+            if getattr(node, "role", None) == "install_output":
+                # Install dir lives outside the build tree.
+                abs_dir = output_dir
+                if not abs_dir.is_absolute() and self._project_root is not None:
+                    abs_dir = self._project_root / abs_dir
+                order_only.append(self._escape_path(abs_dir))
+            else:
+                order_only.append(self._make_build_relative_path(output_dir))
 
         # Build the target line
         prereq_str = " ".join(prereqs)
@@ -563,9 +573,7 @@ class MakefileGenerator(BaseGenerator):
         for name, alias in project.aliases.items():
             # Alias targets need build_dir prefix stripped since make runs from build_dir
             targets = " ".join(
-                self._make_build_relative_path(t.path)
-                for t in alias.targets
-                if isinstance(t, FileNode)
+                self._node_path(t) for t in alias.targets if isinstance(t, FileNode)
             )
             if targets:
                 f.write(f"{name}: {targets}\n")
@@ -618,15 +626,11 @@ class MakefileGenerator(BaseGenerator):
             if target.output_nodes:
                 for out_node in target.output_nodes:
                     if isinstance(out_node, FileNode):
-                        user_defaults.append(
-                            self._make_build_relative_path(out_node.path)
-                        )
+                        user_defaults.append(self._node_path(out_node))
             else:
                 for target_node in target.nodes:
                     if isinstance(target_node, FileNode):
-                        user_defaults.append(
-                            self._make_build_relative_path(target_node.path)
-                        )
+                        user_defaults.append(self._node_path(target_node))
 
         # Collect all target outputs for 'all'
         all_outputs: list[str] = []
@@ -634,7 +638,7 @@ class MakefileGenerator(BaseGenerator):
             if getattr(target, "_resolved", False):
                 for node in target.output_nodes:
                     if isinstance(node, FileNode):
-                        all_outputs.append(self._make_build_relative_path(node.path))
+                        all_outputs.append(self._node_path(node))
 
         # If no resolved targets, find final nodes from env-created nodes
         if not all_outputs:
@@ -781,6 +785,20 @@ class MakefileGenerator(BaseGenerator):
         """
         path_str = self._strip_build_dir_prefix(path)
         return self.ESCAPE_DOLLAR.sub("$$", path_str)
+
+    def _node_path(self, node: FileNode) -> str:
+        """Render a Makefile path for *node*, honoring its role.
+
+        Install outputs (``role == "install_output"``) live outside the build dir.
+        Since make runs from the build dir (via ``-C``), they must have absolute paths.
+        Keeps them project-relative whenever possible (when install destination is within the project source directory).
+        """
+        if getattr(node, "role", None) == "install_output":
+            p = node.path
+            if not p.is_absolute() and self._project_root is not None:
+                p = self._project_root / p
+            return self._escape_path(p)
+        return self._make_build_relative_path(node.path)
 
     def _process_path_tokens(self, tokens: list) -> list:
         """Process PathToken objects in a command token list.

--- a/pcons/generators/makefile.py
+++ b/pcons/generators/makefile.py
@@ -123,7 +123,11 @@ class MakefileGenerator(BaseGenerator):
         for target in project.targets:
             for node in self._get_target_build_nodes(target):
                 parent = node.path.parent
-                if parent != Path(".") and parent != Path(""):
+                if (
+                    parent != Path(".")
+                    and parent != Path("")
+                    and node.role != "install_output"
+                ):
                     self._directories.add(parent)
                 # Track depfile directories
                 build_info = getattr(node, "_build_info", None) or {}
@@ -261,15 +265,12 @@ class MakefileGenerator(BaseGenerator):
         # Directories need build_dir prefix stripped since make runs from build_dir
         order_only: list[str] = []
         output_dir = node.path.parent
-        if output_dir != Path(".") and output_dir != Path(""):
-            if getattr(node, "role", None) == "install_output":
-                # Install dir lives outside the build tree.
-                abs_dir = output_dir
-                if not abs_dir.is_absolute() and self._project_root is not None:
-                    abs_dir = self._project_root / abs_dir
-                order_only.append(self._escape_path(abs_dir))
-            else:
-                order_only.append(self._make_build_relative_path(output_dir))
+        if (
+            output_dir != Path(".")
+            and output_dir != Path("")
+            and node.role != "install_output"
+        ):
+            order_only.append(self._make_build_relative_path(output_dir))
 
         # Build the target line
         prereq_str = " ".join(prereqs)
@@ -546,9 +547,11 @@ class MakefileGenerator(BaseGenerator):
         source_paths = " ".join(in_paths)
 
         # Substitute $in and $out
-        # $out uses node.path with build_dir prefix stripped (make runs from build_dir)
+        # $out uses the role-aware output path (build-relative, or absolute for
+        # install outputs) so the recipe writes exactly where the rule target
+        # points (make runs from build_dir).
         command = command.replace("$in", source_paths)
-        command = command.replace("$out", self._strip_build_dir_prefix(node.path))
+        command = command.replace("$out", self._node_out_raw(node))
 
         # Handle depfile if present (also strip build_dir prefix)
         depfile = build_info.get("depfile")
@@ -786,19 +789,29 @@ class MakefileGenerator(BaseGenerator):
         path_str = self._strip_build_dir_prefix(path)
         return self.ESCAPE_DOLLAR.sub("$$", path_str)
 
-    def _node_path(self, node: FileNode) -> str:
-        """Render a Makefile path for *node*, honoring its role.
+    def _node_out_raw(self, node: FileNode) -> str:
+        """Return the unescaped output path for *node*, honoring its role.
 
-        Install outputs (``role == "install_output"``) live outside the build dir.
-        Since make runs from the build dir (via ``-C``), they must have absolute paths.
-        Keeps them project-relative whenever possible (when install destination is within the project source directory).
+        Install outputs (``role == "install_output"``) live outside the build
+        dir; since make runs from the build dir (via ``-C``) they are emitted
+        as absolute paths (anchored at the project root when stored
+        project-relative). All other nodes are build-dir-relative.
+
+        Returned unescaped so it can be used both in rule targets (after
+        ``$``-escaping via :meth:`_node_path`) and in recipe command tokens
+        (which are escaped/quoted separately). The two must agree so make's
+        target matches the path the recipe actually writes.
         """
-        if getattr(node, "role", None) == "install_output":
+        if node.role == "install_output":
             p = node.path
             if not p.is_absolute() and self._project_root is not None:
                 p = self._project_root / p
-            return self._escape_path(p)
-        return self._make_build_relative_path(node.path)
+            return str(p)
+        return self._strip_build_dir_prefix(node.path)
+
+    def _node_path(self, node: FileNode) -> str:
+        """Render a Makefile rule-target path for *node* ($-escaped)."""
+        return self.ESCAPE_DOLLAR.sub("$$", self._node_out_raw(node))
 
     def _process_path_tokens(self, tokens: list) -> list:
         """Process PathToken objects in a command token list.
@@ -927,8 +940,9 @@ class MakefileGenerator(BaseGenerator):
             if isinstance(dep, FileNode) and dep.path not in source_paths_set:
                 in_paths.append(get_source_path(dep))
 
-        # Output path (single path)
-        out_path = self._strip_build_dir_prefix(node.path)
+        # Output path (single path), role-aware so install outputs resolve to
+        # their absolute destination, matching the rule target.
+        out_path = self._node_out_raw(node)
 
         # Depfile path - get from build_info (PathToken with suffix)
         depfile = build_info.get("depfile")

--- a/pcons/generators/ninja.py
+++ b/pcons/generators/ninja.py
@@ -500,11 +500,15 @@ class NinjaGenerator(BaseGenerator):
                 output += " | " + " ".join(implicit_outputs)
         else:
             # Single-output build
-            output = self._escape_output_path(node.path)
+            output = self._output_ref(node)
 
         # Explicit dependencies (sources + library dependencies)
         # For source files, we need to reference them from the build directory
         def get_dep_path(s: FileNode) -> str:
+            # Install outputs live outside the build dir — render relocatably.
+            if getattr(s, "role", None) == "install_output":
+                return self._install_output_ref(s)
+
             # Check if this is a build output (has _build_info from resolver)
             if getattr(s, "_build_info", None) is not None or s.is_target:
                 # Build output - make relative to build dir
@@ -537,8 +541,7 @@ class NinjaGenerator(BaseGenerator):
         source_paths_set = {s.path for s in sources if isinstance(s, FileNode)}
         for dep in node.explicit_deps:
             if isinstance(dep, FileNode) and dep.path not in source_paths_set:
-                # Use _escape_output_path for build outputs (objects, libraries)
-                explicit_deps_list.append(self._escape_output_path(dep.path))
+                explicit_deps_list.append(self._output_ref(dep))
 
         explicit_deps = " ".join(explicit_deps_list)
 
@@ -647,9 +650,7 @@ class NinjaGenerator(BaseGenerator):
         f.write("# Aliases\n")
         for name, alias in project.aliases.items():
             targets = " ".join(
-                self._escape_output_path(t.path)
-                for t in alias.targets
-                if isinstance(t, FileNode)
+                self._output_ref(t) for t in alias.targets if isinstance(t, FileNode)
             )
             if targets:
                 f.write(f"build {name}: phony {targets}\n")
@@ -684,7 +685,7 @@ class NinjaGenerator(BaseGenerator):
             for dep in test_target.dependencies:
                 for node in dep.output_nodes:
                     if isinstance(node, FileNode):
-                        out = self._escape_output_path(node.path)
+                        out = self._output_ref(node)
                         if out not in seen:
                             seen.add(out)
                             program_outputs.append(out)
@@ -722,13 +723,13 @@ class NinjaGenerator(BaseGenerator):
         for target in project.default_targets:
             for out_node in target.output_nodes:
                 if isinstance(out_node, FileNode):
-                    user_defaults.append(self._escape_output_path(out_node.path))
+                    user_defaults.append(self._output_ref(out_node))
 
         # Collect all target outputs for 'all' target
         for target in project.targets:
             for node in target.output_nodes:
                 if isinstance(node, FileNode):
-                    all_outputs.append(self._escape_output_path(node.path))
+                    all_outputs.append(self._output_ref(node))
 
         if all_outputs:
             # Create 'all' phony target — builds every target in the project
@@ -807,6 +808,28 @@ class NinjaGenerator(BaseGenerator):
     def _escape_output_path(self, path: Path | str) -> str:
         """Make an output path relative to build dir and escape for Ninja."""
         return self._escape_path(self._make_output_relative(path))
+
+    def _install_output_ref(self, node: FileNode) -> str:
+        """Render an install-output node (``role == "install_output"``).
+
+        Such nodes live outside the build dir (e.g. ``<root>/dist/bin/app``).
+        They are emitted like source files (``$topdir/...``) when under the
+        project root, otherwise absolute.
+        """
+        rel = self._make_source_relative(node.path)
+        if rel is not None:
+            return "$topdir/" + self._escape_path(rel)
+        return self._escape_path(node.path)
+
+    def _output_ref(self, node: FileNode) -> str:
+        """Render an output-node reference.
+
+        Build outputs are relative to the build dir.
+        For install outputs see _install_output_ref().
+        """
+        if getattr(node, "role", None) == "install_output":
+            return self._install_output_ref(node)
+        return self._escape_output_path(node.path)
 
     def _make_source_relative(self, path: Path | str) -> str | None:
         """Try to make a source path relative to project root.

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -77,6 +77,46 @@ def _deduplicate_target_name(project: Project, base_name: str) -> str:
     return target_name
 
 
+def install_dir(env: Environment, target_type: str) -> str:
+    """Return the conventional install subdirectory for *target_type*.
+
+    The convention is sourced from the environment's primary toolchain, so it
+    follows the platform that toolchain targets rather than the host OS:
+
+    - ``"program"``: ``bin``
+    - ``"static_library"``: ``lib``
+    - ``"shared_library"``: ``bin`` on DLL platforms (a Windows DLL must sit
+      next to the executable that loads it), ``lib`` elsewhere.
+
+    Pass the result to :meth:`Project.Install` as the destination directory::
+
+        env = project.Environment(toolchain=find_c_toolchain())
+        lib = project.SharedLibrary("foo", env, sources=["foo.c"])
+        project.Install(install_dir(env, "shared_library"), [lib])
+
+    Users who want a different layout can ignore this helper and pass an
+    explicit directory string (e.g. ``project.Install("lib64", [lib])``).
+
+    Args:
+        env: Environment whose toolchain defines the convention.
+        target_type: One of ``"program"``, ``"static_library"``,
+            ``"shared_library"``.
+
+    Returns:
+        The install subdirectory name (relative to the install prefix).
+
+    Raises:
+        ValueError: If *env* has no toolchain.
+    """
+    toolchains = env.toolchains
+    if not toolchains:
+        raise ValueError(
+            "install_dir() requires an environment with a toolchain; "
+            "pass an explicit directory string to Install() instead."
+        )
+    return toolchains[0].get_install_dir(target_type)
+
+
 class InstallTool(StandaloneTool):
     """Tool for file and directory installation operations.
 
@@ -235,8 +275,10 @@ class InstallNodeFactory(PendingSourceFactory):
             # Destination path
             dest_path = dest_dir / file_node.path.name
 
-            # Create destination node via project for deduplication
-            dest_node = self.project.node(dest_path, canonicalize=False)
+            # Create destination node via project for deduplication.
+            # Mark it as an install output so generators render its path
+            # (which may live outside the build dir) relocatably.
+            dest_node = self.project.node(dest_path, role="install_output")
             dest_node.depends([file_node])
 
             # Store build info referencing env.install.copycmd
@@ -337,8 +379,9 @@ class InstallNodeFactory(PendingSourceFactory):
 
         source_node = sources[0]
 
-        # Create destination node via project for deduplication
-        dest_node = self.project.node(dest, canonicalize=False)
+        # Create destination node via project for deduplication.
+        # Mark it as an install output (path may live outside the build dir).
+        dest_node = self.project.node(dest, role="install_output")
         dest_node.depends([source_node])
 
         # Store build info referencing env.install.copycmd
@@ -395,8 +438,11 @@ class InstallNodeFactory(PendingSourceFactory):
         stamp_name = _stamp_name_for(rel_dest)
         stamp_path = stamps_dir / stamp_name
 
-        # Create stamp node via project for deduplication (this is what ninja tracks)
-        stamp_node = self.project.node(stamp_path, canonicalize=False)
+        # Create stamp node via project for deduplication (this is what ninja
+        # tracks). The stamp lives under build/.stamps, so it is a normal
+        # build output; the copied tree's destination is handled separately
+        # via the copytree command's destdir argument.
+        stamp_node = self.project.node(stamp_path)
         # Source directory is the explicit dep (becomes $in for copytree).
         # Child nodes are implicit deps — they trigger rebuilds but don't
         # appear in $in (ninja's | syntax).

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -506,6 +506,8 @@ class InstallAsBuilder:
         Raises:
             BuilderError: If source is a list (use Install() for multiple files).
         """
+        from pcons import get_var
+
         # Validate source is not a list - common user error
         if isinstance(source, (list, tuple)):
             from pcons.core.errors import BuilderError
@@ -518,6 +520,12 @@ class InstallAsBuilder:
 
         dest = Path(dest)
         target_name = _deduplicate_target_name(project, name or f"install_{dest.name}")
+
+        if not dest.is_absolute():
+            dest = (
+                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
+                / dest
+            )
 
         # Create the install target
         install_target = Target(
@@ -561,10 +569,18 @@ class InstallDirBuilder:
         Returns:
             A Target representing the install operation.
         """
+        from pcons import get_var
+
         dest_dir = Path(dest_dir)
         target_name = _deduplicate_target_name(
             project, name or f"install_dir_{dest_dir.name}"
         )
+
+        if not dest_dir.is_absolute():
+            dest_dir = (
+                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
+                / dest_dir
+            )
 
         # Create the install target
         install_target = Target(

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -222,7 +222,7 @@ class InstallNodeFactory(PendingSourceFactory):
             dest_path = dest_dir / file_node.path.name
 
             # Create destination node via project for deduplication
-            dest_node = self.project.node(dest_path)
+            dest_node = self.project.node(dest_path, canonicalize=False)
             dest_node.depends([file_node])
 
             # Store build info referencing env.install.copycmd
@@ -324,7 +324,7 @@ class InstallNodeFactory(PendingSourceFactory):
         source_node = sources[0]
 
         # Create destination node via project for deduplication
-        dest_node = self.project.node(dest)
+        dest_node = self.project.node(dest, canonicalize=False)
         dest_node.depends([source_node])
 
         # Store build info referencing env.install.copycmd
@@ -376,7 +376,7 @@ class InstallNodeFactory(PendingSourceFactory):
         stamp_path = stamps_dir / stamp_name
 
         # Create stamp node via project for deduplication (this is what ninja tracks)
-        stamp_node = self.project.node(stamp_path)
+        stamp_node = self.project.node(stamp_path, canonicalize=False)
         # Source directory is the explicit dep (becomes $in for copytree).
         # Child nodes are implicit deps — they trigger rebuilds but don't
         # appear in $in (ninja's | syntax).
@@ -448,10 +448,18 @@ class InstallBuilder:
         Returns:
             A Target representing the install operation.
         """
+        from pcons import get_var
+
         dest_dir = Path(dest_dir)
         target_name = _deduplicate_target_name(
             project, name or f"install_{dest_dir.name}"
         )
+
+        if not dest_dir.is_absolute():
+            dest_dir = (
+                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
+                / dest_dir
+            )
 
         # Create the install target
         install_target = Target(

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from pcons.core.builder_registry import builder
-from pcons.core.node import BuildInfo, FileNode
+from pcons.core.node import BuildInfo, FileNode, PathRole
 from pcons.core.resolver import PendingSourceFactory
 from pcons.core.subst import PathToken, SourcePath, TargetPath
 from pcons.core.target import Target
@@ -51,6 +51,19 @@ def _stamp_name_for(path: Path) -> str:
     if len(s) >= 2 and s[1] == ":":
         s = "_" + s[0] + s[2:]
     return s.replace("/", "_").replace("\\", "_") + ".stamp"
+
+
+def _install_role(dest: Path) -> PathRole | None:
+    """Return the node role for an install destination.
+    An absolute destination it is an ``"install_output"``.
+    A relative destination is a build-dir-relative staging path (e.g. the ``no_prefix``
+    installers in ``pcons.contrib.installers``), return ``None``.
+
+    ``Path.anchor`` is used rather than ``Path.is_absolute()`` because the
+    latter is platform-dependent: ``Path("/opt/x").is_absolute()`` is False on
+    Windows (no drive), which would misclassify a rooted POSIX-style path.
+    """
+    return "install_output" if dest.anchor else None
 
 
 def _deduplicate_target_name(project: Project, base_name: str) -> str:
@@ -276,9 +289,8 @@ class InstallNodeFactory(PendingSourceFactory):
             dest_path = dest_dir / file_node.path.name
 
             # Create destination node via project for deduplication.
-            # Mark it as an install output so generators render its path
-            # (which may live outside the build dir) relocatably.
-            dest_node = self.project.node(dest_path, role="install_output")
+            # Mark it as an install output only for absolute (outside-build) destinations; see _install_role.
+            dest_node = self.project.node(dest_path, role=_install_role(dest_path))
             dest_node.depends([file_node])
 
             # Store build info referencing env.install.copycmd
@@ -380,8 +392,8 @@ class InstallNodeFactory(PendingSourceFactory):
         source_node = sources[0]
 
         # Create destination node via project for deduplication.
-        # Mark it as an install output (path may live outside the build dir).
-        dest_node = self.project.node(dest, role="install_output")
+        # Mark it as an install output only for absolute (outside-build) destinations; see _install_role.
+        dest_node = self.project.node(dest, role=_install_role(dest))
         dest_node.depends([source_node])
 
         # Store build info referencing env.install.copycmd

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -53,17 +53,26 @@ def _stamp_name_for(path: Path) -> str:
     return s.replace("/", "_").replace("\\", "_") + ".stamp"
 
 
-def _install_role(dest: Path) -> PathRole | None:
-    """Return the node role for an install destination.
-    An absolute destination it is an ``"install_output"``.
-    A relative destination is a build-dir-relative staging path (e.g. the ``no_prefix``
-    installers in ``pcons.contrib.installers``), return ``None``.
+def _is_rooted(dest: Path) -> bool:
+    """Return whether *dest* is rooted (has a drive and/or a leading separator).
 
     ``Path.anchor`` is used rather than ``Path.is_absolute()`` because the
     latter is platform-dependent: ``Path("/opt/x").is_absolute()`` is False on
     Windows (no drive), which would misclassify a rooted POSIX-style path.
     """
-    return "install_output" if dest.anchor else None
+    return bool(dest.anchor)
+
+
+def _install_role(dest: Path) -> PathRole | None:
+    """Return the node role for an install destination.
+
+    A rooted destination lives outside the build tree, so it is an
+    ``"install_output"``.
+    A relative destination is a build-dir-relative staging path
+    (e.g. the ``no_prefix`` installers in ``pcons.contrib.installers``),
+    for which ``None`` is returned.
+    """
+    return "install_output" if _is_rooted(dest) else None
 
 
 def _deduplicate_target_name(project: Project, base_name: str) -> str:
@@ -529,7 +538,7 @@ class InstallBuilder:
             project, name or f"install_{dest_dir.name}"
         )
 
-        if not no_prefix and not dest_dir.is_absolute():
+        if not no_prefix and not _is_rooted(dest_dir):
             dest_dir = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest_dir
@@ -597,7 +606,7 @@ class InstallAsBuilder:
         dest = Path(dest)
         target_name = _deduplicate_target_name(project, name or f"install_{dest.name}")
 
-        if not no_prefix and not dest.is_absolute():
+        if not no_prefix and not _is_rooted(dest):
             dest = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest
@@ -654,7 +663,7 @@ class InstallDirBuilder:
             project, name or f"install_dir_{dest_dir.name}"
         )
 
-        if not no_prefix and not dest_dir.is_absolute():
+        if not no_prefix and not _is_rooted(dest_dir):
             dest_dir = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest_dir

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -450,6 +450,7 @@ class InstallBuilder:
         sources: Sequence[Target | FileNode | Path | str],
         *,
         name: str | None = None,
+        no_prefix: bool = False,
     ) -> Target:
         """Create an Install target.
 
@@ -458,6 +459,7 @@ class InstallBuilder:
             dest_dir: Destination directory path.
             sources: Files to install.
             name: Optional name for the install target.
+            no_prefix: If True, do not prepend the install prefix to the destination.
 
         Returns:
             A Target representing the install operation.
@@ -469,7 +471,7 @@ class InstallBuilder:
             project, name or f"install_{dest_dir.name}"
         )
 
-        if not dest_dir.is_absolute():
+        if not no_prefix and not dest_dir.is_absolute():
             dest_dir = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest_dir
@@ -505,6 +507,7 @@ class InstallAsBuilder:
         source: Target | FileNode | Path | str,
         *,
         name: str | None = None,
+        no_prefix: bool = False,
     ) -> Target:
         """Create an InstallAs target.
 
@@ -513,6 +516,7 @@ class InstallAsBuilder:
             dest: Full destination path (including filename).
             source: Source file.
             name: Optional name for the install target.
+            no_prefix: If True, do not prepend the install prefix to the destination.
 
         Returns:
             A Target representing the install operation.
@@ -535,7 +539,7 @@ class InstallAsBuilder:
         dest = Path(dest)
         target_name = _deduplicate_target_name(project, name or f"install_{dest.name}")
 
-        if not dest.is_absolute():
+        if not no_prefix and not dest.is_absolute():
             dest = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest
@@ -571,6 +575,7 @@ class InstallDirBuilder:
         source: Target | FileNode | Path | str,
         *,
         name: str | None = None,
+        no_prefix: bool = False,
     ) -> Target:
         """Create an InstallDir target.
 
@@ -579,6 +584,7 @@ class InstallDirBuilder:
             dest_dir: Destination directory.
             source: Source directory.
             name: Optional name for the install target.
+            no_prefix: If True, do not prepend the install prefix to the destination.
 
         Returns:
             A Target representing the install operation.
@@ -590,7 +596,7 @@ class InstallDirBuilder:
             project, name or f"install_dir_{dest_dir.name}"
         )
 
-        if not dest_dir.is_absolute():
+        if not no_prefix and not dest_dir.is_absolute():
             dest_dir = (
                 Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
                 / dest_dir

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -39,6 +39,20 @@ if TYPE_CHECKING:
     from pcons.core.project import Project
 
 
+def _stamp_name_for(path: Path) -> str:
+    """Convert a path to a flat stamp file name.
+
+    POSIX absolute paths start with "/" which becomes "_".
+    Windows absolute paths start with "C:\", the colon is replaced so they
+    become "_C_..." matching the POSIX pattern.
+    """
+    s = str(path)
+    # Replace Windows drive colon so "C:\..." becomes "_C_..." like POSIX "_/..."
+    if len(s) >= 2 and s[1] == ":":
+        s = "_" + s[0] + s[2:]
+    return s.replace("/", "_").replace("\\", "_") + ".stamp"
+
+
 def _deduplicate_target_name(project: Project, base_name: str) -> str:
     """Generate a unique target name, appending a numeric suffix if needed.
 
@@ -260,9 +274,15 @@ class InstallNodeFactory(PendingSourceFactory):
         source_path = source_node.path
         dest_path = dest_dir / source_path.name
 
+        # Compute dest relative to build dir for a platform-neutral stamp name
+        try:
+            rel_dest = dest_path.relative_to(target.build_dir)
+        except ValueError:
+            rel_dest = dest_path
+
         # Stamp file for ninja tracking
         stamps_dir = target.build_dir / ".stamps"
-        stamp_name = str(dest_path).replace("/", "_").replace("\\", "_") + ".stamp"
+        stamp_name = _stamp_name_for(rel_dest)
         stamp_path = stamps_dir / stamp_name
 
         stamp_node = self.project.node(stamp_path)
@@ -272,12 +292,6 @@ class InstallNodeFactory(PendingSourceFactory):
         stamp_node.depends([source_node])
         child_nodes = self.project.get_child_nodes(source_path)
         stamp_node.implicit_deps.extend(child_nodes)
-
-        # Build destination path relative to build directory
-        try:
-            rel_dest = dest_path.relative_to(target.build_dir)
-        except ValueError:
-            rel_dest = dest_path
 
         context = InstallContext.from_target(
             target, env, destdir=str(rel_dest).replace("\\", "/")
@@ -370,9 +384,15 @@ class InstallNodeFactory(PendingSourceFactory):
         # Destination is dest_dir / source directory name
         dest_path = dest_dir / source_path.name
 
+        # Compute dest relative to build dir for a platform-neutral stamp name
+        try:
+            rel_dest = dest_path.relative_to(target.build_dir)
+        except ValueError:
+            rel_dest = dest_path
+
         # Put stamp files in a dedicated .stamps directory
         stamps_dir = target.build_dir / ".stamps"
-        stamp_name = str(dest_path).replace("/", "_").replace("\\", "_") + ".stamp"
+        stamp_name = _stamp_name_for(rel_dest)
         stamp_path = stamps_dir / stamp_name
 
         # Create stamp node via project for deduplication (this is what ninja tracks)
@@ -383,12 +403,6 @@ class InstallNodeFactory(PendingSourceFactory):
         stamp_node.depends([source_node])
         child_nodes = self.project.get_child_nodes(source_path)
         stamp_node.implicit_deps.extend(child_nodes)
-
-        # Build the destination path relative to build directory for the command
-        try:
-            rel_dest = dest_path.relative_to(target.build_dir)
-        except ValueError:
-            rel_dest = dest_path
 
         # Create context from target (merges env defaults with target overrides)
         env = self._get_install_env(target)

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -456,6 +456,14 @@ class Toolchain(Protocol):
         """
         ...
 
+    def get_install_dir(self, target_type: str) -> str:
+        """Return the conventional install subdirectory for a target type.
+
+        E.g., "bin" for programs, "lib" for static libraries, and "bin" or
+        "lib" for shared libraries depending on the target platform.
+        """
+        ...
+
     def get_compile_flags_for_target_type(self, target_type: str) -> list[str]:
         """Return additional compile flags needed for the target type."""
         ...
@@ -933,6 +941,28 @@ class BaseToolchain(ABC):
         elif target_type == "shared_library":
             return plat.shared_lib_suffix
         return plat.exe_suffix
+
+    def get_install_dir(self, target_type: str) -> str:
+        """Return the conventional install subdirectory for a target type.
+
+        The convention follows the platform this toolchain targets:
+
+        - programs go in ``bin``
+        - static libraries (and archives) go in ``lib``
+        - shared libraries go in ``bin`` when the toolchain produces Windows
+          DLLs (a ``.dll`` must sit next to the executable that loads it), and
+          in ``lib`` otherwise (ELF ``.so`` / Mach-O ``.dylib``).
+
+        Override in subclasses for non-standard layouts (e.g. ``lib64``).
+        """
+        if target_type == "program":
+            return "bin"
+        if target_type == "shared_library":
+            if self.get_output_suffix("shared_library") == ".dll":
+                return "bin"
+            return "lib"
+        # static_library and anything else (archives, data) default to lib.
+        return "lib"
 
     def get_static_library_name(self, name: str) -> str:
         """Return filename for a static library."""

--- a/tests/contrib/test_installers.py
+++ b/tests/contrib/test_installers.py
@@ -313,6 +313,61 @@ class TestWindowsInstallers:
             assert "MakeAppx" in path
 
 
+class TestWindowsInstallersErrors:
+    """Tests for error handling in Windows installer creation."""
+
+    def test_create_msix_without_makeappx(self, monkeypatch) -> None:
+        """Test that _find_sdk_tool raises if tool is not found."""
+        from pcons.contrib.installers import windows
+        from pcons.contrib.installers._helpers import ToolNotFoundError
+
+        # Monkeypatch _find_sdk_tool to always return None
+        def _mock_find_sdk_tool(tool_name: str) -> str | None:
+            if tool_name == "MakeAppx.exe":
+                return None
+            else:
+                return "sometool.exe"
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", _mock_find_sdk_tool)
+        project = Project("test_msix_error")
+        env = project.Environment()
+        with pytest.raises(ToolNotFoundError, match="MakeAppx.exe"):
+            windows.create_msix(
+                project=project,
+                env=env,
+                name="TestApp",
+                version="1.0.0",
+                publisher="CN=Test Publisher",
+                sources=[],
+            )
+
+    def test_create_msix_with_signing_but_no_signtool(self, monkeypatch) -> None:
+        """Test that _find_sdk_tool raises if SignTool.exe is not found when signing."""
+        from pcons.contrib.installers import windows
+        from pcons.contrib.installers._helpers import ToolNotFoundError
+
+        # Monkeypatch _find_sdk_tool to return None for SignTool.exe
+        def _mock_find_sdk_tool(tool_name: str) -> str | None:
+            if tool_name == "SignTool.exe":
+                return None
+            else:
+                return "sometool.exe"
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", _mock_find_sdk_tool)
+        project = Project("test_msix_sign_error")
+        env = project.Environment()
+        with pytest.raises(ToolNotFoundError, match="SignTool.exe"):
+            windows.create_msix(
+                project=project,
+                env=env,
+                name="TestApp",
+                version="1.0.0",
+                publisher="CN=Test Publisher",
+                sources=[],
+                sign_cert=Path("dummy_cert.pfx"),
+            )
+
+
 class TestInstallersCLI:
     """Tests for the _helpers CLI interface."""
 

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -361,6 +361,34 @@ class TestInstallWithNinja:
         assert "build $topdir/dist/lib/mylib.a:" in content
         assert str(tmp_path) not in content
 
+    def test_no_prefix_relative_dest_stays_build_relative(self, tmp_path):
+        """no_prefix install with a relative dest is a build-dir-relative staging
+        path (e.g. the contrib installers), not an external install output.
+        """
+        from pcons.generators.ninja import NinjaGenerator
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        src_file = tmp_path / "app"
+        src_file.touch()
+
+        install = project.Install(".pkg_staging/payload", [src_file], no_prefix=True)
+        project.resolve()
+
+        node = install.output_nodes[0]
+        assert node.role is None
+        assert node.path == Path(".pkg_staging/payload/app")
+
+        gen = NinjaGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+        content = (tmp_path / "build" / "build.ninja").read_text()
+
+        # Emitted build-dir-relative (resolves to build/.pkg_staging/...),
+        # NOT via $topdir.
+        assert "build .pkg_staging/payload/app:" in content
+        assert "$topdir/.pkg_staging" not in content
+
 
 class TestInstallDirHelper:
     """Tests for the install_dir() convenience helper."""

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -86,13 +86,13 @@ class TestInstall:
         # Nodes are created during resolve
         project.resolve()
 
-        # Destination should be in dest_dir with same filename
-        # InstallNodeFactory prevents canonicalization (project.node(..., canonicalizes=False)
-        # in order to preserve the exact destination path specified by the user.
+        # Install destinations are first-class "install_output" nodes; their
+        # paths are canonicalized (project-root-relative when under the root)
+        # and tagged so generators render them relocatably.
         assert len(install.output_nodes) == 1
         node = install.output_nodes[0]
-        expected = dest_dir / "mylib.so"
-        assert node.path == expected
+        assert node.path == Path("bundle/Contents/MacOS/mylib.so")
+        assert node.role == "install_output"
 
     def test_install_from_target(self, tmp_path):
         """Install can install output files from a Target after resolve."""
@@ -120,12 +120,11 @@ class TestInstall:
         # Resolve to create install nodes
         project.resolve()
 
-        # Should have a node for the library
-        # InstallNodeFactory prevents canonicalization (project.node(..., canonicalizes=False)
-        # in order to preserve the exact destination path specified by the user.
+        # Should have a node for the library, canonicalized relative to the
+        # project root and tagged as an install output.
         assert len(install.output_nodes) == 1
-        expected = tmp_path / "dist" / "lib" / "libmylib.a"
-        assert install.output_nodes[0].path == expected
+        assert install.output_nodes[0].path == Path("dist/lib/libmylib.a")
+        assert install.output_nodes[0].role == "install_output"
 
     def test_install_non_absolute_dest_uses_pcons_install_prefix(self, tmp_path):
         """Install uses PCONS_INSTALL_PREFIX as the base install directory."""
@@ -140,9 +139,10 @@ class TestInstall:
         # Resolve to create install nodes
         project.resolve()
 
-        # Destination should be under PCONS_INSTALL_PREFIX (default: ./dist)
-        expected = tmp_path / "dist" / "lib" / "mylib.a"
-        assert install.output_nodes[0].path == expected
+        # Destination should be under PCONS_INSTALL_PREFIX (default: <root>/dist),
+        # canonicalized relative to the project root.
+        assert install.output_nodes[0].path == Path("dist/lib/mylib.a")
+        assert install.output_nodes[0].role == "install_output"
 
     def test_install_non_absolute_dest_can_be_customized_with_pcons_install_prefix(
         self, tmp_path, monkeypatch
@@ -162,9 +162,11 @@ class TestInstall:
             # Resolve to create install nodes
             project.resolve()
 
-            # Destination should be under the custom prefix
+            # The custom prefix is outside the project root, so the install
+            # path stays absolute (it cannot be made root-relative).
             expected = custom_prefix / "lib" / "mylib.a"
             assert install.output_nodes[0].path == expected
+            assert install.output_nodes[0].role == "install_output"
 
     def test_install_target_registered(self, tmp_path):
         """Install target is registered with the project."""
@@ -231,7 +233,8 @@ class TestInstallAs:
 
         assert len(install.output_nodes) == 1
         node = install.output_nodes[0]
-        assert node.path == dest_path
+        assert node.path == Path("bundle/Contents/MacOS/plugin.ofx")
+        assert node.role == "install_output"
 
     def test_install_as_from_target(self, tmp_path):
         """InstallAs can install from a Target after resolve."""
@@ -260,7 +263,8 @@ class TestInstallAs:
 
         # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        assert install.output_nodes[0].path == dest
+        assert install.output_nodes[0].path == Path("bundle/plugin.ofx")
+        assert install.output_nodes[0].role == "install_output"
 
     def test_install_as_dependency(self, tmp_path):
         """InstallAs destination depends on source after resolve."""
@@ -333,6 +337,58 @@ class TestInstallWithNinja:
         # Should have a build statement for the installed file
         assert "mylib.a" in content
 
+    def test_install_output_rendered_relocatably(self, tmp_path):
+        """Install destinations under the project root render via $topdir."""
+        from pcons.generators.ninja import NinjaGenerator
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        src_file = tmp_path / "mylib.a"
+        src_file.touch()
+
+        # Default prefix (<root>/dist) keeps the destination under the root.
+        project.Install("lib", [src_file])
+        project.resolve()
+
+        gen = NinjaGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "build" / "build.ninja").read_text()
+
+        # The install output is emitted relative to the project root ($topdir),
+        # not baked in as an absolute path, so the build file stays relocatable.
+        assert "build $topdir/dist/lib/mylib.a:" in content
+        assert str(tmp_path) not in content
+
+
+class TestInstallDirHelper:
+    """Tests for the install_dir() convenience helper."""
+
+    def test_install_dir_uses_toolchain_convention(self, tmp_path):
+        from pcons import install_dir
+        from pcons.toolchains import find_c_toolchain
+
+        try:
+            toolchain = find_c_toolchain()
+        except RuntimeError:
+            pytest.skip("No C toolchain available")
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        env = project.Environment(toolchain=toolchain)
+
+        assert install_dir(env, "program") == "bin"
+        assert install_dir(env, "static_library") == "lib"
+
+    def test_install_dir_requires_toolchain(self, tmp_path):
+        from pcons import install_dir
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        env = project.Environment()  # no toolchain
+
+        with pytest.raises(ValueError):
+            install_dir(env, "program")
+
 
 class TestInstallOrderIndependence:
     """Tests that Install/InstallAs work regardless of declaration order."""
@@ -369,8 +425,8 @@ class TestInstallOrderIndependence:
 
         # Install target should now have the installed file
         assert len(install.output_nodes) == 1
-        expected = tmp_path / "dist" / "lib" / "libmylib.a"
-        assert install.output_nodes[0].path == expected
+        assert install.output_nodes[0].path == Path("dist/lib/libmylib.a")
+        assert install.output_nodes[0].role == "install_output"
 
     def test_install_as_before_target_definition(self, tmp_path):
         """InstallAs can reference a target before its output_nodes are populated."""
@@ -405,7 +461,8 @@ class TestInstallOrderIndependence:
 
         # Should have the installed file with the custom name
         assert len(install.output_nodes) == 1
-        assert install.output_nodes[0].path == dest
+        assert install.output_nodes[0].path == Path("bundle/plugin.ofx")
+        assert install.output_nodes[0].role == "install_output"
 
     def test_install_chain_order_independence(self, tmp_path):
         """Install targets can be chained in any order."""
@@ -435,8 +492,13 @@ class TestInstallOrderIndependence:
         # Both should work
         assert len(final_install.output_nodes) == 1
         assert len(intermediate_install.output_nodes) == 1
-        assert final_install.output_nodes[0].path == final_dir / "mylib.a"
-        assert intermediate_install.output_nodes[0].path == intermediate_dir / "mylib.a"
+        # Paths are canonicalized relative to the project root.
+        assert final_install.output_nodes[0].path == (
+            final_dir / "mylib.a"
+        ).relative_to(tmp_path)
+        assert intermediate_install.output_nodes[0].path == (
+            intermediate_dir / "mylib.a"
+        ).relative_to(tmp_path)
 
     def test_install_file_before_it_exists(self, tmp_path):
         """Install can reference a file path before the file exists."""
@@ -451,10 +513,9 @@ class TestInstallOrderIndependence:
         # Resolve (file still doesn't exist, but that's OK for generation)
         project.resolve()
 
-        # Should have the install node
+        # Should have the install node (path canonicalized relative to root)
         assert len(install.output_nodes) == 1
-        expected = tmp_path / "include" / "generated.h"
-        assert install.output_nodes[0].path == expected
+        assert install.output_nodes[0].path == Path("include/generated.h")
 
 
 class TestInstallAsValidation:
@@ -510,7 +571,7 @@ class TestInstallAsValidation:
         project.resolve()
 
         assert len(install.output_nodes) == 1
-        assert install.output_nodes[0].path == expected_dest
+        assert install.output_nodes[0].path == expected_dest.relative_to(tmp_path)
 
 
 class TestInstallDirectoryAutoDetection:

--- a/tests/core/test_install.py
+++ b/tests/core/test_install.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: MIT
 """Tests for Project.Install() method."""
 
+from pathlib import Path
+
 import pytest
 
 from pcons.core.node import FileNode
@@ -85,10 +87,11 @@ class TestInstall:
         project.resolve()
 
         # Destination should be in dest_dir with same filename
-        # project.node() canonicalizes paths to be project-root-relative
+        # InstallNodeFactory prevents canonicalization (project.node(..., canonicalizes=False)
+        # in order to preserve the exact destination path specified by the user.
         assert len(install.output_nodes) == 1
         node = install.output_nodes[0]
-        expected = dest_dir.relative_to(tmp_path) / "mylib.so"
+        expected = dest_dir / "mylib.so"
         assert node.path == expected
 
     def test_install_from_target(self, tmp_path):
@@ -118,10 +121,50 @@ class TestInstall:
         project.resolve()
 
         # Should have a node for the library
-        # project.node() canonicalizes paths to be project-root-relative
+        # InstallNodeFactory prevents canonicalization (project.node(..., canonicalizes=False)
+        # in order to preserve the exact destination path specified by the user.
         assert len(install.output_nodes) == 1
-        expected = (tmp_path / "dist" / "lib" / "libmylib.a").relative_to(tmp_path)
+        expected = tmp_path / "dist" / "lib" / "libmylib.a"
         assert install.output_nodes[0].path == expected
+
+    def test_install_non_absolute_dest_uses_pcons_install_prefix(self, tmp_path):
+        """Install uses PCONS_INSTALL_PREFIX as the base install directory."""
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        src_file = tmp_path / "mylib.a"
+        src_file.touch()
+
+        # non-absolute dest paths uses PCONS_INSTALL_PREFIX
+        install = project.Install("lib", [src_file])
+
+        # Resolve to create install nodes
+        project.resolve()
+
+        # Destination should be under PCONS_INSTALL_PREFIX (default: ./dist)
+        expected = tmp_path / "dist" / "lib" / "mylib.a"
+        assert install.output_nodes[0].path == expected
+
+    def test_install_non_absolute_dest_can_be_customized_with_pcons_install_prefix(
+        self, tmp_path, monkeypatch
+    ):
+        """Install uses modified PCONS_INSTALL_PREFIX as the base install directory."""
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        src_file = tmp_path / "mylib.a"
+        src_file.touch()
+
+        with monkeypatch.context() as m:
+            # Set a custom install prefix via environment variable
+            custom_prefix = Path("/opt/myapp")
+            m.setenv("PCONS_INSTALL_PREFIX", str(custom_prefix))
+
+            install = project.Install("lib", [src_file])
+            # Resolve to create install nodes
+            project.resolve()
+
+            # Destination should be under the custom prefix
+            expected = custom_prefix / "lib" / "mylib.a"
+            assert install.output_nodes[0].path == expected
 
     def test_install_target_registered(self, tmp_path):
         """Install target is registered with the project."""
@@ -186,10 +229,9 @@ class TestInstallAs:
         # Resolve to create install nodes
         project.resolve()
 
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
         node = install.output_nodes[0]
-        assert node.path == dest_path.relative_to(tmp_path)
+        assert node.path == dest_path
 
     def test_install_as_from_target(self, tmp_path):
         """InstallAs can install from a Target after resolve."""
@@ -218,7 +260,7 @@ class TestInstallAs:
 
         # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        assert install.output_nodes[0].path == dest.relative_to(tmp_path)
+        assert install.output_nodes[0].path == dest
 
     def test_install_as_dependency(self, tmp_path):
         """InstallAs destination depends on source after resolve."""
@@ -318,7 +360,7 @@ class TestInstallOrderIndependence:
         assert len(lib.output_nodes) == 0
 
         # Manually add an output node (simulating what resolve would do)
-        lib_node = FileNode(tmp_path / "build" / "libmylib.a")
+        lib_node = FileNode(tmp_path / "dist" / "lib" / "libmylib.a")
         lib.output_nodes.append(lib_node)
         lib._resolved = True
 
@@ -326,9 +368,8 @@ class TestInstallOrderIndependence:
         project.resolve()
 
         # Install target should now have the installed file
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        expected = (tmp_path / "dist" / "lib" / "libmylib.a").relative_to(tmp_path)
+        expected = tmp_path / "dist" / "lib" / "libmylib.a"
         assert install.output_nodes[0].path == expected
 
     def test_install_as_before_target_definition(self, tmp_path):
@@ -363,9 +404,8 @@ class TestInstallOrderIndependence:
         project.resolve()
 
         # Should have the installed file with the custom name
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        assert install.output_nodes[0].path == dest.relative_to(tmp_path)
+        assert install.output_nodes[0].path == dest
 
     def test_install_chain_order_independence(self, tmp_path):
         """Install targets can be chained in any order."""
@@ -393,15 +433,10 @@ class TestInstallOrderIndependence:
         project.resolve()
 
         # Both should work
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(final_install.output_nodes) == 1
         assert len(intermediate_install.output_nodes) == 1
-        assert final_install.output_nodes[0].path == (
-            final_dir / "mylib.a"
-        ).relative_to(tmp_path)
-        assert intermediate_install.output_nodes[0].path == (
-            intermediate_dir / "mylib.a"
-        ).relative_to(tmp_path)
+        assert final_install.output_nodes[0].path == final_dir / "mylib.a"
+        assert intermediate_install.output_nodes[0].path == intermediate_dir / "mylib.a"
 
     def test_install_file_before_it_exists(self, tmp_path):
         """Install can reference a file path before the file exists."""
@@ -417,9 +452,8 @@ class TestInstallOrderIndependence:
         project.resolve()
 
         # Should have the install node
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        expected = (tmp_path / "include" / "generated.h").relative_to(tmp_path)
+        expected = tmp_path / "include" / "generated.h"
         assert install.output_nodes[0].path == expected
 
 
@@ -470,14 +504,13 @@ class TestInstallAsValidation:
         src.touch()
 
         # Should work with a single source
-        install = project.InstallAs(tmp_path / "dest" / "renamed.txt", src)
+        expected_dest = tmp_path / "dest" / "renamed.txt"
+        install = project.InstallAs(expected_dest, src)
 
         project.resolve()
 
-        # project.node() canonicalizes paths to be project-root-relative
         assert len(install.output_nodes) == 1
-        expected = (tmp_path / "dest" / "renamed.txt").relative_to(tmp_path)
-        assert install.output_nodes[0].path == expected
+        assert install.output_nodes[0].path == expected_dest
 
 
 class TestInstallDirectoryAutoDetection:

--- a/tests/core/test_vars.py
+++ b/tests/core/test_vars.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: MIT
+"""Tests for pcons core vars."""
+
+from __future__ import annotations
+
+import platform
+
+import pytest
+
+from pcons import (
+    get_var,
+    get_variant,
+)
+from pcons.core.vars import _clear_cli_vars, _reload_platform_vars
+
+
+class TestGetVar:
+    """Tests for get_var and get_variant functions."""
+
+    def test_get_var_default(self, monkeypatch) -> None:
+        """Test get_var returns default when not set."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        assert get_var("TEST_VAR", "default_value") == "default_value"
+
+    def test_get_var_no_default_raises(self, monkeypatch) -> None:
+        """Test get_var raises ValueError when not set and no default."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        with pytest.raises(ValueError):
+            get_var("TEST_VAR")
+
+    def test_get_var_with_none_default(self, monkeypatch) -> None:
+        """Test get_var returns None when default is None."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        assert get_var("TEST_VAR", None) is None
+
+    def test_get_var_from_env(self, monkeypatch) -> None:
+        """Test get_var reads from environment variable."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.setenv("TEST_VAR", "env_value")
+
+        assert get_var("TEST_VAR", "default") == "env_value"
+
+    def test_get_var_from_pcons_vars(self, monkeypatch) -> None:
+        """Test get_var reads from PCONS_VARS JSON."""
+        _clear_cli_vars()
+        monkeypatch.setenv("PCONS_VARS", '{"TEST_VAR": "cli_value"}')
+        monkeypatch.setenv("TEST_VAR", "env_value")  # Should be overridden
+
+        assert get_var("TEST_VAR", "default") == "cli_value"
+
+    def test_get_variant_default(self, monkeypatch) -> None:
+        """Test get_variant returns default when not set."""
+        monkeypatch.delenv("PCONS_VARIANT", raising=False)
+        monkeypatch.delenv("VARIANT", raising=False)
+
+        assert get_variant("release") == "release"
+
+    def test_get_variant_from_pcons_variant(self, monkeypatch) -> None:
+        """Test get_variant reads from PCONS_VARIANT (CLI sets this)."""
+        monkeypatch.setenv("PCONS_VARIANT", "debug")
+        monkeypatch.delenv("VARIANT", raising=False)
+
+        assert get_variant("release") == "debug"
+
+    def test_get_variant_from_variant_env(self, monkeypatch) -> None:
+        """Test get_variant falls back to VARIANT env var."""
+        monkeypatch.delenv("PCONS_VARIANT", raising=False)
+        monkeypatch.setenv("VARIANT", "debug")
+
+        assert get_variant("release") == "debug"
+
+    def test_get_variant_pcons_variant_takes_precedence(self, monkeypatch) -> None:
+        """Test PCONS_VARIANT takes precedence over VARIANT."""
+        monkeypatch.setenv("PCONS_VARIANT", "release")
+        monkeypatch.setenv("VARIANT", "debug")
+
+        assert get_variant("default") == "release"
+
+
+class TestPlatformVars:
+    """Tests for platform-specific variables."""
+
+    def test_linux_platform_vars(self, monkeypatch) -> None:
+        """Test platform-specific variables are set correctly."""
+        monkeypatch.setattr(platform, "system", lambda: "Linux")
+        _reload_platform_vars()
+        assert get_var("BINARY_EXT") == ""
+        assert get_var("LIBRARY_EXT") == ".so"
+        assert get_var("ARCHIVE_EXT") == ".a"
+        assert get_var("LIBRARY_PREFIX") == "lib"
+        assert get_var("PATHSEP") == ":"
+        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
+        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
+        assert get_var("BINARY_INSTALL_DIR") == "bin"
+
+    def test_windows_platform_vars(self, monkeypatch) -> None:
+        """Test platform-specific variables for Windows."""
+        monkeypatch.setattr(platform, "system", lambda: "Windows")
+        _reload_platform_vars()
+        assert get_var("BINARY_EXT") == ".exe"
+        assert get_var("LIBRARY_EXT") == ".dll"
+        assert get_var("ARCHIVE_EXT") == ".lib"
+        assert get_var("LIBRARY_PREFIX") == ""
+        assert get_var("PATHSEP") == ";"
+        assert get_var("LIBRARY_INSTALL_DIR") == "bin"
+        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
+        assert get_var("BINARY_INSTALL_DIR") == "bin"
+
+    def test_macos_platform_vars(self, monkeypatch) -> None:
+        """Test platform-specific variables for macOS."""
+        monkeypatch.setattr(platform, "system", lambda: "Darwin")
+        _reload_platform_vars()
+        assert get_var("BINARY_EXT") == ""
+        assert get_var("LIBRARY_EXT") == ".dylib"
+        assert get_var("ARCHIVE_EXT") == ".a"
+        assert get_var("LIBRARY_PREFIX") == "lib"
+        assert get_var("PATHSEP") == ":"
+        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
+        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
+        assert get_var("BINARY_INSTALL_DIR") == "bin"
+
+    def test_unknown_platform_vars(self, monkeypatch) -> None:
+        """Test platform-specific variables for unknown platform fallback (assuming POSIX)."""
+        monkeypatch.setattr(platform, "system", lambda: "Unknown")
+        _reload_platform_vars()
+        assert get_var("BINARY_EXT") == ""
+        assert get_var("LIBRARY_EXT") == ".so"
+        assert get_var("ARCHIVE_EXT") == ".a"
+        assert get_var("LIBRARY_PREFIX") == "lib"
+        assert get_var("PATHSEP") == ":"
+        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
+        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
+        assert get_var("BINARY_INSTALL_DIR") == "bin"

--- a/tests/core/test_vars.py
+++ b/tests/core/test_vars.py
@@ -3,15 +3,11 @@
 
 from __future__ import annotations
 
-import platform
-
-import pytest
-
 from pcons import (
     get_var,
     get_variant,
 )
-from pcons.core.vars import _clear_cli_vars, _reload_platform_vars
+from pcons.core.vars import _clear_cli_vars
 
 
 class TestGetVar:
@@ -25,14 +21,13 @@ class TestGetVar:
 
         assert get_var("TEST_VAR", "default_value") == "default_value"
 
-    def test_get_var_no_default_raises(self, monkeypatch) -> None:
-        """Test get_var raises ValueError when not set and no default."""
+    def test_get_var_no_default_returns_none(self, monkeypatch) -> None:
+        """Test get_var returns None when not set and no default given."""
         _clear_cli_vars()
         monkeypatch.delenv("PCONS_VARS", raising=False)
         monkeypatch.delenv("TEST_VAR", raising=False)
 
-        with pytest.raises(ValueError):
-            get_var("TEST_VAR")
+        assert get_var("TEST_VAR") is None
 
     def test_get_var_with_none_default(self, monkeypatch) -> None:
         """Test get_var returns None when default is None."""
@@ -85,59 +80,3 @@ class TestGetVar:
         monkeypatch.setenv("VARIANT", "debug")
 
         assert get_variant("default") == "release"
-
-
-class TestPlatformVars:
-    """Tests for platform-specific variables."""
-
-    def test_linux_platform_vars(self, monkeypatch) -> None:
-        """Test platform-specific variables are set correctly."""
-        monkeypatch.setattr(platform, "system", lambda: "Linux")
-        _reload_platform_vars()
-        assert get_var("BINARY_EXT") == ""
-        assert get_var("LIBRARY_EXT") == ".so"
-        assert get_var("ARCHIVE_EXT") == ".a"
-        assert get_var("LIBRARY_PREFIX") == "lib"
-        assert get_var("PATHSEP") == ":"
-        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
-        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
-        assert get_var("BINARY_INSTALL_DIR") == "bin"
-
-    def test_windows_platform_vars(self, monkeypatch) -> None:
-        """Test platform-specific variables for Windows."""
-        monkeypatch.setattr(platform, "system", lambda: "Windows")
-        _reload_platform_vars()
-        assert get_var("BINARY_EXT") == ".exe"
-        assert get_var("LIBRARY_EXT") == ".dll"
-        assert get_var("ARCHIVE_EXT") == ".lib"
-        assert get_var("LIBRARY_PREFIX") == ""
-        assert get_var("PATHSEP") == ";"
-        assert get_var("LIBRARY_INSTALL_DIR") == "bin"
-        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
-        assert get_var("BINARY_INSTALL_DIR") == "bin"
-
-    def test_macos_platform_vars(self, monkeypatch) -> None:
-        """Test platform-specific variables for macOS."""
-        monkeypatch.setattr(platform, "system", lambda: "Darwin")
-        _reload_platform_vars()
-        assert get_var("BINARY_EXT") == ""
-        assert get_var("LIBRARY_EXT") == ".dylib"
-        assert get_var("ARCHIVE_EXT") == ".a"
-        assert get_var("LIBRARY_PREFIX") == "lib"
-        assert get_var("PATHSEP") == ":"
-        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
-        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
-        assert get_var("BINARY_INSTALL_DIR") == "bin"
-
-    def test_unknown_platform_vars(self, monkeypatch) -> None:
-        """Test platform-specific variables for unknown platform fallback (assuming POSIX)."""
-        monkeypatch.setattr(platform, "system", lambda: "Unknown")
-        _reload_platform_vars()
-        assert get_var("BINARY_EXT") == ""
-        assert get_var("LIBRARY_EXT") == ".so"
-        assert get_var("ARCHIVE_EXT") == ".a"
-        assert get_var("LIBRARY_PREFIX") == "lib"
-        assert get_var("PATHSEP") == ":"
-        assert get_var("LIBRARY_INSTALL_DIR") == "lib"
-        assert get_var("ARCHIVE_INSTALL_DIR") == "lib"
-        assert get_var("BINARY_INSTALL_DIR") == "bin"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ from pcons.cli import (
     run_script,
     setup_logging,
 )
+from pcons.core.vars import _clear_cli_vars
 
 if TYPE_CHECKING:
     pass
@@ -94,20 +95,32 @@ class TestGetVar:
 
     def test_get_var_default(self, monkeypatch) -> None:
         """Test get_var returns default when not set."""
-        # Clear any cached vars
-        import pcons
-
-        pcons._cli_vars = None
+        _clear_cli_vars()
         monkeypatch.delenv("PCONS_VARS", raising=False)
         monkeypatch.delenv("TEST_VAR", raising=False)
 
         assert get_var("TEST_VAR", "default_value") == "default_value"
 
+    def test_get_var_no_default_raises(self, monkeypatch) -> None:
+        """Test get_var raises ValueError when not set and no default."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        with pytest.raises(ValueError):
+            get_var("TEST_VAR")
+
+    def test_get_var_with_none_default(self, monkeypatch) -> None:
+        """Test get_var returns None when default is None."""
+        _clear_cli_vars()
+        monkeypatch.delenv("PCONS_VARS", raising=False)
+        monkeypatch.delenv("TEST_VAR", raising=False)
+
+        assert get_var("TEST_VAR", None) is None
+
     def test_get_var_from_env(self, monkeypatch) -> None:
         """Test get_var reads from environment variable."""
-        import pcons
-
-        pcons._cli_vars = None
+        _clear_cli_vars()
         monkeypatch.delenv("PCONS_VARS", raising=False)
         monkeypatch.setenv("TEST_VAR", "env_value")
 
@@ -115,9 +128,7 @@ class TestGetVar:
 
     def test_get_var_from_pcons_vars(self, monkeypatch) -> None:
         """Test get_var reads from PCONS_VARS JSON."""
-        import pcons
-
-        pcons._cli_vars = None
+        _clear_cli_vars()
         monkeypatch.setenv("PCONS_VARS", '{"TEST_VAR": "cli_value"}')
         monkeypatch.setenv("TEST_VAR", "env_value")  # Should be overridden
 
@@ -355,15 +366,13 @@ class TestRunScriptEnvironment:
         """Pre-existing PCONS environment should be restored after the run."""
         import os
 
-        import pcons
-
         script = tmp_path / "pcons-build.py"
         script.write_text("from pcons import Project\nProject('demo')\n")
 
         monkeypatch.setenv("PCONS_BUILD_DIR", "original-build")
         monkeypatch.setenv("PCONS_GENERATOR", "original-generator")
         monkeypatch.setenv("CUSTOM_ENV", "original-custom")
-        pcons._cli_vars = None
+        _clear_cli_vars()
 
         exit_code, projects = run_script(
             script,
@@ -384,7 +393,6 @@ class TestRunScriptEnvironment:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """run_script with a list of generators sets PCONS_GENERATOR as colon-joined."""
-        import pcons
 
         script = tmp_path / "pcons-build.py"
         script.write_text(
@@ -396,7 +404,7 @@ class TestRunScriptEnvironment:
         )
 
         monkeypatch.delenv("PCONS_GENERATOR", raising=False)
-        pcons._cli_vars = None
+        _clear_cli_vars()
 
         exit_code, _ = run_script(
             script, tmp_path / "build", generator=["ninja", "metadata"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,7 +7,6 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
 
 import pytest
 
@@ -17,8 +16,6 @@ from pcons import (
     MetadataGenerator,
     MultiGenerator,
     NinjaGenerator,
-    get_var,
-    get_variant,
 )
 from pcons.cli import (
     find_command_in_argv,
@@ -28,9 +25,6 @@ from pcons.cli import (
     setup_logging,
 )
 from pcons.core.vars import _clear_cli_vars
-
-if TYPE_CHECKING:
-    pass
 
 
 def _has_c_compiler() -> bool:
@@ -88,79 +82,6 @@ class TestSetupLogging:
     def test_setup_logging_debug(self) -> None:
         """Test debug logging setup with subsystem specification."""
         setup_logging(verbose=False, debug="resolve,subst")
-
-
-class TestGetVar:
-    """Tests for get_var and get_variant functions."""
-
-    def test_get_var_default(self, monkeypatch) -> None:
-        """Test get_var returns default when not set."""
-        _clear_cli_vars()
-        monkeypatch.delenv("PCONS_VARS", raising=False)
-        monkeypatch.delenv("TEST_VAR", raising=False)
-
-        assert get_var("TEST_VAR", "default_value") == "default_value"
-
-    def test_get_var_no_default_raises(self, monkeypatch) -> None:
-        """Test get_var raises ValueError when not set and no default."""
-        _clear_cli_vars()
-        monkeypatch.delenv("PCONS_VARS", raising=False)
-        monkeypatch.delenv("TEST_VAR", raising=False)
-
-        with pytest.raises(ValueError):
-            get_var("TEST_VAR")
-
-    def test_get_var_with_none_default(self, monkeypatch) -> None:
-        """Test get_var returns None when default is None."""
-        _clear_cli_vars()
-        monkeypatch.delenv("PCONS_VARS", raising=False)
-        monkeypatch.delenv("TEST_VAR", raising=False)
-
-        assert get_var("TEST_VAR", None) is None
-
-    def test_get_var_from_env(self, monkeypatch) -> None:
-        """Test get_var reads from environment variable."""
-        _clear_cli_vars()
-        monkeypatch.delenv("PCONS_VARS", raising=False)
-        monkeypatch.setenv("TEST_VAR", "env_value")
-
-        assert get_var("TEST_VAR", "default") == "env_value"
-
-    def test_get_var_from_pcons_vars(self, monkeypatch) -> None:
-        """Test get_var reads from PCONS_VARS JSON."""
-        _clear_cli_vars()
-        monkeypatch.setenv("PCONS_VARS", '{"TEST_VAR": "cli_value"}')
-        monkeypatch.setenv("TEST_VAR", "env_value")  # Should be overridden
-
-        assert get_var("TEST_VAR", "default") == "cli_value"
-
-    def test_get_variant_default(self, monkeypatch) -> None:
-        """Test get_variant returns default when not set."""
-        monkeypatch.delenv("PCONS_VARIANT", raising=False)
-        monkeypatch.delenv("VARIANT", raising=False)
-
-        assert get_variant("release") == "release"
-
-    def test_get_variant_from_pcons_variant(self, monkeypatch) -> None:
-        """Test get_variant reads from PCONS_VARIANT (CLI sets this)."""
-        monkeypatch.setenv("PCONS_VARIANT", "debug")
-        monkeypatch.delenv("VARIANT", raising=False)
-
-        assert get_variant("release") == "debug"
-
-    def test_get_variant_from_variant_env(self, monkeypatch) -> None:
-        """Test get_variant falls back to VARIANT env var."""
-        monkeypatch.delenv("PCONS_VARIANT", raising=False)
-        monkeypatch.setenv("VARIANT", "debug")
-
-        assert get_variant("release") == "debug"
-
-    def test_get_variant_pcons_variant_takes_precedence(self, monkeypatch) -> None:
-        """Test PCONS_VARIANT takes precedence over VARIANT."""
-        monkeypatch.setenv("PCONS_VARIANT", "release")
-        monkeypatch.setenv("VARIANT", "debug")
-
-        assert get_variant("default") == "release"
 
 
 class TestGenerator:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -12,11 +12,13 @@ Tests both invocation methods:
 
 from __future__ import annotations
 
+import fnmatch
 import os
 import platform
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -201,7 +203,7 @@ def run_rebuild_test(
     # If expect_rebuild: verify each target was rebuilt (substring match)
     expect_rebuild = rebuild_config.get("expect_rebuild", [])
     for expected in expect_rebuild:
-        found = any(expected in target for target in rebuilt_targets)
+        found = any(fnmatch.fnmatch(target, expected) for target in rebuilt_targets)
         if not found:
             pytest.fail(
                 f"Rebuild test '{description}': expected '{expected}' to be rebuilt, "
@@ -211,7 +213,7 @@ def run_rebuild_test(
     # If expect_no_rebuild: verify each target was NOT rebuilt
     expect_no_rebuild = rebuild_config.get("expect_no_rebuild", [])
     for not_expected in expect_no_rebuild:
-        found = any(not_expected in target for target in rebuilt_targets)
+        found = any(fnmatch.fnmatch(target, not_expected) for target in rebuilt_targets)
         if found:
             pytest.fail(
                 f"Rebuild test '{description}': expected '{not_expected}' NOT to be rebuilt, "
@@ -661,7 +663,23 @@ def run_example(
         pytest.skip(f"Requested toolchain '{toolchain}' is not available on this host")
 
     build_dir.mkdir(parents=True, exist_ok=True)
-    tc_vars = {"TOOLCHAIN": toolchain} if toolchain else None
+    tc_vars = {"TOOLCHAIN": toolchain} if toolchain else {}
+
+    # Check expected install outputs exist (auto-adapts for Windows if no override)
+    expected_install_outputs = get_platform_value(
+        test_config, "expected_install_outputs", [], adapt_for_windows=True
+    )
+
+    build_targets = get_platform_value(test_config, "build_targets", [])
+
+    if expected_install_outputs:
+        if "install" not in build_targets:
+            build_targets.append("install")
+
+        install_prefix = tempfile.TemporaryDirectory()
+        tc_vars["PCONS_INSTALL_PREFIX"] = install_prefix.name
+    else:
+        install_prefix = None
 
     for variant in variants:
         _run_generate(
@@ -709,8 +727,6 @@ def run_example(
         if ninja_cmd_base is None:
             pytest.skip("ninja not available")
 
-        build_targets = get_platform_value(test_config, "build_targets", [])
-
         for vbd in variant_build_dirs:
             ninja_file = vbd / "build.ninja"
             if not ninja_file.exists():
@@ -733,8 +749,6 @@ def run_example(
     elif generator == "make":
         if shutil.which("make") is None:
             pytest.skip("make not available")
-
-        build_targets = get_platform_value(test_config, "build_targets", [])
 
         for vbd in variant_build_dirs:
             makefile = vbd / "Makefile"
@@ -808,9 +822,35 @@ def run_example(
         expected_outputs, generator, project_name
     )
     for output in expected_outputs:
-        output_path = work_dir / output
+        if "*" in output:
+            # Handle wildcard outputs (e.g., build/*.o)
+            matches = list(work_dir.glob(output))
+            if not matches:
+                pytest.fail(f"Expected output not found: {output} (no matches)")
+        else:
+            output_path = work_dir / output
+            if not output_path.exists():
+                pytest.fail(f"Expected output not found: {output}")
+
+    for output in expected_install_outputs:
+        assert install_prefix is not None
+        if isinstance(output, list):
+            output = output[0]
+            content = output[1]
+        else:
+            content = None
+        output_path = Path(install_prefix.name) / output
         if not output_path.exists():
-            pytest.fail(f"Expected output not found: {output}")
+            pytest.fail(f"Expected install output not found: {output}")
+        if content is not None:
+            actual_content = output_path.read_text()
+            if content not in actual_content:
+                pytest.fail(
+                    f"Expected '{content}' in installed {output}, got:\n{actual_content}"
+                )
+
+    if install_prefix is not None:
+        install_prefix.cleanup()
 
     # Run verification commands (auto-adapts for Windows if no override)
     verify_config = config.get("verify", {})

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import fnmatch
 import os
 import platform
+import re
 import shutil
 import subprocess
 import sys
@@ -592,6 +593,20 @@ def _run_generate(
             pytest.fail(f"pcons failed with code {result.returncode}{variant_msg}")
 
 
+_variable_expr = re.compile(r"\$\{([^}]+)\}")
+
+
+def _substitute_variables(path: str) -> str:
+    """Substitute variables in the path string."""
+    from pcons.core.vars import get_var
+
+    def replacer(match: re.Match) -> str:
+        var_name = match.group(1)
+        return get_var(var_name)
+
+    return _variable_expr.sub(replacer, path)
+
+
 def run_example(
     example_dir: Path,
     tmp_path: Path,
@@ -822,6 +837,7 @@ def run_example(
         expected_outputs, generator, project_name
     )
     for output in expected_outputs:
+        output = _substitute_variables(output)
         if "*" in output:
             # Handle wildcard outputs (e.g., build/*.o)
             matches = list(work_dir.glob(output))
@@ -839,6 +855,7 @@ def run_example(
             content = output[1]
         else:
             content = None
+        output = _substitute_variables(output)
         output_path = Path(install_prefix.name) / output
         if not output_path.exists():
             pytest.fail(f"Expected install output not found: {output}")

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -93,7 +93,6 @@ def adapt_path_for_windows(path: str, gcc_toolchain: bool = False) -> str:
             path = path[:-3] + ".dll"
 
     # Add .exe to executables (paths in build/ without extension)
-    # Check if it's a build output without an extension
     if "\\build\\" in path or path.startswith("build\\"):
         parts = path.rsplit("\\", 1)
         if len(parts) == 2 and "." not in parts[1]:
@@ -153,6 +152,7 @@ def run_rebuild_test(
     work_dir: Path,
     build_dir: Path,
     rebuild_config: dict[str, Any],
+    toolchain: str | None = None,
 ) -> None:
     """Run a single rebuild test scenario.
 
@@ -161,6 +161,7 @@ def run_rebuild_test(
         build_dir: Build output directory
         rebuild_config: Dict with keys like 'description', 'touch', 'expect_rebuild',
                        'expect_no_rebuild', 'expect_no_work'
+        toolchain: Optional toolchain name (used for platform path adaptation)
     """
     description = rebuild_config.get("description", "unnamed rebuild test")
 
@@ -205,8 +206,21 @@ def run_rebuild_test(
                 f"but ninja rebuilt: {rebuilt_targets}"
             )
 
-    # If expect_rebuild: verify each target was rebuilt (substring match)
-    expect_rebuild = rebuild_config.get("expect_rebuild", [])
+    # Adapt expected paths for the current platform
+    gcc_tc = toolchain == "gcc"
+
+    def _adapt(p: str) -> str:
+        if not IS_WINDOWS:
+            return p
+        adapted = adapt_path_for_windows(p, gcc_toolchain=gcc_tc)
+        # Rebuild paths are build-dir-relative bare names (e.g. "hello");
+        # adapt_path_for_windows only adds .exe for build/-prefixed paths.
+        if "\\" not in adapted and "." not in adapted and adapted:
+            adapted += ".exe"
+        return adapted
+
+    # If expect_rebuild: verify each target was rebuilt
+    expect_rebuild = [_adapt(p) for p in rebuild_config.get("expect_rebuild", [])]
     for expected in expect_rebuild:
         found = any(fnmatch.fnmatch(target, expected) for target in rebuilt_targets)
         if not found:
@@ -216,7 +230,7 @@ def run_rebuild_test(
             )
 
     # If expect_no_rebuild: verify each target was NOT rebuilt
-    expect_no_rebuild = rebuild_config.get("expect_no_rebuild", [])
+    expect_no_rebuild = [_adapt(p) for p in rebuild_config.get("expect_no_rebuild", [])]
     for not_expected in expect_no_rebuild:
         found = any(fnmatch.fnmatch(target, not_expected) for target in rebuilt_targets)
         if found:
@@ -519,10 +533,19 @@ def get_platform_value(
     # Optionally adapt for Windows when no override exists
     if adapt_for_windows and IS_WINDOWS and value is not None:
         if isinstance(value, list):
-            return [
-                adapt_path_for_windows(str(v), gcc_toolchain=gcc_toolchain)
-                for v in value
-            ]
+            result = []
+            for v in value:
+                if isinstance(v, list):
+                    # [path, content] pair — adapt only the path (first element)
+                    result.append(
+                        [adapt_path_for_windows(str(v[0]), gcc_toolchain=gcc_toolchain)]
+                        + v[1:]
+                    )
+                else:
+                    result.append(
+                        adapt_path_for_windows(str(v), gcc_toolchain=gcc_toolchain)
+                    )
+            return result
         elif isinstance(value, str):
             return adapt_path_for_windows(value, gcc_toolchain=gcc_toolchain)
 
@@ -857,8 +880,7 @@ def run_example(
         for output in expected_install_outputs:
             assert install_prefix is not None
             if isinstance(output, list):
-                output = output[0]
-                content = output[1]
+                output, content = output[0], output[1]
             else:
                 content = None
             output = _substitute_variables(output)
@@ -983,7 +1005,9 @@ def run_example(
                 pytest.skip("ninja not available for rebuild tests")
 
             for rebuild_config in rebuild_tests:
-                run_rebuild_test(work_dir, build_dir, rebuild_config)
+                run_rebuild_test(
+                    work_dir, build_dir, rebuild_config, toolchain=toolchain
+                )
 
 
 # Discover examples and create test parameters

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -70,6 +70,10 @@ def adapt_path_for_windows(path: str, gcc_toolchain: bool = False) -> str:
     if path.startswith(".\\"):
         path = path[2:]
 
+    if path.endswith("EXT}"):
+        # Don't adapt if extension variables are used, as they will be substituted later
+        return path
+
     # Convert extensions
     if path.endswith(".o") and not gcc_toolchain:
         path = path[:-2] + ".obj"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -623,13 +623,37 @@ def _run_generate(
 _variable_expr = re.compile(r"\$\{([^}]+)\}")
 
 
+def _example_template_vars() -> dict[str, str]:
+    """Platform-derived substitutions for ``${...}`` placeholders in test.toml."""
+    from pcons.configure.platform import get_platform
+
+    plat = get_platform()
+    # Shared libraries install next to executables on DLL platforms (Windows),
+    # matching Toolchain.get_install_dir("shared_library").
+    shared_install_dir = "bin" if plat.shared_lib_suffix == ".dll" else "lib"
+    return {
+        "BINARY_EXT": plat.exe_suffix,
+        "LIBRARY_EXT": plat.shared_lib_suffix,
+        "ARCHIVE_EXT": plat.static_lib_suffix,
+        "LIBRARY_PREFIX": plat.shared_lib_prefix,
+        "BINARY_INSTALL_DIR": "bin",
+        "LIBRARY_INSTALL_DIR": shared_install_dir,
+        "ARCHIVE_INSTALL_DIR": "lib",
+    }
+
+
 def _substitute_variables(path: str) -> str:
-    """Substitute variables in the path string."""
-    from pcons.core.vars import get_var
+    """Substitute ``${VAR}`` placeholders in an expected-output path."""
+    table = _example_template_vars()
 
     def replacer(match: re.Match) -> str:
         var_name = match.group(1)
-        return get_var(var_name)
+        if var_name not in table:
+            raise KeyError(
+                f"Unknown test.toml template variable: ${{{var_name}}}. "
+                f"Known: {', '.join(sorted(table))}"
+            )
+        return table[var_name]
 
     return _variable_expr.sub(replacer, path)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -691,14 +691,14 @@ def run_example(
 
     build_targets = get_platform_value(test_config, "build_targets", [])
 
-    if expected_install_outputs:
-        if "install" not in build_targets:
-            build_targets.append("install")
+    install_prefix = None
+    if generator != "xcode":
+        if expected_install_outputs:
+            if "install" not in build_targets:
+                build_targets.append("install")
 
-        install_prefix = tempfile.TemporaryDirectory()
-        tc_vars["PCONS_INSTALL_PREFIX"] = install_prefix.name
-    else:
-        install_prefix = None
+            install_prefix = tempfile.TemporaryDirectory()
+            tc_vars["PCONS_INSTALL_PREFIX"] = install_prefix.name
 
     for variant in variants:
         _run_generate(
@@ -852,23 +852,25 @@ def run_example(
             if not output_path.exists():
                 pytest.fail(f"Expected output not found: {output}")
 
-    for output in expected_install_outputs:
-        assert install_prefix is not None
-        if isinstance(output, list):
-            output = output[0]
-            content = output[1]
-        else:
-            content = None
-        output = _substitute_variables(output)
-        output_path = Path(install_prefix.name) / output
-        if not output_path.exists():
-            pytest.fail(f"Expected install output not found: {output}")
-        if content is not None:
-            actual_content = output_path.read_text()
-            if content not in actual_content:
-                pytest.fail(
-                    f"Expected '{content}' in installed {output}, got:\n{actual_content}"
-                )
+    if generator != "xcode":
+        # no install on xcode generator, so skip install output checks
+        for output in expected_install_outputs:
+            assert install_prefix is not None
+            if isinstance(output, list):
+                output = output[0]
+                content = output[1]
+            else:
+                content = None
+            output = _substitute_variables(output)
+            output_path = Path(install_prefix.name) / output
+            if not output_path.exists():
+                pytest.fail(f"Expected install output not found: {output}")
+            if content is not None:
+                actual_content = output_path.read_text()
+                if content not in actual_content:
+                    pytest.fail(
+                        f"Expected '{content}' in installed {output}, got:\n{actual_content}"
+                    )
 
     if install_prefix is not None:
         install_prefix.cleanup()

--- a/tests/tools/test_toolchain.py
+++ b/tests/tools/test_toolchain.py
@@ -86,6 +86,36 @@ class TestAuxiliaryInputHandler:
         assert handler is None
 
 
+class TestInstallDir:
+    """Tests for the toolchain-based install-dir convention."""
+
+    def test_program_goes_to_bin(self):
+        tc = MockToolchain()
+        assert tc.get_install_dir("program") == "bin"
+
+    def test_static_library_goes_to_lib(self):
+        tc = MockToolchain()
+        assert tc.get_install_dir("static_library") == "lib"
+
+    def test_shared_library_unix_goes_to_lib(self):
+        """ELF/Mach-O shared libraries (.so/.dylib) install to lib/."""
+
+        class UnixToolchain(MockToolchain):
+            def get_output_suffix(self, target_type: str) -> str:
+                return ".so" if target_type == "shared_library" else ""
+
+        assert UnixToolchain().get_install_dir("shared_library") == "lib"
+
+    def test_shared_library_dll_goes_to_bin(self):
+        """Windows DLLs install next to executables in bin/."""
+
+        class DllToolchain(MockToolchain):
+            def get_output_suffix(self, target_type: str) -> str:
+                return ".dll" if target_type == "shared_library" else ".exe"
+
+        assert DllToolchain().get_install_dir("shared_library") == "bin"
+
+
 class TestLanguagePriority:
     def test_default_priorities(self):
         tc = MockToolchain()


### PR DESCRIPTION
### Summary :memo:
Allow pcons to install build artifacts outside of the build directory by introducing a `PCONS_INSTALL_PREFIX` customization variable. This also includes a refactor of variable management into a dedicated module with platform-aware built-in install directory variables, and improved wildcard support in example tests.

### Details
1. **Allow pcons to install outside of build directory** - Introduced `PCONS_INSTALL_PREFIX` (defaulted to `<project-root>/dist`) to control the install destination. Updated `InstallBuilder` to resolve the prefix when the destination is not an absolute path. Added a `canonicalize` option to `Project.node()` and `Project.dir_node()` to support non-canonicalized paths. Updated test cases and adjusted the `06_archive_install` example accordingly.
2. **Homogeneous `PCONS_INSTALL_PREFIX` handling across all install builders** - Extended prefix support to `InstallAsBuilder` and `InstallDirBuilder` for consistent behavior. Improved `test_examples.py` to support wildcards in `expect_rebuild`, `expect_no_rebuild`, and `expected_outputs`. Added `expected_install_outputs` to `test.toml` with wildcard support.
3. **Install helper function** - Return the conventional install subdirectory for *target_type* (e.g: "program" -> "bin", "static_library" -> "lib", etc...).

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
