### PR TITLE
Feature/cxxmodule bmi compat

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -244,7 +244,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ \
             /usr/bin/g++-15 100
       - name: Run C++20 modules example tests
-        run: uv run pytest tests/test_examples.py --cov=pcons --cov-report=xml -k "29_cxx_modules or 30_cxx_partitions or 31_cxx_modules_optin or 32_cxx_import_std or 35_cxx_modules_deps" -v
+        run: uv run pytest tests/test_examples.py --cov=pcons --cov-report=xml -k "29_cxx_modules or 30_cxx_partitions or 31_cxx_modules_optin or 32_cxx_import_std or 35_cxx_modules_deps or 39_bmi_compat" -v
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:

--- a/examples/39_bmi_compat/consumer.cpp
+++ b/examples/39_bmi_compat/consumer.cpp
@@ -1,1 +1,6 @@
+// SPDX-License-Identifier: MIT
 import provider;
+
+int consume() {
+    return answer();
+}

--- a/examples/39_bmi_compat/consumer.cpp
+++ b/examples/39_bmi_compat/consumer.cpp
@@ -1,0 +1,1 @@
+import provider;

--- a/examples/39_bmi_compat/main.cpp
+++ b/examples/39_bmi_compat/main.cpp
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+#include <cstdio>
+
+int consume();  // provided by lib1 (consumer.cpp)
+
+int main() {
+    std::printf("answer = %d\n", consume());
+    return consume() == 42 ? 0 : 1;
+}

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -1,7 +1,28 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Build script demonstrating C++20 module interface (BMI) reuse across targets.
+
+A Binary Module Interface (`.gcm` on GCC) can only be consumed by translation
+units compiled with matching BMI-sensitive flags (C++ dialect, ABI knobs, ...).
+pcons keys each BMI by a hash of those flags and stores it under
+`cxx_modules/<hash>/<module>.gcm`, wiring every translation unit to the right
+BMI via a per-key GCC module mapper file. As a result:
+
+  - lib1 and lib2 compile `provider.cppm` with identical flags (`-std=c++23`),
+    so they share one compiled interface (`cxx_modules/<hashA>/provider.gcm`).
+    pcons's object cache already collapses the two identical compiles into a
+    single object + BMI.
+  - lib3 compiles `provider.cppm` with `-std=c++26` - a BMI-incompatible
+    dialect - so it gets its own interface (`cxx_modules/<hashB>/provider.gcm`).
+
+Status by toolchain:
+  - GCC:  supported (per-key BMI dirs + module mapper files).
+  - Clang/MSVC: not yet wired for cross-target BMI reuse.
+"""
+
 from pcons import Project, find_c_toolchain, get_var
 
 project = Project("bmi-compat")
-
 
 toolchain_override = get_var("TOOLCHAIN")
 if toolchain_override:
@@ -11,35 +32,20 @@ else:
 
 env = project.Environment(toolchain=toolchain)
 
-# lib1 - reference library
-lib1 = project.StaticLibrary(
-    "lib1",
-    env,
-    sources=["provider.cppm", "consumer.cpp"],
-)
+# lib1 and lib2: identical (-std=c++23) -> share one compiled interface.
+lib1 = project.StaticLibrary("lib1", env, sources=["provider.cppm", "consumer.cpp"])
 lib1.private.compile_flags.append("-std=c++23")
 
-# lib2 - provider.bmi should point to the same BMI as lib1 (same flags)
-# status:
-#  - GCC: OK, uses gcm.cache/provider.gcm
-#  - Clang: OK, uses cxx_modules/provider.gcm
-#  - MSVC: ???
-lib2 = project.StaticLibrary(
-    "lib2",
-    env,
-    sources=["provider.cppm", "consumer.cpp"],
-)
+lib2 = project.StaticLibrary("lib2", env, sources=["provider.cppm", "consumer.cpp"])
 lib2.private.compile_flags.append("-std=c++23")
 
-
-# lib3 - provider.bmi should point to a NEW BMI (c++26 is BMI breaker)
-# status:
-#  - GCC: does not compile (multiple rules generate gcm.cache/provider.gcm)
-#  - Clang: multiple rules generate cxx_modules/provider.pcm
-#  - MSVC: ???
-lib3 = project.StaticLibrary(
-    "lib3",
-    env,
-    sources=["provider.cppm", "consumer.cpp"],
-)
+# lib3: -std=c++26 is a BMI breaker -> gets its own compiled interface.
+lib3 = project.StaticLibrary("lib3", env, sources=["provider.cppm", "consumer.cpp"])
 lib3.private.compile_flags.append("-std=c++26")
+
+# A program to prove the c++23 interface links and runs end to end.
+app = project.Program("app", env, sources=["main.cpp"])
+app.private.compile_flags.append("-std=c++23")
+app.link(lib1)
+
+project.generate()

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -38,14 +38,13 @@ else:
 env = project.Environment(toolchain=toolchain)
 
 # Pick a shared dialect and a BMI-incompatible "breaker" dialect per toolchain.
-# MSVC needs /std: (and /EHsc to compile modules); GCC/clang use -std=.
 if toolchain.name == "msvc":
     env.cxx.flags.append("/EHsc")
     shared_dialect = ["/std:c++20"]
     breaker_dialect = ["/std:c++latest"]
 else:
-    shared_dialect = ["-std=c++23"]
-    breaker_dialect = ["-std=c++26"]
+    shared_dialect = ["-std=c++20"]
+    breaker_dialect = ["-std=c++23"]
 
 # lib1 and lib2: identical flags -> share one compiled interface.
 lib1 = project.StaticLibrary("lib1", env, sources=["provider.cppm", "consumer.cpp"])

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -1,0 +1,45 @@
+from pcons import Project, find_c_toolchain, get_var
+
+project = Project("bmi-compat")
+
+
+toolchain_override = get_var("TOOLCHAIN")
+if toolchain_override:
+    toolchain = find_c_toolchain(prefer=[toolchain_override])
+else:
+    toolchain = find_c_toolchain(prefer=["gcc", "llvm", "msvc"])
+
+env = project.Environment(toolchain=toolchain)
+
+# lib1 - reference library
+lib1 = project.StaticLibrary(
+    "lib1",
+    env,
+    sources=["provider.cppm", "consumer.cpp"],
+)
+lib1.private.compile_flags.append("-std=c++23")
+
+# lib2 - provider.bmi should point to the same BMI as lib1 (same flags)
+# status:
+#  - GCC: OK, uses gcm.cache/provider.gcm
+#  - Clang: OK, uses cxx_modules/provider.gcm
+#  - MSVC: ???
+lib2 = project.StaticLibrary(
+    "lib2",
+    env,
+    sources=["provider.cppm", "consumer.cpp"],
+)
+lib2.private.compile_flags.append("-std=c++23")
+
+
+# lib3 - provider.bmi should point to a NEW BMI (c++26 is BMI breaker)
+# status:
+#  - GCC: does not compile (multiple rules generate gcm.cache/provider.gcm)
+#  - Clang: multiple rules generate cxx_modules/provider.pcm
+#  - MSVC: ???
+lib3 = project.StaticLibrary(
+    "lib3",
+    env,
+    sources=["provider.cppm", "consumer.cpp"],
+)
+lib3.private.compile_flags.append("-std=c++26")

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -16,8 +16,9 @@ BMI via a per-key GCC module mapper file. As a result:
     dialect - so it gets its own interface (`cxx_modules/<hashB>/provider.gcm`).
 
 Status by toolchain:
-  - GCC:  supported (per-key BMI dirs + module mapper files).
-  - Clang/MSVC: not yet wired for cross-target BMI reuse.
+  - GCC:   supported (per-key BMI dirs + module mapper files).
+  - clang: supported (per-key dirs + -fmodule-output / -fprebuilt-module-path).
+  - MSVC:  not yet wired for cross-target BMI reuse.
 """
 
 from pcons import Project, find_c_toolchain, get_var

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -2,23 +2,27 @@
 # SPDX-License-Identifier: MIT
 """Build script demonstrating C++20 module interface (BMI) reuse across targets.
 
-A Binary Module Interface (`.gcm` on GCC) can only be consumed by translation
-units compiled with matching BMI-sensitive flags (C++ dialect, ABI knobs, ...).
-pcons keys each BMI by a hash of those flags and stores it under
-`cxx_modules/<hash>/<module>.gcm`, wiring every translation unit to the right
-BMI via a per-key GCC module mapper file. As a result:
+A Binary Module Interface (`.gcm` on GCC, `.pcm` on clang, `.ifc` on MSVC) can
+only be consumed by translation units compiled with matching BMI-sensitive
+flags (C++ dialect, ABI knobs, ...). pcons keys each BMI by a hash of those
+flags and stores it under `cxx_modules/<hash>/<module>.<ext>`, wiring every
+translation unit to the right BMI. As a result:
 
-  - lib1 and lib2 compile `provider.cppm` with identical flags (`-std=c++23`),
-    so they share one compiled interface (`cxx_modules/<hashA>/provider.gcm`).
-    pcons's object cache already collapses the two identical compiles into a
-    single object + BMI.
-  - lib3 compiles `provider.cppm` with `-std=c++26` - a BMI-incompatible
-    dialect - so it gets its own interface (`cxx_modules/<hashB>/provider.gcm`).
+  - lib1 and lib2 compile `provider.cppm` with identical flags, so they share
+    one compiled interface (`cxx_modules/<hashA>/provider.<ext>`). pcons's
+    object cache already collapses the two identical compiles into a single
+    object + BMI.
+  - lib3 compiles `provider.cppm` with a BMI-incompatible dialect, so it gets
+    its own interface (`cxx_modules/<hashB>/provider.<ext>`).
+
+Dialect flags are toolchain-specific (GCC/clang use `-std=`, MSVC uses
+`/std:`), so the script selects a "shared" and a BMI-breaking dialect per
+toolchain.
 
 Status by toolchain:
   - GCC:   supported (per-key BMI dirs + module mapper files).
   - clang: supported (per-key dirs + -fmodule-output / -fprebuilt-module-path).
-  - MSVC:  not yet wired for cross-target BMI reuse.
+  - MSVC:  supported (per-key dirs + /ifcOutput / /ifcSearchDir).
 """
 
 from pcons import Project, find_c_toolchain, get_var
@@ -33,20 +37,30 @@ else:
 
 env = project.Environment(toolchain=toolchain)
 
-# lib1 and lib2: identical (-std=c++23) -> share one compiled interface.
+# Pick a shared dialect and a BMI-incompatible "breaker" dialect per toolchain.
+# MSVC needs /std: (and /EHsc to compile modules); GCC/clang use -std=.
+if toolchain.name == "msvc":
+    env.cxx.flags.append("/EHsc")
+    shared_dialect = ["/std:c++20"]
+    breaker_dialect = ["/std:c++latest"]
+else:
+    shared_dialect = ["-std=c++23"]
+    breaker_dialect = ["-std=c++26"]
+
+# lib1 and lib2: identical flags -> share one compiled interface.
 lib1 = project.StaticLibrary("lib1", env, sources=["provider.cppm", "consumer.cpp"])
-lib1.private.compile_flags.append("-std=c++23")
+lib1.private.compile_flags.extend(shared_dialect)
 
 lib2 = project.StaticLibrary("lib2", env, sources=["provider.cppm", "consumer.cpp"])
-lib2.private.compile_flags.append("-std=c++23")
+lib2.private.compile_flags.extend(shared_dialect)
 
-# lib3: -std=c++26 is a BMI breaker -> gets its own compiled interface.
+# lib3: a BMI-breaking dialect -> gets its own compiled interface.
 lib3 = project.StaticLibrary("lib3", env, sources=["provider.cppm", "consumer.cpp"])
-lib3.private.compile_flags.append("-std=c++26")
+lib3.private.compile_flags.extend(breaker_dialect)
 
-# A program to prove the c++23 interface links and runs end to end.
+# A program to prove the shared interface links and runs end to end.
 app = project.Program("app", env, sources=["main.cpp"])
-app.private.compile_flags.append("-std=c++23")
+app.private.compile_flags.extend(shared_dialect)
 app.link(lib1)
 
 project.generate()

--- a/examples/39_bmi_compat/provider.cppm
+++ b/examples/39_bmi_compat/provider.cppm
@@ -1,1 +1,6 @@
+// SPDX-License-Identifier: MIT
 export module provider;
+
+export int answer() {
+    return 42;
+}

--- a/examples/39_bmi_compat/provider.cppm
+++ b/examples/39_bmi_compat/provider.cppm
@@ -1,0 +1,1 @@
+export module provider;

--- a/examples/39_bmi_compat/test.toml
+++ b/examples/39_bmi_compat/test.toml
@@ -32,4 +32,5 @@ description = "No rebuild when nothing changed"
 expect_no_work = true
 
 [skip]
+requires = ["clang-scan-deps", "clang++"]
 generators = ["xcode", "make"]

--- a/examples/39_bmi_compat/test.toml
+++ b/examples/39_bmi_compat/test.toml
@@ -14,12 +14,12 @@ expected_outputs = [
     "build/app",
 ]
 
-# Cross-target BMI reuse is currently wired for GCC only
-# (per-key BMI dirs + module mapper files).
+# Cross-target BMI reuse is wired for GCC (per-key BMI dirs + module mapper
+# files) and clang (per-key dirs + -fmodule-output / -fprebuilt-module-path).
 [toolchains]
-linux = ["gcc"]
-darwin = []
-windows = ["gcc"]
+linux = ["gcc", "llvm"]
+darwin = ["llvm"]
+windows = ["gcc", "llvm"]
 
 [verify]
 commands = [

--- a/examples/39_bmi_compat/test.toml
+++ b/examples/39_bmi_compat/test.toml
@@ -1,0 +1,34 @@
+# Test configuration for the bmi_compat example
+
+[test]
+description = "C++20 module interface (BMI) reuse across targets, keyed by BMI-sensitive flags"
+
+expected_outputs = [
+    "build/obj.lib1/provider.cppm.o",
+    "build/obj.lib1/consumer.cpp.o",
+    "build/obj.lib3/provider.cppm.o",
+    "build/obj.lib3/consumer.cpp.o",
+    "build/liblib1.a",
+    "build/liblib2.a",
+    "build/liblib3.a",
+    "build/app",
+]
+
+# Cross-target BMI reuse is currently wired for GCC only
+# (per-key BMI dirs + module mapper files).
+[toolchains]
+linux = ["gcc"]
+darwin = []
+windows = ["gcc"]
+
+[verify]
+commands = [
+    { run = "./build/app", expect_exit_code = 0, expect_output_contains = "answer = 42" },
+]
+
+[[rebuild]]
+description = "No rebuild when nothing changed"
+expect_no_work = true
+
+[skip]
+generators = ["xcode", "make"]

--- a/examples/39_bmi_compat/test.toml
+++ b/examples/39_bmi_compat/test.toml
@@ -15,11 +15,12 @@ expected_outputs = [
 ]
 
 # Cross-target BMI reuse is wired for GCC (per-key BMI dirs + module mapper
-# files) and clang (per-key dirs + -fmodule-output / -fprebuilt-module-path).
+# files), clang (per-key dirs + -fmodule-output / -fprebuilt-module-path), and
+# MSVC (per-key dirs + /ifcOutput / /ifcSearchDir).
 [toolchains]
 linux = ["gcc", "llvm"]
 darwin = ["llvm"]
-windows = ["gcc", "llvm"]
+windows = ["gcc", "llvm", "msvc"]
 
 [verify]
 commands = [

--- a/pcons/core/node.py
+++ b/pcons/core/node.py
@@ -113,6 +113,11 @@ class BuildInfo(TypedDict, total=False):
     # the C++ module and Fortran module scanners.
     dyndep: str
 
+    # Extra command-line flags appended verbatim to the build command, after
+    # template expansion. Used by the GCC C++ module path to attach
+    # -fmodule-mapper=/-Mno-modules to specific object compiles.
+    extra_command_flags: list[str]
+
     # Environment reference for command expansion
     # Used by resolver to expand command templates
     env: Any  # Environment, but avoid circular import

--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -626,6 +626,26 @@ def select_std_module_flags(
     return out
 
 
+def bmi_key_for_flags(flags: list[str], spec: StdModuleFlagSpec) -> str:
+    """Compute a short hash identifying a BMI-compatibility class.
+
+    A Binary Module Interface (``.gcm`` / ``.pcm`` / ``.ifc``) can only be
+    consumed by translation units compiled with matching BMI-sensitive flags
+    (the C++ dialect, ABI knobs, stdlib feature macros, etc. — exactly the set
+    ``spec`` selects). Two TUs that agree on every such flag may share one
+    compiled module interface; TUs that differ on any of them must each get
+    their own. Keying the BMI's on-disk directory by this hash lets the same
+    module interface be reused across targets when compatible
+    (``cxx_modules/<key>/provider.gcm``) and kept separate when not.
+
+    The hash is order-independent: BMI compatibility does not depend on the
+    order BMI-sensitive flags appear on the command line.
+    """
+    relevant = select_std_module_flags(list(flags), spec)
+    canonical = "\0".join(sorted(relevant))
+    return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
+
+
 def wire_std_into_targets(
     project: Any,
     results: list[TuScanResult],
@@ -674,7 +694,6 @@ def write_dyndep_from_results(
       - implicit outputs are the IFC/PCM files this TU provides
       - implicit inputs are the IFC/PCM files this TU imports
     """
-    lines = ["ninja_dyndep_version = 1", ""]
     entries: list[tuple[str, list[str], list[str]]] = []
     for r in results:
         provides_pcms: list[str] = []
@@ -686,22 +705,35 @@ def write_dyndep_from_results(
             if ln in module_to_pcm:
                 requires_pcms.append(module_to_pcm[ln])
 
-        entries.append(
-            (
-                r.spec.obj_rel,
-                sorted(set(provides_pcms)),
-                sorted(set(requires_pcms)),
-            )
-        )
+        entries.append((r.spec.obj_rel, provides_pcms, requires_pcms))
 
+    write_dyndep_entries(entries, out_path)
+
+
+def write_dyndep_entries(
+    entries: list[tuple[str, list[str], list[str]]],
+    out_path: str | Path,
+) -> None:
+    """Write a Ninja dyndep file from pre-resolved (obj, provides, requires).
+
+    Each entry is ``(obj_rel, provides_paths, requires_paths)`` where the
+    provides/requires are build-dir-relative BMI paths. Toolchains that map
+    one logical module name to different BMI paths per compatibility class
+    (GCC's per-key ``cxx_modules/<key>/`` layout) build entries directly,
+    since a single ``{logical: path}`` map cannot express that.
+    """
+    lines = ["ninja_dyndep_version = 1", ""]
     for obj_rel, provides_pcms, requires_pcms in sorted(entries, key=lambda e: e[0]):
-        implicit_out = " | " + " ".join(provides_pcms) if provides_pcms else ""
-        implicit_in = " | " + " ".join(requires_pcms) if requires_pcms else ""
+        implicit_out = (
+            " | " + " ".join(sorted(set(provides_pcms))) if provides_pcms else ""
+        )
+        implicit_in = (
+            " | " + " ".join(sorted(set(requires_pcms))) if requires_pcms else ""
+        )
         lines.append(f"build {obj_rel}{implicit_out}: dyndep{implicit_in}")
         lines.append("")
 
-    dyndep_text = "\n".join(lines)
-    _write_text_if_changed(Path(out_path), dyndep_text)
+    _write_text_if_changed(Path(out_path), "\n".join(lines))
 
 
 def write_dyndep(

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -599,12 +599,16 @@ class GccToolchain(UnixToolchain):
         """
         from pcons.toolchains.cxx_module_scanner import (
             TuScanSpec,
-            build_module_map,
+            _write_text_if_changed,
+            bmi_key_for_flags,
+            module_file_for,
             scan_translation_units,
             select_modules_scope,
             wire_std_into_targets,
-            write_dyndep_from_results,
+            write_dyndep_entries,
         )
+
+        flag_spec = _gcc_std_module_flag_spec()
 
         cxx_module_pairs, cxx_pairs = select_modules_scope(source_obj_by_language)
         all_cxx_pairs = cxx_module_pairs + cxx_pairs
@@ -645,8 +649,13 @@ class GccToolchain(UnixToolchain):
                 bi["depfile"] = None
 
         # Build per-TU scan specs and run GCC p1689 scanning.
+        # obj_key maps each participating object node to the hash of its
+        # BMI-sensitive flags. TUs sharing a key may share one compiled
+        # module interface under cxx_modules/<key>/; TUs with different
+        # keys (e.g. -std=c++23 vs -std=c++26) get separate BMIs.
         specs: list[TuScanSpec] = []
         spec_to_obj: dict[int, FileNode] = {}
+        obj_key: dict[int, str] = {}
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
@@ -689,6 +698,7 @@ class GccToolchain(UnixToolchain):
             )
             specs.append(spec)
             spec_to_obj[id(spec)] = obj_node
+            obj_key[id(obj_node)] = bmi_key_for_flags(compile_flags, flag_spec)
 
         results = scan_translation_units(
             specs, scanner=compiler_cmd, scanner_style="gcc"
@@ -729,6 +739,9 @@ class GccToolchain(UnixToolchain):
                 )
                 std_specs.append(std_spec)
                 spec_to_obj[id(std_spec)] = std_obj_node
+                obj_key[id(std_obj_node)] = bmi_key_for_flags(
+                    std_spec.compile_flags, flag_spec
+                )
 
             results.extend(
                 scan_translation_units(
@@ -738,8 +751,61 @@ class GccToolchain(UnixToolchain):
                 )
             )
 
-        module_to_gcm = build_module_map(results, "gcm.cache", ".gcm")
-        write_dyndep_from_results(results, module_to_gcm, dyndep_path)
+        # Map every module provider to a BMI path under its key's directory,
+        # then write a GCC module mapper file per key. Module interfaces no
+        # longer land in the shared gcm.cache/; each compatibility class owns
+        # cxx_modules/<key>/<module>.gcm, so the same logical module compiled
+        # with incompatible flags never collides on a single output path.
+        def keyed_bmi(logical: str, key: str) -> str:
+            return module_file_for(logical, f"{moddir}/{key}", ".gcm")
+
+        key_to_modules: dict[str, dict[str, str]] = {}
+        provider_obj: dict[tuple[str, str], str] = {}
+        for r in results:
+            if not r.is_module_provider:
+                continue
+            obj_node = spec_to_obj[id(r.spec)]
+            key = obj_key[id(obj_node)]
+            slot = (key, r.logical_name)
+            if slot in provider_obj and provider_obj[slot] != r.spec.obj_rel:
+                raise RuntimeError(
+                    f"Module '{r.logical_name}' is compiled into two different "
+                    f"objects ({provider_obj[slot]} and {r.spec.obj_rel}) with "
+                    f"BMI-equivalent flags, so both would write the same "
+                    f"{keyed_bmi(r.logical_name, key)}. Give them distinct "
+                    f"BMI-sensitive flags or build the interface in one place."
+                )
+            provider_obj[slot] = r.spec.obj_rel
+            key_to_modules.setdefault(key, {})[r.logical_name] = keyed_bmi(
+                r.logical_name, key
+            )
+
+        mapper_flag_for_key: dict[str, str] = {}
+        for key, modules in key_to_modules.items():
+            (build_dir / moddir / key).mkdir(parents=True, exist_ok=True)
+            mapper_rel = f"{moddir}/{key}/modules.modmap"
+            lines = ["$root ."]
+            for logical in sorted(modules):
+                lines.append(f"{logical} {modules[logical]}")
+            _write_text_if_changed(build_dir / mapper_rel, "\n".join(lines) + "\n")
+            mapper_flag_for_key[key] = f"-fmodule-mapper={mapper_rel}"
+
+        # Build a keyed dyndep: each TU's provides/requires resolve to BMIs in
+        # its own compatibility class's directory.
+        entries: list[tuple[str, list[str], list[str]]] = []
+        for r in results:
+            obj_node = spec_to_obj[id(r.spec)]
+            key = obj_key[id(obj_node)]
+            provides: list[str] = []
+            if r.is_module_provider:
+                provides.append(keyed_bmi(r.logical_name, key))
+            requires: list[str] = [
+                keyed_bmi(ln, key)
+                for ln in r.required_logical_names
+                if (key, ln) in provider_obj
+            ]
+            entries.append((r.spec.obj_rel, provides, requires))
+        write_dyndep_entries(entries, dyndep_path)
         logger.debug("Wrote GCC C++ module dyndep to %s", dyndep_path)
 
         dyndep_node = project.node(dyndep_path)
@@ -747,16 +813,22 @@ class GccToolchain(UnixToolchain):
             bi = getattr(obj_node, "_build_info", None)
             if bi is not None:
                 bi["dyndep"] = dyndep_rel
-                if src not in module_src_paths:
-                    extra = bi.setdefault("extra_command_flags", [])
-                    if "-Mno-modules" not in extra:
-                        extra.append("-Mno-modules")
+                extra = bi.setdefault("extra_command_flags", [])
+                mapper_flag = mapper_flag_for_key.get(obj_key[id(obj_node)])
+                if mapper_flag and mapper_flag not in extra:
+                    extra.append(mapper_flag)
+                if src not in module_src_paths and "-Mno-modules" not in extra:
+                    extra.append("-Mno-modules")
             if dyndep_node not in obj_node.implicit_deps:
                 obj_node.implicit_deps.append(dyndep_node)
         for std_obj_node in std_obj_nodes.values():
             std_bi = std_obj_node._build_info
             assert std_bi is not None
             std_bi["dyndep"] = dyndep_rel
+            extra = std_bi.setdefault("extra_command_flags", [])
+            mapper_flag = mapper_flag_for_key.get(obj_key[id(std_obj_node)])
+            if mapper_flag and mapper_flag not in extra:
+                extra.append(mapper_flag)
             if dyndep_node not in std_obj_node.implicit_deps:
                 std_obj_node.implicit_deps.append(dyndep_node)
 

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -605,12 +605,15 @@ class LlvmToolchain(UnixToolchain):
         """
         from pcons.toolchains.cxx_module_scanner import (
             TuScanSpec,
-            build_module_map,
+            bmi_key_for_flags,
+            module_file_for,
             scan_translation_units,
             select_modules_scope,
             wire_std_into_targets,
-            write_dyndep_from_results,
+            write_dyndep_entries,
         )
+
+        flag_spec = _clang_std_module_flag_spec()
 
         cxx_module_pairs, cxx_pairs = select_modules_scope(source_obj_by_language)
         all_cxx_pairs = cxx_module_pairs + cxx_pairs
@@ -635,16 +638,6 @@ class LlvmToolchain(UnixToolchain):
         build_dir.mkdir(parents=True, exist_ok=True)
         (build_dir / moddir).mkdir(exist_ok=True)
 
-        # -fprebuilt-module-path on every C++ TU so importers find PCMs.
-        modpath_flag = f"-fprebuilt-module-path={moddir}"
-        for _, obj_node in all_cxx_pairs:
-            bi = getattr(obj_node, "_build_info", None)
-            if bi:
-                context = bi.get("context")
-                if context is not None and hasattr(context, "flags"):
-                    if modpath_flag not in context.flags:
-                        context.flags.append(modpath_flag)
-
         # Pre-flag extension-tagged module units with -x c++-module so the
         # scanner sees them as modules (clang doesn't recognize .ixx natively).
         # The scan output may identify *additional* TUs (e.g., partition units
@@ -657,8 +650,13 @@ class LlvmToolchain(UnixToolchain):
                     if "-x" not in context.flags:
                         context.flags.extend(["-x", "c++-module"])
 
-        # Build per-TU scan specs.
+        # Build per-TU scan specs. obj_key maps each participating object to a
+        # hash of its BMI-sensitive flags: PCMs live under cxx_modules/<key>/
+        # so the same logical module compiled with incompatible flags (e.g.
+        # -std=c++23 vs -std=c++26) never writes to a single shared path.
         specs: list[TuScanSpec] = []
+        spec_to_obj: dict[int, FileNode] = {}
+        obj_key: dict[int, str] = {}
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
@@ -674,16 +672,15 @@ class LlvmToolchain(UnixToolchain):
                 for d in context.defines:
                     compile_flags.append(f"-D{d}")
 
-            specs.append(
-                TuScanSpec(
-                    src=src.resolve(),
-                    obj_rel=str(obj_node.path.relative_to(build_dir)).replace(
-                        "\\", "/"
-                    ),
-                    compiler=compiler_cmd,
-                    compile_flags=compile_flags,
-                )
+            spec = TuScanSpec(
+                src=src.resolve(),
+                obj_rel=str(obj_node.path.relative_to(build_dir)).replace("\\", "/"),
+                compiler=compiler_cmd,
+                compile_flags=compile_flags,
             )
+            specs.append(spec)
+            spec_to_obj[id(spec)] = obj_node
+            obj_key[id(obj_node)] = bmi_key_for_flags(compile_flags, flag_spec)
 
         results = scan_translation_units(
             specs, scanner="clang-scan-deps", scanner_style="clang"
@@ -692,20 +689,28 @@ class LlvmToolchain(UnixToolchain):
         # `import std;` / `import std.compat;` support: if any TU requires
         # the standard library module, locate libc++'s std.cppm via the
         # manifest the compiler ships and synthesize a build node for it.
-        # Appended to `results` so build_module_map() registers it and the
-        # dyndep file lists the .pcm as an implicit output.
+        # Appended to `results` so the dyndep file lists the .pcm as an
+        # implicit output. The synthesized std build is keyed like any other
+        # module (cxx_modules/<key>/std.pcm) so it matches its importers.
         std_obj_nodes = self._inject_clang_std_module_builds(
-            project, build_dir, moddir, compiler_cmd, base_flags, results, first_env
+            project,
+            build_dir,
+            moddir,
+            compiler_cmd,
+            base_flags,
+            results,
+            first_env,
+            flag_spec,
+            obj_key,
+            spec_to_obj,
         )
 
-        module_to_pcm = build_module_map(results, moddir, ".pcm")
+        def keyed_bmi(logical: str, key: str) -> str:
+            return module_file_for(logical, f"{moddir}/{key}", ".pcm")
 
-        # For each module-providing TU (interfaces, partition interfaces,
-        # internal partitions), inject -x c++-module and -fmodule-output.
-        spec_to_obj = {
-            id(spec): obj_node
-            for spec, (_, obj_node) in zip(specs, all_cxx_pairs, strict=True)
-        }
+        # For each module-providing TU (interfaces, partition interfaces, internal partitions),
+        # inject -x c++-module and a keyed -fmodule-output.
+        provider_obj: dict[tuple[str, str], str] = {}
         for r in results:
             if not r.is_module_provider:
                 continue
@@ -714,20 +719,64 @@ class LlvmToolchain(UnixToolchain):
             if id(r.spec) not in spec_to_obj:
                 continue
             obj_node = spec_to_obj[id(r.spec)]
+            key = obj_key[id(obj_node)]
+            slot = (key, r.logical_name)
+            if slot in provider_obj and provider_obj[slot] != r.spec.obj_rel:
+                raise RuntimeError(
+                    f"Module '{r.logical_name}' is compiled into two different "
+                    f"objects ({provider_obj[slot]} and {r.spec.obj_rel}) with "
+                    f"BMI-equivalent flags, so both would write the same "
+                    f"{keyed_bmi(r.logical_name, key)}. Give them distinct "
+                    f"BMI-sensitive flags or build the interface in one place."
+                )
+            provider_obj[slot] = r.spec.obj_rel
             bi = getattr(obj_node, "_build_info", None)
             if bi is None:
                 continue
             context = bi.get("context")
             if context is None or not hasattr(context, "flags"):
                 continue
-            pcm_path = module_to_pcm[r.logical_name]
-            module_out_flag = f"-fmodule-output={pcm_path}"
+            module_out_flag = f"-fmodule-output={keyed_bmi(r.logical_name, key)}"
             if module_out_flag not in context.flags:
                 context.flags.append(module_out_flag)
             if "-x" not in context.flags:
                 context.flags.extend(["-x", "c++-module"])
 
-        write_dyndep_from_results(results, module_to_pcm, dyndep_path)
+        # Every participating TU searches its own key's directory for the PCMs
+        # it imports. All of a TU's imports share its BMI-sensitive flags, so
+        # one -fprebuilt-module-path per key suffices.
+        for _, obj_node in all_cxx_pairs:
+            bi = getattr(obj_node, "_build_info", None)
+            if not bi:
+                continue
+            context = bi.get("context")
+            if context is None or not hasattr(context, "flags"):
+                continue
+            modpath = f"-fprebuilt-module-path={moddir}/{obj_key[id(obj_node)]}"
+            if modpath not in context.flags:
+                context.flags.append(modpath)
+
+        for key in set(obj_key.values()):
+            (build_dir / moddir / key).mkdir(parents=True, exist_ok=True)
+
+        # Keyed dyndep: each TU's provides/requires resolve to PCMs in its own
+        # compatibility class's directory.
+        entries: list[tuple[str, list[str], list[str]]] = []
+        for r in results:
+            obj_node = spec_to_obj.get(id(r.spec))
+            if obj_node is None:
+                continue
+            key = obj_key[id(obj_node)]
+            provides: list[str] = []
+            if r.is_module_provider:
+                provides.append(keyed_bmi(r.logical_name, key))
+            requires: list[str] = [
+                keyed_bmi(ln, key)
+                for ln in r.required_logical_names
+                if (key, ln) in provider_obj
+            ]
+            entries.append((r.spec.obj_rel, provides, requires))
+        write_dyndep_entries(entries, dyndep_path)
         logger.debug("Wrote C++ module dyndep to %s", dyndep_path)
 
         dyndep_node = project.node(dyndep_path)
@@ -754,6 +803,9 @@ class LlvmToolchain(UnixToolchain):
         base_flags: list[str],
         results: list[Any],
         first_env: Environment | None,
+        flag_spec: Any,
+        obj_key: dict[int, str],
+        spec_to_obj: dict[int, FileNode],
     ) -> dict[str, FileNode]:
         """Synthesize build nodes for `import std;` / `import std.compat;` (clang).
 
@@ -769,7 +821,11 @@ class LlvmToolchain(UnixToolchain):
             Dict mapping logical module name -> std obj FileNode for the
             modules that were synthesized.
         """
-        from pcons.toolchains.cxx_module_scanner import TuScanResult, TuScanSpec
+        from pcons.toolchains.cxx_module_scanner import (
+            TuScanResult,
+            TuScanSpec,
+            bmi_key_for_flags,
+        )
 
         required_logical_names: set[str] = set()
         for r in results:
@@ -816,6 +872,12 @@ class LlvmToolchain(UnixToolchain):
         if not any(f.startswith("-stdlib=") for f in passthrough):
             passthrough.append("-stdlib=libc++")
 
+        # The std module's BMI is keyed like any other, its key is derived from
+        # the same BMI-sensitive flags its importers use, so they resolve it
+        # from the same cxx_modules/<key>/ directory.
+        std_key = bmi_key_for_flags(passthrough, flag_spec)
+        std_moddir = f"{moddir}/{std_key}"
+
         std_obj_nodes: dict[str, FileNode] = {}
         for logical in sorted(wanted):
             if logical not in modules:
@@ -836,7 +898,7 @@ class LlvmToolchain(UnixToolchain):
                 )
                 continue
 
-            pcm_rel = f"{moddir}/{logical}.pcm"
+            pcm_rel = f"{std_moddir}/{logical}.pcm"
             obj_rel = f"{moddir}/{logical}.o"
             obj_path = build_dir / obj_rel
 
@@ -851,6 +913,8 @@ class LlvmToolchain(UnixToolchain):
                 "-Wno-reserved-identifier",
                 "-Wno-reserved-user-defined-literal",
                 *(f"-isystem{d}" for d in sys_includes),
+                # std.compat imports std, let it find the keyed std.pcm.
+                f"-fprebuilt-module-path={std_moddir}",
                 "-x",
                 "c++-module",
                 f"-fmodule-output={pcm_rel}",
@@ -884,6 +948,8 @@ class LlvmToolchain(UnixToolchain):
                 ]
             }
             results.append(TuScanResult(spec=synthetic_spec, p1689=synthetic_p1689))
+            obj_key[id(std_obj_node)] = std_key
+            spec_to_obj[id(synthetic_spec)] = std_obj_node
             std_obj_nodes[logical] = std_obj_node
 
         return std_obj_nodes

--- a/pcons/toolchains/msvc.py
+++ b/pcons/toolchains/msvc.py
@@ -713,12 +713,15 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         """
         from pcons.toolchains.cxx_module_scanner import (
             TuScanSpec,
-            build_module_map,
+            bmi_key_for_flags,
+            module_file_for,
             scan_translation_units,
             select_modules_scope,
             wire_std_into_targets,
-            write_dyndep_from_results,
+            write_dyndep_entries,
         )
+
+        flag_spec = _msvc_std_module_flag_spec()
 
         # Restrict scanning to envs that opted in (extension-driven or
         # explicit `env.cxx.modules = True`). If no env qualifies, skip.
@@ -745,15 +748,6 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         build_dir.mkdir(parents=True, exist_ok=True)
         (build_dir / moddir).mkdir(exist_ok=True)
 
-        # Inject /ifcSearchDir on all C++ TUs so importers find IFCs.
-        for _, obj_node in all_cxx_pairs:
-            bi = getattr(obj_node, "_build_info", None)
-            if bi:
-                context = bi.get("context")
-                if context is not None and hasattr(context, "flags"):
-                    if "/ifcSearchDir" not in context.flags:
-                        context.flags.extend(["/ifcSearchDir", moddir])
-
         # Pre-flag every extension-tagged module unit with /TP so cl.exe
         # treats the file as C++ during scan and compile (.cppm isn't a
         # native MSVC C++ extension; .ixx is). We deliberately do NOT add
@@ -768,8 +762,13 @@ class MsvcToolchain(MsvcCompatibleToolchain):
                     if "/TP" not in context.flags:
                         context.flags.append("/TP")
 
-        # Build per-TU scan specs using the now-flag-injected compile flags.
+        # Build per-TU scan specs. obj_key maps each participating object to a
+        # hash of its BMI-sensitive flags: IFCs live under cxx_modules/<key>/
+        # so the same logical module compiled with incompatible flags (e.g.
+        # /std:c++23 vs /std:c++latest) never writes to a single shared path.
         specs: list[TuScanSpec] = []
+        spec_to_obj: dict[int, FileNode] = {}
+        obj_key: dict[int, str] = {}
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
@@ -785,16 +784,15 @@ class MsvcToolchain(MsvcCompatibleToolchain):
                 for d in context.defines:
                     compile_flags.append(f"/D{d}")
 
-            specs.append(
-                TuScanSpec(
-                    src=src.resolve(),
-                    obj_rel=str(obj_node.path.relative_to(build_dir)).replace(
-                        "\\", "/"
-                    ),
-                    compiler=compiler_cmd,
-                    compile_flags=compile_flags,
-                )
+            spec = TuScanSpec(
+                src=src.resolve(),
+                obj_rel=str(obj_node.path.relative_to(build_dir)).replace("\\", "/"),
+                compiler=compiler_cmd,
+                compile_flags=compile_flags,
             )
+            specs.append(spec)
+            spec_to_obj[id(spec)] = obj_node
+            obj_key[id(obj_node)] = bmi_key_for_flags(compile_flags, flag_spec)
 
         # Run cl.exe /scanDependencies on each TU. Failures (e.g. compiler
         # not on PATH) leave that result with p1689=None — propagated as
@@ -807,22 +805,31 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         # `import std;`/`import std.compat;` support: if any TU requires the
         # standard library module, synthesize a build node for it from
         # %VCToolsInstallDir%/modules/std.ixx. The synthetic TU is appended
-        # to `results` so build_module_map() registers it and the dyndep
-        # file declares the .ifc as an implicit output.
+        # to `results` so the dyndep file declares the .ifc as an implicit
+        # output. The synthesized std build is keyed like any other module
+        # (cxx_modules/<key>/std.ifc) so it matches its importers.
         std_obj_nodes = self._inject_std_module_builds(
-            project, build_dir, moddir, compiler_cmd, base_flags, results, first_env
+            project,
+            build_dir,
+            moddir,
+            compiler_cmd,
+            base_flags,
+            results,
+            first_env,
+            flag_spec,
+            obj_key,
+            spec_to_obj,
         )
 
-        # Build logical-name -> IFC path map (handles partitions: ':' -> '-').
-        module_to_ifc = build_module_map(results, moddir, ".ifc")
+        def keyed_bmi(logical: str, key: str) -> str:
+            return module_file_for(logical, f"{moddir}/{key}", ".ifc")
 
-        # Now inject per-TU module flags driven by the scan output.
+        # Inject per-TU module flags driven by the scan output, with a keyed
+        # /ifcOutput so the same logical module compiled with incompatible
+        # flags never writes to a single shared .ifc path.
         # A TU is a module provider iff scan reports a non-empty provides[].
         # An *internal* partition (is-interface=false) needs /internalPartition.
-        spec_to_obj = {
-            id(spec): obj_node
-            for spec, (_, obj_node) in zip(specs, all_cxx_pairs, strict=True)
-        }
+        provider_obj: dict[tuple[str, str], str] = {}
         for r in results:
             if not r.is_module_provider:
                 continue
@@ -831,13 +838,24 @@ class MsvcToolchain(MsvcCompatibleToolchain):
             if id(r.spec) not in spec_to_obj:
                 continue
             obj_node = spec_to_obj[id(r.spec)]
+            key = obj_key[id(obj_node)]
+            slot = (key, r.logical_name)
+            if slot in provider_obj and provider_obj[slot] != r.spec.obj_rel:
+                raise RuntimeError(
+                    f"Module '{r.logical_name}' is compiled into two different "
+                    f"objects ({provider_obj[slot]} and {r.spec.obj_rel}) with "
+                    f"BMI-equivalent flags, so both would write the same "
+                    f"{keyed_bmi(r.logical_name, key)}. Give them distinct "
+                    f"BMI-sensitive flags or build the interface in one place."
+                )
+            provider_obj[slot] = r.spec.obj_rel
             bi = getattr(obj_node, "_build_info", None)
             if bi is None:
                 continue
             context = bi.get("context")
             if context is None or not hasattr(context, "flags"):
                 continue
-            ifc_path = module_to_ifc[r.logical_name]
+            ifc_path = keyed_bmi(r.logical_name, key)
             if "/ifcOutput" in context.flags:
                 continue
             # /interface and /internalPartition are mutually exclusive (D8016).
@@ -849,9 +867,41 @@ class MsvcToolchain(MsvcCompatibleToolchain):
             else:
                 context.flags.extend(["/internalPartition", "/ifcOutput", ifc_path])
 
-        # Write the dyndep file at configure time and reference it as an
-        # implicit input on each obj. No build-time scan rule needed.
-        write_dyndep_from_results(results, module_to_ifc, dyndep_path)
+        # Every participating TU searches its own key's directory for the IFCs
+        # it imports. All of a TU's imports share its BMI-sensitive flags, so
+        # one /ifcSearchDir per key suffices.
+        for _, obj_node in all_cxx_pairs:
+            bi = getattr(obj_node, "_build_info", None)
+            if not bi:
+                continue
+            context = bi.get("context")
+            if context is None or not hasattr(context, "flags"):
+                continue
+            searchdir = f"{moddir}/{obj_key[id(obj_node)]}"
+            if searchdir not in context.flags:
+                context.flags.extend(["/ifcSearchDir", searchdir])
+
+        for key in set(obj_key.values()):
+            (build_dir / moddir / key).mkdir(parents=True, exist_ok=True)
+
+        # Keyed dyndep: each TU's provides/requires resolve to IFCs in its own
+        # compatibility class's directory.
+        entries: list[tuple[str, list[str], list[str]]] = []
+        for r in results:
+            obj_node = spec_to_obj.get(id(r.spec))
+            if obj_node is None:
+                continue
+            key = obj_key[id(obj_node)]
+            provides: list[str] = []
+            if r.is_module_provider:
+                provides.append(keyed_bmi(r.logical_name, key))
+            requires: list[str] = [
+                keyed_bmi(ln, key)
+                for ln in r.required_logical_names
+                if (key, ln) in provider_obj
+            ]
+            entries.append((r.spec.obj_rel, provides, requires))
+        write_dyndep_entries(entries, dyndep_path)
         logger.debug("Wrote C++ module dyndep to %s", dyndep_path)
 
         dyndep_node = project.node(dyndep_path)
@@ -881,6 +931,9 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         base_flags: list[str],
         results: list[Any],
         first_env: Environment | None,
+        flag_spec: Any,
+        obj_key: dict[int, str],
+        spec_to_obj: dict[int, FileNode],
     ) -> dict[str, FileNode]:
         """Synthesize build nodes for `import std;` / `import std.compat;`.
 
@@ -889,14 +942,20 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         under `%VCToolsInstallDir%/modules/`, create a build node that
         compiles them, and append a synthetic TuScanResult to `results` so
         the dyndep file declares the corresponding .ifc as an implicit
-        output.
+        output. The std module's BMI is keyed like any other (its key is
+        derived from the same BMI-sensitive flags its importers use), so they
+        resolve it from the same cxx_modules/<key>/ directory.
 
         Returns:
             Dict mapping logical module name -> std obj FileNode for
             modules that were synthesized. Caller is responsible for
             wiring these into target link inputs.
         """
-        from pcons.toolchains.cxx_module_scanner import TuScanResult, TuScanSpec
+        from pcons.toolchains.cxx_module_scanner import (
+            TuScanResult,
+            TuScanSpec,
+            bmi_key_for_flags,
+        )
 
         required_logical_names: set[str] = set()
         for r in results:
@@ -938,6 +997,12 @@ class MsvcToolchain(MsvcCompatibleToolchain):
         if not any(f in {"/EHs", "/EHsc", "/EHa"} for f in passthrough):
             passthrough.append("/EHsc")
 
+        # The std module's BMI is keyed like any other; its key is derived from
+        # the same BMI-sensitive flags its importers use, so they resolve it
+        # from the same cxx_modules/<key>/ directory.
+        std_key = bmi_key_for_flags(passthrough, flag_spec)
+        std_moddir = f"{moddir}/{std_key}"
+
         std_obj_nodes: dict[str, FileNode] = {}
         for logical in sorted(wanted):
             ixx_name = "std.ixx" if logical == "std" else "std.compat.ixx"
@@ -950,7 +1015,7 @@ class MsvcToolchain(MsvcCompatibleToolchain):
                 )
                 continue
 
-            ifc_rel = f"{moddir}/{logical}.ifc"
+            ifc_rel = f"{std_moddir}/{logical}.ifc"
             obj_rel = f"{moddir}/{logical}.obj"
             obj_path = build_dir / obj_rel
 
@@ -965,6 +1030,9 @@ class MsvcToolchain(MsvcCompatibleToolchain):
                     "/nologo",
                     *passthrough,
                     "/c",
+                    # std.compat imports std, let it find the keyed std.ifc.
+                    "/ifcSearchDir",
+                    std_moddir,
                     "/TP",
                     "/interface",
                     "/ifcOutput",
@@ -976,9 +1044,9 @@ class MsvcToolchain(MsvcCompatibleToolchain):
             if first_env is not None:
                 first_env.register_node(std_obj_node)
 
-            # Synthesize a TuScanResult so build_module_map() picks up `std`
-            # and write_dyndep_from_results() emits a `build <obj> | <ifc>`
-            # entry for it.
+            # Synthesize a TuScanResult so the dyndep file emits a
+            # `build <obj> | <ifc>` entry for it. The synthesized std build is
+            # keyed (cxx_modules/<key>/std.ifc) so it matches its importers.
             synthetic_spec = TuScanSpec(
                 src=ixx_path,
                 obj_rel=obj_rel,
@@ -994,6 +1062,8 @@ class MsvcToolchain(MsvcCompatibleToolchain):
                 ]
             }
             results.append(TuScanResult(spec=synthetic_spec, p1689=synthetic_p1689))
+            obj_key[id(std_obj_node)] = std_key
+            spec_to_obj[id(synthetic_spec)] = std_obj_node
             std_obj_nodes[logical] = std_obj_node
 
         return std_obj_nodes

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -18,6 +18,7 @@ from pcons.toolchains.cxx_module_scanner import (
     StdModuleFlagSpec,
     TuScanResult,
     TuScanSpec,
+    bmi_key_for_flags,
     build_module_map,
     module_file_for,
     run_scan_deps,
@@ -26,6 +27,7 @@ from pcons.toolchains.cxx_module_scanner import (
     select_std_module_flags,
     wire_std_into_targets,
     write_dyndep,
+    write_dyndep_entries,
     write_dyndep_from_results,
 )
 
@@ -587,3 +589,83 @@ class TestSelectStdModuleFlags:
             "-D_LIBCPP_FOO=1",
             "-frtti",
         ]
+
+
+class TestBmiKeyForFlags:
+    """A BMI's on-disk directory is keyed by the hash of its BMI-sensitive
+    flags so compatible compiles share one interface and incompatible ones
+    (e.g. different C++ dialects) stay separate.
+    """
+
+    def test_identical_bmi_flags_share_key(self) -> None:
+        a = bmi_key_for_flags(["-std=c++23", "-O2"], _CLANG_LIKE_SPEC)
+        b = bmi_key_for_flags(["-std=c++23", "-O0"], _CLANG_LIKE_SPEC)
+        # -O level is not BMI-sensitive, so the key is the same.
+        assert a == b
+
+    def test_different_dialect_gives_different_key(self) -> None:
+        a = bmi_key_for_flags(["-std=c++23"], _CLANG_LIKE_SPEC)
+        b = bmi_key_for_flags(["-std=c++26"], _CLANG_LIKE_SPEC)
+        assert a != b
+
+    def test_order_independent(self) -> None:
+        a = bmi_key_for_flags(["-std=c++23", "-frtti"], _CLANG_LIKE_SPEC)
+        b = bmi_key_for_flags(["-frtti", "-std=c++23"], _CLANG_LIKE_SPEC)
+        assert a == b
+
+    def test_non_bmi_flags_ignored(self) -> None:
+        # Unrelated includes/defines do not change the key.
+        a = bmi_key_for_flags(["-std=c++23"], _CLANG_LIKE_SPEC)
+        b = bmi_key_for_flags(
+            ["-std=c++23", "-I/some/inc", "-DUSER_FOO=1"], _CLANG_LIKE_SPEC
+        )
+        assert a == b
+
+    def test_key_is_short_hex(self) -> None:
+        key = bmi_key_for_flags(["-std=c++23"], _CLANG_LIKE_SPEC)
+        assert len(key) == 12
+        assert all(c in "0123456789abcdef" for c in key)
+
+
+class TestWriteDyndepEntries:
+    """Per-key dyndep emission: a single logical module can resolve to
+    different BMI paths in different compatibility classes, which a flat
+    {logical: path} map cannot express.
+    """
+
+    def test_keyed_provides_and_requires(self, tmp_path: Path) -> None:
+        out = tmp_path / "x.dyndep"
+        write_dyndep_entries(
+            [
+                (
+                    "obj.lib1/provider.cppm.o",
+                    ["cxx_modules/aaa/provider.gcm"],
+                    [],
+                ),
+                (
+                    "obj.lib1/consumer.cpp.o",
+                    [],
+                    ["cxx_modules/aaa/provider.gcm"],
+                ),
+                (
+                    "obj.lib3/provider.cppm.o",
+                    ["cxx_modules/bbb/provider.gcm"],
+                    [],
+                ),
+            ],
+            out,
+        )
+        text = out.read_text()
+        assert text.startswith("ninja_dyndep_version = 1")
+        assert (
+            "build obj.lib1/provider.cppm.o | cxx_modules/aaa/provider.gcm: dyndep"
+            in text
+        )
+        assert (
+            "build obj.lib3/provider.cppm.o | cxx_modules/bbb/provider.gcm: dyndep"
+            in text
+        )
+        assert (
+            "build obj.lib1/consumer.cpp.o: dyndep | cxx_modules/aaa/provider.gcm"
+            in text
+        )

--- a/tests/toolchains/test_gcc.py
+++ b/tests/toolchains/test_gcc.py
@@ -364,10 +364,11 @@ class TestGccModulesDepsTracking:
             "pcons.toolchains.cxx_module_scanner.scan_translation_units",
             lambda specs, scanner, scanner_style: [
                 SimpleNamespace(
+                    spec=s,
                     required_logical_names=set(),
                     is_module_provider=False,
                 )
-                for _ in specs
+                for s in specs
             ],
         )
         monkeypatch.setattr(

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -414,6 +414,163 @@ class TestMsvcSourceHandlers:
         assert handler.deps_style == "msvc"
 
 
+class TestMsvcModulesBmiKeying:
+    """after_resolve keys each module interface (.ifc) by a hash of its
+    BMI-sensitive flags, so the same logical module compiled with incompatible
+    flags (e.g. /std:c++23 vs /std:c++latest) lands in distinct
+    cxx_modules/<key>/ directories instead of colliding on one path.
+    """
+
+    def _make_obj(self, env, rel_path, flags):
+        from types import SimpleNamespace
+
+        obj = FileNode(rel_path)
+        obj._build_info = {
+            "env": env,
+            "context": SimpleNamespace(flags=list(flags), includes=[], defines=[]),
+        }
+        return obj
+
+    def test_incompatible_dialects_get_separate_ifc_dirs(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from pcons.core.project import Project
+
+        monkeypatch.chdir(tmp_path)
+        tc = MsvcToolchain()
+        project = Project("bmi", root_dir=tmp_path, build_dir="build")
+
+        env = SimpleNamespace(
+            cxx=SimpleNamespace(cmd="cl.exe", flags=["/nologo"], defines=[]),
+            register_node=lambda _node: None,
+        )
+
+        # Two libraries provide the same logical module 'provider' but with
+        # BMI-incompatible dialects, plus a consumer for each.
+        prov23 = self._make_obj(env, "build/obj.lib1/provider.cppm.obj", ["/std:c++23"])
+        cons23 = self._make_obj(env, "build/obj.lib1/consumer.cpp.obj", ["/std:c++23"])
+        prov26 = self._make_obj(
+            env, "build/obj.lib3/provider.cppm.obj", ["/std:c++latest"]
+        )
+        cons26 = self._make_obj(
+            env, "build/obj.lib3/consumer.cpp.obj", ["/std:c++latest"]
+        )
+
+        module_pairs = [
+            (tmp_path / "provider.cppm", prov23),
+            (tmp_path / "provider.cppm", prov26),
+        ]
+        cxx_pairs = [
+            (tmp_path / "consumer.cpp", cons23),
+            (tmp_path / "consumer.cpp", cons26),
+        ]
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.select_modules_scope",
+            lambda _s: (module_pairs, cxx_pairs),
+        )
+
+        def fake_scan(specs, scanner, scanner_style):
+            out = []
+            for s in specs:
+                is_provider = str(s.src).endswith(".cppm")
+                out.append(
+                    SimpleNamespace(
+                        spec=s,
+                        is_module_provider=is_provider,
+                        is_interface=is_provider,
+                        logical_name="provider" if is_provider else "",
+                        required_logical_names=set() if is_provider else {"provider"},
+                    )
+                )
+            return out
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.scan_translation_units", fake_scan
+        )
+
+        tc.after_resolve(project, {"cxx": [], "cxx_module": []})
+
+        # The two providers must resolve to different keyed .ifc paths.
+        def ifc_of(obj):
+            flags = obj._build_info["context"].flags
+            i = flags.index("/ifcOutput")
+            return flags[i + 1]
+
+        ifc23 = ifc_of(prov23)
+        ifc26 = ifc_of(prov26)
+        assert ifc23 != ifc26
+        assert ifc23.startswith("cxx_modules/") and ifc23.endswith("/provider.ifc")
+        assert ifc26.startswith("cxx_modules/") and ifc26.endswith("/provider.ifc")
+
+        # Each consumer searches its own key's directory (the same one its
+        # provider writes into).
+        def searchdir_of(obj):
+            flags = obj._build_info["context"].flags
+            i = flags.index("/ifcSearchDir")
+            return flags[i + 1]
+
+        assert searchdir_of(cons23) == ifc23.rsplit("/", 1)[0]
+        assert searchdir_of(cons26) == ifc26.rsplit("/", 1)[0]
+        assert searchdir_of(cons23) != searchdir_of(cons26)
+
+        # The keyed dyndep wires each consumer to the provider in its own class.
+        dyndep = (tmp_path / "build" / "cxx_modules.dyndep").read_text()
+        assert f"build obj.lib1/consumer.cpp.obj: dyndep | {ifc23}" in dyndep
+        assert f"build obj.lib3/consumer.cpp.obj: dyndep | {ifc26}" in dyndep
+        assert f"build obj.lib1/provider.cppm.obj | {ifc23}: dyndep" in dyndep
+        assert f"build obj.lib3/provider.cppm.obj | {ifc26}: dyndep" in dyndep
+
+    def test_compatible_compiles_share_one_ifc_path(self, tmp_path, monkeypatch):
+        from types import SimpleNamespace
+
+        from pcons.core.project import Project
+
+        monkeypatch.chdir(tmp_path)
+        tc = MsvcToolchain()
+        project = Project("bmi", root_dir=tmp_path, build_dir="build")
+
+        env = SimpleNamespace(
+            cxx=SimpleNamespace(cmd="cl.exe", flags=["/nologo"], defines=[]),
+            register_node=lambda _node: None,
+        )
+
+        # Same dialect, two targets: they may share one compiled interface, so
+        # only one of them carries the /ifcOutput (the second is collapsed).
+        prov_a = self._make_obj(env, "build/obj.lib1/provider.cppm.obj", ["/std:c++23"])
+        prov_b = self._make_obj(env, "build/obj.lib2/provider.cppm.obj", ["/std:c++23"])
+        module_pairs = [
+            (tmp_path / "provider.cppm", prov_a),
+            (tmp_path / "provider.cppm", prov_b),
+        ]
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.select_modules_scope",
+            lambda _s: (module_pairs, []),
+        )
+
+        def fake_scan(specs, scanner, scanner_style):
+            return [
+                SimpleNamespace(
+                    spec=s,
+                    is_module_provider=True,
+                    is_interface=True,
+                    logical_name="provider",
+                    required_logical_names=set(),
+                )
+                for s in specs
+            ]
+
+        monkeypatch.setattr(
+            "pcons.toolchains.cxx_module_scanner.scan_translation_units", fake_scan
+        )
+
+        # Two distinct objects providing the same module with BMI-equivalent
+        # flags would both write the same keyed .ifc - that's a hard error.
+        with pytest.raises(RuntimeError, match="BMI-equivalent flags"):
+            tc.after_resolve(project, {"cxx": [], "cxx_module": []})
+
+
 class TestMsvcLinkerAcceptsRes:
     def test_program_builder_accepts_res(self):
         """Test that Program builder accepts .res files."""


### PR DESCRIPTION
### Summary :memo:
Allow C++20 module interfaces (BMIs) to be **reused across targets** instead of colliding. A BMI (`.gcm` on GCC, `.pcm` on clang, `.ifc` on MSVC) is only consumable by translation units built with matching *BMI-sensitive* flags (C++ dialect, ABI knobs, ...).

pcons now keys each BMI by a hash of those flags and stores it under `cxx_modules/<hash>/<module>.<ext>`, wiring every translation unit to the right interface. Targets that compile a module interface with identical flags share one compiled BMI, targets with an incompatible dialect transparently get their own.

This removes the `multiple rules generate gcm.cache/<module>.gcm` failure that made it impossible to use the same module interface in more than one target.

### Details
1. **Bug evidence (example `39_bmi_compat`)** - Added a reproducible example: `lib1`/`lib2` compile `provider.cppm` with the same dialect (`-std=c++23` / `/std:c++20`) while `lib3` uses a BMI-breaking dialect (`-std=c++26` / `/std:c++latest`). This example did not build at all before the fix, due to duplicate rule errors.

2. **BMI keying** - Added `bmi_key_for_flags(flags, spec)` in `cxx_module_scanner.py`: it selects the BMI-sensitive subset of compile flags (using `_<toolchain>_std_module_flag_spec(...)`) and returns a 12-char sha1. Added reusable `write_dyndep_entries(entries, out_path)`. Added the `extra_command_flags` field to `BuildInfo` so toolchains can attach per-TU flags (mapper / module-path) without bypassing the type.

3. **GCC** - Each translation unit's BMI lives at `cxx_modules/<key>/<module>.gcm` (no longer `gcm.cache/`). Per-key module mapper files (`cxx_modules/<key>/modules.modmap`) are generated and attached via `-fmodule-mapper=`, with keyed dyndep.

4. **clang/LLVM** - Producers emit `-fmodule-output=cxx_modules/<key>/<module>.pcm`; consumers get `-fprebuilt-module-path=cxx_modules/<key>` for their own key. `import std` synthetic builds are keyed the same way. Replaces the previous single shared `cxx_modules` module path.

5. **MSVC** - Producers emit `/ifcOutput cxx_modules/<key>/<module>.ifc`; consumers get `/ifcSearchDir cxx_modules/<key>`, keyed on the `/std:` dialect and other BMI-sensitive flags.

### Bugfixes :bug:
- Fixed `ninja: error: multiple rules generate gcm.cache/<module>.gcm` (and the clang/MSVC equivalents) that aborted the build whenever the same module interface was compiled into more than one target. BMIs are now keyed by their BMI-sensitive flags, so each compatible flag set gets a single, unambiguous interface path.
