### PR TITLE
Feature/pyproject backend win

### DIFF
--- a/examples/50_pyproject/pcons-build.py
+++ b/examples/50_pyproject/pcons-build.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 """Build a nanobind Python extension, packaged via the pcons.pyproject backend."""
 
+import os
 import sys
 import sysconfig
 from pathlib import Path
@@ -16,13 +17,18 @@ project = Project("hello_python")
 toolchain_override = get_var("TOOLCHAIN")
 if toolchain_override:
     toolchain = find_c_toolchain(prefer=[toolchain_override])
+elif sys.platform == "win32":
+    # MSVC-ABI compilers only. The extension links the MSVC-built CPython
+    # (pythonNN.lib) and must match its ABI, so a GNU-driver clang (pcons's
+    # "llvm" toolchain, which may be on PATH) is not suitable here.
+    toolchain = find_c_toolchain(prefer=["msvc"])
 else:
-    toolchain = find_c_toolchain(prefer=["gcc", "llvm", "msvc"])
+    toolchain = find_c_toolchain(prefer=["gcc", "llvm"])
 
 env = project.Environment(toolchain=toolchain)
 
-if toolchain.name == "msvc":
-    env.cxx.flags.extend(["/std:c++latest", "/EHsc", "/permissive-"])
+if toolchain.name in ("msvc"):
+    env.cxx.flags.extend(["/std:c++23", "/EHsc", "/permissive-"])
 elif toolchain.name == "llvm":
     env.cxx.flags.extend(["-std=c++23", "-stdlib=libc++"])
     env.link.libs.append("c++")
@@ -31,6 +37,21 @@ else:
 
 # Discover Python's dev headers from the *running* interpreter via sysconfig,
 # rather than pkg-config.
+#
+# On Windows the linker must resolve every symbol, so we also link CPython's
+# import library (pythonNN.lib, in <base_prefix>/libs). On Linux/macOS the Py*
+# symbols are deliberately left undefined and resolved by the interpreter at
+# import time (see the macOS dynamic-lookup handling below), so no Python
+# library is linked there.
+py_library_dirs: list[str] = []
+py_libraries: list[str] = []
+if sys.platform == "win32":
+    py_library_dirs = [os.path.join(sys.base_prefix, "libs")]
+    libname = f"python{sys.version_info.major}{sys.version_info.minor}"
+    if sysconfig.get_config_var("Py_GIL_DISABLED"):
+        libname += "t"  # free-threaded builds link pythonNNt.lib
+    py_libraries = [libname]
+
 python = ImportedTarget.from_package(
     PackageDescription(
         name="python3",
@@ -39,6 +60,8 @@ python = ImportedTarget.from_package(
             sysconfig.get_path("include"),
             sysconfig.get_path("platinclude"),
         ],
+        library_dirs=py_library_dirs,
+        libraries=py_libraries,
         found_by="sysconfig",
     )
 )

--- a/examples/50_pyproject/pcons-build.py
+++ b/examples/50_pyproject/pcons-build.py
@@ -27,7 +27,7 @@ else:
 
 env = project.Environment(toolchain=toolchain)
 
-if toolchain.name in ("msvc"):
+if toolchain.name == "msvc":
     env.cxx.flags.extend(["/std:c++20", "/EHsc", "/permissive-"])
 elif toolchain.name == "llvm":
     env.cxx.flags.extend(["-std=c++20", "-stdlib=libc++"])

--- a/examples/50_pyproject/pcons-build.py
+++ b/examples/50_pyproject/pcons-build.py
@@ -28,12 +28,12 @@ else:
 env = project.Environment(toolchain=toolchain)
 
 if toolchain.name in ("msvc"):
-    env.cxx.flags.extend(["/std:c++23", "/EHsc", "/permissive-"])
+    env.cxx.flags.extend(["/std:c++20", "/EHsc", "/permissive-"])
 elif toolchain.name == "llvm":
-    env.cxx.flags.extend(["-std=c++23", "-stdlib=libc++"])
+    env.cxx.flags.extend(["-std=c++20", "-stdlib=libc++"])
     env.link.libs.append("c++")
 else:
-    env.cxx.flags.append("-std=c++23")
+    env.cxx.flags.append("-std=c++20")
 
 # Discover Python's dev headers from the *running* interpreter via sysconfig,
 # rather than pkg-config.
@@ -50,7 +50,9 @@ if sys.platform == "win32":
     libname = f"python{sys.version_info.major}{sys.version_info.minor}"
     if sysconfig.get_config_var("Py_GIL_DISABLED"):
         libname += "t"  # free-threaded builds link pythonNNt.lib
-    py_libraries = [libname]
+    # MSVC link.exe takes libraries as filenames (python314.lib), not -l names;
+    # a bare stem would be treated as python314.obj.
+    py_libraries = [f"{libname}.lib"]
 
 python = ImportedTarget.from_package(
     PackageDescription(
@@ -119,6 +121,7 @@ if toolchain.name in ("gcc", "llvm"):
 
 hello_lib = project.SharedLibrary("hello_lib", env, sources=["src/hello.cpp"])
 hello_lib.public.include_dirs.append("src")
+hello_lib.private.defines.append("HELLO_LIB_EXPORTS")
 
 # Python extensions must not have the "lib" prefix and must use the platform suffix
 # e.g. pcons_hello_ext.cpython-314-x86_64-linux-gnu.so

--- a/examples/50_pyproject/src/hello.hpp
+++ b/examples/50_pyproject/src/hello.hpp
@@ -2,5 +2,14 @@
 
 #include <string_view>
 
-std::string_view hello();
+#if defined(_WIN32)
+#  if defined(HELLO_LIB_EXPORTS)
+#    define HELLO_API __declspec(dllexport)
+#  else
+#    define HELLO_API __declspec(dllimport)
+#  endif
+#else
+#  define HELLO_API
+#endif
 
+HELLO_API std::string_view hello();

--- a/examples/50_pyproject/test.toml
+++ b/examples/50_pyproject/test.toml
@@ -7,6 +7,10 @@ description = "Build a Python extension using the pyproject.toml backend and run
 expected_outputs = [
     "build/pcons_hello_ext.cpython-*.so",
 ]
+# On Windows the extension suffix is e.g. .cp314-win_amd64.pyd (not .so/.dll).
+expected_outputs_windows = [
+    "build/pcons_hello_ext.cp*.pyd",
+]
 
 [verify.variables]
 
@@ -51,7 +55,10 @@ commands = [
     # which uv pip would otherwise target instead.
     { run = "uv build --wheel" },
     { run = "uv pip uninstall --python .venv pcons_hello_ext" },
-    { run = "uv pip install --python .venv dist/*.whl" },
+    # Install the freshly built wheel by name from dist/, rather than globbing
+    # dist/*.whl: the glob isn't expanded by cmd.exe on Windows. --no-index keeps
+    # it offline (the package has no runtime deps).
+    { run = "uv pip install --python .venv --no-index --find-links dist pcons_hello_ext" },
     { run = "uv run --no-sync python -c \"${test_wheel_script}\"", expect_stdout = "Hello, world!" },
 
     # --- source distribution ---
@@ -60,6 +67,6 @@ commands = [
 ]
 
 [skip]
-platforms = ["windows"]
+platforms = []
 generators = ["xcode", "make"]
 

--- a/examples/50_pyproject/test.toml
+++ b/examples/50_pyproject/test.toml
@@ -12,27 +12,6 @@ expected_outputs_windows = [
     "build/pcons_hello_ext.cp*.pyd",
 ]
 
-[verify.variables]
-
-test_editable_script = """import pcons_hello_ext
-print(pcons_hello_ext.say_hello('world'))
-assert 'build' in pcons_hello_ext.__file__, f'Expected extension in build dir (editable install), found: {pcons_hello_ext.__file__}'
-"""
-
-test_wheel_script = """import pcons_hello_ext
-print(pcons_hello_ext.say_hello('world'))
-assert 'site-packages' in pcons_hello_ext.__file__, f'Expected installed (non-editable) extension in site-packages, found: {pcons_hello_ext.__file__}'
-"""
-
-# The sdist must ship a spec-required PKG-INFO and every source needed to
-# rebuild (recursively, including src/), not just the top-level files.
-test_sdist_script = """import tarfile, glob
-ns = tarfile.open(glob.glob('dist/*.tar.gz')[0]).getnames()
-assert any(n.endswith('/PKG-INFO') for n in ns), f'PKG-INFO missing from sdist: {ns}'
-assert any(n.endswith('src/hello.cpp') for n in ns), f'hello.cpp missing from sdist: {ns}'
-assert any(n.endswith('src/hello.hpp') for n in ns), f'hello.hpp missing from sdist: {ns}'
-"""
-
 [verify]
 # Two install paths are exercised, both driving the full PEP 517 / pcons.pyproject
 # code path. pcons is installed from the local checkout (injected by the test
@@ -45,7 +24,7 @@ assert any(n.endswith('src/hello.hpp') for n in ns), f'hello.hpp missing from sd
 commands = [
     # --- editable install ---
     { run = "uv sync" },
-    { run = "uv run python -c \"${test_editable_script}\"", expect_stdout = "Hello, world!" },
+    { run = "uv run python test_editable.py", expect_stdout = "Hello, world!" },
 
     # --- real (non-editable) install from a built wheel ---
     # Build a wheel and install it into the project .venv, replacing the editable
@@ -59,11 +38,11 @@ commands = [
     # dist/*.whl: the glob isn't expanded by cmd.exe on Windows. --no-index keeps
     # it offline (the package has no runtime deps).
     { run = "uv pip install --python .venv --no-index --find-links dist pcons_hello_ext" },
-    { run = "uv run --no-sync python -c \"${test_wheel_script}\"", expect_stdout = "Hello, world!" },
+    { run = "uv run --no-sync python test_wheel.py", expect_stdout = "Hello, world!" },
 
     # --- source distribution ---
     { run = "uv build --sdist" },
-    { run = "uv run --no-sync python -c \"${test_sdist_script}\"" },
+    { run = "uv run --no-sync python test_sdist.py" },
 ]
 
 [skip]

--- a/examples/50_pyproject/test_editable.py
+++ b/examples/50_pyproject/test_editable.py
@@ -1,0 +1,6 @@
+import pcons_hello_ext
+
+print(pcons_hello_ext.say_hello("world"))
+assert "build" in pcons_hello_ext.__file__, (
+    f"Expected extension in build dir (editable install), found: {pcons_hello_ext.__file__}"
+)

--- a/examples/50_pyproject/test_sdist.py
+++ b/examples/50_pyproject/test_sdist.py
@@ -1,0 +1,12 @@
+import glob
+import tarfile
+
+ns = tarfile.open(glob.glob("dist/*.tar.gz")[0]).getnames()
+
+assert any(n.endswith("/PKG-INFO") for n in ns), f"PKG-INFO missing from sdist: {ns}"
+assert any(n.endswith("src/hello.cpp") for n in ns), (
+    f"hello.cpp missing from sdist: {ns}"
+)
+assert any(n.endswith("src/hello.hpp") for n in ns), (
+    f"hello.hpp missing from sdist: {ns}"
+)

--- a/examples/50_pyproject/test_wheel.py
+++ b/examples/50_pyproject/test_wheel.py
@@ -1,0 +1,6 @@
+import pcons_hello_ext
+
+print(pcons_hello_ext.say_hello("world"))
+assert "site-packages" in pcons_hello_ext.__file__, (
+    f"Expected installed (non-editable) extension in site-packages, found: {pcons_hello_ext.__file__}"
+)

--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -558,7 +558,15 @@ class ConanFinder(BaseFinder):
         self._save_cache_key()
 
         # Parse the generated .pc files
-        return self._parse_pkgconfig_files()
+        packages = self._parse_pkgconfig_files()
+        if not packages:
+            raise RuntimeError(
+                f"Conan install succeeded but no packages were parsed. "
+                f"No .pc files found under {self.output_folder}. "
+                f"Check that the conanfile declares dependencies and that "
+                f"the PkgConfigDeps generator produced output."
+            )
+        return packages
 
     def _parse_pkgconfig_files(self) -> dict[str, PackageDescription]:
         """Parse the .pc files Conan's PkgConfigDeps generator produced.

--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -571,16 +571,21 @@ class ConanFinder(BaseFinder):
         """
         packages: dict[str, PackageDescription] = {}
 
-        # Find the directory containing .pc files
-        # Conan with cmake_layout puts them in build/{build_type}/generators/
+        # Find the directory containing .pc files. With cmake_layout their
+        # location depends on whether the CMake generator is single- or
+        # multi-config:
+        #   single-config (Make/Ninja, e.g. gcc):  build/<build_type>/generators/
+        #   multi-config (MSVC/Xcode):              build/generators/
+        # Search recursively rather than enumerating layouts, so any future
+        # layout is handled too. Prefer a directory literally named "generators".
         pc_dir = self.output_folder
         if not list(pc_dir.glob("*.pc")):
-            # Check cmake_layout subfolders
-            for build_type in ["Release", "Debug", "RelWithDebInfo", "MinSizeRel"]:
-                candidate = self.output_folder / "build" / build_type / "generators"
-                if candidate.exists() and list(candidate.glob("*.pc")):
-                    pc_dir = candidate
-                    break
+            candidates = sorted(
+                {p.parent for p in self.output_folder.rglob("*.pc")},
+                key=lambda d: (d.name != "generators", str(d)),
+            )
+            if candidates:
+                pc_dir = candidates[0]
 
         if not list(pc_dir.glob("*.pc")):
             # No .pc files found anywhere
@@ -600,7 +605,10 @@ class ConanFinder(BaseFinder):
             finder = PkgConfigFinder()
             if not finder.is_available():
                 # Fallback to manual parsing if pkg-config is not available
-                return self._parse_pc_files_manually()
+                # (common on Windows). Parse the directory we just located the
+                # .pc files in, not self.output_folder — with cmake_layout they
+                # live in build/<build_type>/generators/, not the root.
+                return self._parse_pc_files_manually(pc_dir)
 
             # Find all .pc files
             for pc_file in pc_dir.glob("*.pc"):
@@ -628,17 +636,26 @@ class ConanFinder(BaseFinder):
         self._packages = packages
         return packages
 
-    def _parse_pc_files_manually(self) -> dict[str, PackageDescription]:
+    def _parse_pc_files_manually(
+        self, pc_dir: Path | None = None
+    ) -> dict[str, PackageDescription]:
         """Parse .pc files manually when pkg-config is not available.
 
         This is a fallback that parses the basic structure of .pc files.
+
+        Args:
+            pc_dir: Directory containing the .pc files. Defaults to the output
+                folder; callers that located the files in a cmake_layout
+                subfolder should pass that directory.
 
         Returns:
             Dict mapping package names to PackageDescription objects.
         """
         packages: dict[str, PackageDescription] = {}
+        if pc_dir is None:
+            pc_dir = self.output_folder
 
-        for pc_file in self.output_folder.glob("*.pc"):
+        for pc_file in pc_dir.glob("*.pc"):
             pkg = self._parse_single_pc_file(pc_file)
             if pkg is not None:
                 packages[pkg.name] = pkg

--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING, Any
 from pcons.configure.platform import get_platform
 from pcons.packages.description import PackageDescription
 from pcons.packages.finders.base import BaseFinder
-from pcons.packages.finders.pkgconfig import PkgConfigFinder
 
 if TYPE_CHECKING:
     from pcons.configure.config import Configure
@@ -562,16 +561,25 @@ class ConanFinder(BaseFinder):
         return self._parse_pkgconfig_files()
 
     def _parse_pkgconfig_files(self) -> dict[str, PackageDescription]:
-        """Parse all .pc files in the output folder.
+        """Parse the .pc files Conan's PkgConfigDeps generator produced.
 
-        Automatically searches cmake_layout subfolders if no .pc files found
-        in the main output folder.
+        Conan fully controls these files, so we parse them directly rather
+        than shelling out to a system pkg-config. Relying on pkg-config made
+        the result depend on whether one happens to be installed and on which
+        implementation it is: GitHub's windows-latest runners carry Strawberry
+        Perl's old pkg-config on PATH, and it fails to resolve nanobind's
+        transitive ``Requires`` — silently dropping the package, which
+        surfaces later as ``KeyError 'nanobind'`` — whereas the same build
+        works on machines with no pkg-config because the manual parser runs
+        instead. One deterministic, cross-platform path removes that
+        fragility.
+
+        Automatically searches cmake_layout subfolders if no .pc files are in
+        the main output folder.
 
         Returns:
             Dict mapping package names to PackageDescription objects.
         """
-        packages: dict[str, PackageDescription] = {}
-
         # Find the directory containing .pc files. With cmake_layout their
         # location depends on whether the CMake generator is single- or
         # multi-config:
@@ -588,54 +596,7 @@ class ConanFinder(BaseFinder):
             if candidates:
                 pc_dir = candidates[0]
 
-        if not list(pc_dir.glob("*.pc")):
-            # No .pc files found anywhere
-            self._packages = packages
-            return packages
-
-        # Create a PkgConfigFinder that searches in the pc_dir
-        # Set PKG_CONFIG_PATH environment for pkg-config
-        old_pkg_config_path = os.environ.get("PKG_CONFIG_PATH", "")
-        try:
-            # Prepend our pc_dir to PKG_CONFIG_PATH
-            new_path = str(pc_dir)
-            if old_pkg_config_path:
-                new_path = f"{new_path}{os.pathsep}{old_pkg_config_path}"
-            os.environ["PKG_CONFIG_PATH"] = new_path
-
-            finder = PkgConfigFinder()
-            if not finder.is_available():
-                # Fallback to manual parsing if pkg-config is not available
-                # (common on Windows). Parse the directory we just located the
-                # .pc files in, not self.output_folder — with cmake_layout they
-                # live in build/<build_type>/generators/, not the root.
-                return self._parse_pc_files_manually(pc_dir)
-
-            # Find all .pc files
-            for pc_file in pc_dir.glob("*.pc"):
-                pkg_name = pc_file.stem
-                # Skip private files (those with - in name that are components)
-                # but only if the base package also exists
-                if "-" in pkg_name:
-                    base_name = pkg_name.rsplit("-", 1)[0]
-                    base_pc = pc_dir / f"{base_name}.pc"
-                    if base_pc.exists():
-                        continue  # Skip, this is a component
-
-                pkg = finder.find(pkg_name)
-                if pkg is not None:
-                    pkg.found_by = "conan"
-                    packages[pkg_name] = pkg
-
-        finally:
-            # Restore original PKG_CONFIG_PATH
-            if old_pkg_config_path:
-                os.environ["PKG_CONFIG_PATH"] = old_pkg_config_path
-            elif "PKG_CONFIG_PATH" in os.environ:
-                del os.environ["PKG_CONFIG_PATH"]
-
-        self._packages = packages
-        return packages
+        return self._parse_pc_files_manually(pc_dir)
 
     def _parse_pc_files_manually(
         self, pc_dir: Path | None = None

--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -660,8 +661,65 @@ class ConanFinder(BaseFinder):
             if pkg is not None:
                 packages[pkg.name] = pkg
 
+        # Resolve Requires: transitively and fold each required package's flags into the dependent.
+        # Real pkg-config does this when emitting
+        # --cflags/--libs (e.g. nanobind Requires tsl-robin-map, so building
+        # against nanobind must see robin-map's include dir).
+        # The manual parser sees each .pc in isolation, so we replicate the merge here.
+        self._merge_transitive_requires(packages)
+
         self._packages = packages
         return packages
+
+    @staticmethod
+    def _merge_transitive_requires(
+        packages: dict[str, PackageDescription],
+    ) -> None:
+        """Fold each package's transitive Requires flags into it, in place."""
+
+        def closure(name: str, seen: set[str]) -> list[str]:
+            ordered: list[str] = []
+            pkg = packages.get(name)
+            if pkg is None:
+                return ordered
+            for dep in pkg.dependencies:
+                if dep in seen or dep not in packages:
+                    continue
+                seen.add(dep)
+                ordered.append(dep)
+                ordered.extend(closure(dep, seen))
+            return ordered
+
+        def dedupe(seq: list[str]) -> list[str]:
+            seen: set[str] = set()
+            out: list[str] = []
+            for item in seq:
+                if item not in seen:
+                    seen.add(item)
+                    out.append(item)
+            return out
+
+        for name, pkg in packages.items():
+            dep_names = closure(name, {name})
+            if not dep_names:
+                continue
+            deps = [packages[d] for d in dep_names]
+            pkg.include_dirs = dedupe(
+                pkg.include_dirs + [d for dep in deps for d in dep.include_dirs]
+            )
+            pkg.library_dirs = dedupe(
+                pkg.library_dirs + [d for dep in deps for d in dep.library_dirs]
+            )
+            pkg.libraries = dedupe(
+                pkg.libraries + [d for dep in deps for d in dep.libraries]
+            )
+            pkg.defines = dedupe(pkg.defines + [d for dep in deps for d in dep.defines])
+            pkg.compile_flags = dedupe(
+                pkg.compile_flags + [f for dep in deps for f in dep.compile_flags]
+            )
+            pkg.link_flags = dedupe(
+                pkg.link_flags + [f for dep in deps for f in dep.link_flags]
+            )
 
     def _parse_single_pc_file(self, pc_file: Path) -> PackageDescription | None:
         """Parse a single .pc file.
@@ -682,6 +740,7 @@ class ConanFinder(BaseFinder):
         version = ""
         cflags = ""
         libs = ""
+        requires_raw = ""
 
         for line in content.splitlines():
             line = line.strip()
@@ -707,6 +766,10 @@ class ConanFinder(BaseFinder):
                     cflags = value
                 elif key == "libs":
                     libs = value
+                elif key in ("requires", "requires.private"):
+                    # Accumulate both public and private requires,
+                    # pkg-config merges the cflags/libs of both into its output.
+                    requires_raw = f"{requires_raw} {value}".strip()
 
         # Substitute variables recursively in cflags and libs
         def substitute_vars(s: str, max_iterations: int = 10) -> str:
@@ -723,16 +786,35 @@ class ConanFinder(BaseFinder):
         cflags = substitute_vars(cflags)
         libs = substitute_vars(libs)
 
+        def strip_quotes(value: str) -> str:
+            """Remove a single pair of surrounding matching quotes.
+
+            Conan's PkgConfigDeps generator quotes path values (e.g. ``-I"${includedir}"``).
+            Real pkg-config strips these, the manual fallback parser must too,
+            otherwise the leading quote defeats absolute-path detection downstream.
+            """
+            if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                return value[1:-1]
+            return value
+
+        # Tokenize with shlex (posix=False keeps backslashes literal for
+        # Windows paths) so quoted values containing spaces stay intact.
+        def tokenize(s: str) -> list[str]:
+            try:
+                return shlex.split(s, posix=False)
+            except ValueError:
+                return s.split()
+
         # Parse cflags
         include_dirs: list[str] = []
         defines: list[str] = []
         compile_flags: list[str] = []
 
-        for flag in cflags.split():
+        for flag in tokenize(cflags):
             if flag.startswith("-I"):
-                include_dirs.append(flag[2:])
+                include_dirs.append(strip_quotes(flag[2:]))
             elif flag.startswith("-D"):
-                defines.append(flag[2:])
+                defines.append(strip_quotes(flag[2:]))
             else:
                 compile_flags.append(flag)
 
@@ -741,13 +823,29 @@ class ConanFinder(BaseFinder):
         libraries: list[str] = []
         link_flags: list[str] = []
 
-        for flag in libs.split():
+        for flag in tokenize(libs):
             if flag.startswith("-L"):
-                library_dirs.append(flag[2:])
+                library_dirs.append(strip_quotes(flag[2:]))
             elif flag.startswith("-l"):
-                libraries.append(flag[2:])
+                libraries.append(strip_quotes(flag[2:]))
             else:
                 link_flags.append(flag)
+
+        # Parse Requires names.
+        # Entries are separated by commas/whitespace and
+        # may carry a version constraint (e.g. "foo >= 1.2"),
+        # keep only names.
+        dependencies: list[str] = []
+        operators = {"=", "<", ">", "<=", ">=", "!="}
+        expect_version = False
+        for token in requires_raw.replace(",", " ").split():
+            if expect_version:
+                expect_version = False
+                continue
+            if token in operators:
+                expect_version = True
+                continue
+            dependencies.append(token)
 
         return PackageDescription(
             name=name,
@@ -758,6 +856,8 @@ class ConanFinder(BaseFinder):
             defines=defines,
             compile_flags=compile_flags,
             link_flags=link_flags,
+            dependencies=dependencies,
+            prefix=variables.get("prefix", ""),
             found_by="conan",
         )
 

--- a/pcons/packages/imported.py
+++ b/pcons/packages/imported.py
@@ -96,10 +96,8 @@ class ImportedTarget(Target):
         for lib in package.libraries:
             self.public.link_libs.append(lib)
 
-        # Library directories go into link_flags as -L prefixed
-        # (UsageRequirements doesn't have link_dirs, only link_flags)
         for lib_dir in package.library_dirs:
-            self.public.link_flags.append(f"-L{lib_dir}")
+            self.public.link_dirs.append(Path(lib_dir))
 
         # Framework directories and frameworks (macOS)
         for fw_dir in package.framework_dirs:

--- a/pcons/tools/requirements.py
+++ b/pcons/tools/requirements.py
@@ -76,6 +76,10 @@ class EffectiveRequirements:
         for lib in reqs.link_libs:
             if lib not in self.link_libs:
                 self.link_libs.append(lib)
+        for lib_dir in reqs.link_dirs:
+            dir_path = Path(lib_dir) if isinstance(lib_dir, str) else lib_dir
+            if dir_path not in self.link_dirs:
+                self.link_dirs.append(dir_path)
 
     def as_hashable_tuple(self) -> tuple:
         """Return hashable representation for caching.

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -287,6 +288,34 @@ Cflags: -I${includedir}
             pkg = packages["zlib"]
             assert pkg.name == "zlib"
             assert pkg.found_by == "conan"
+
+    def test_install_raises_when_nothing_parses(self, tmp_path: Path) -> None:
+        """Install must fail when conan succeeds but no .pc files are found."""
+        conanfile = tmp_path / "conanfile.txt"
+        conanfile.write_text("[requires]\nzlib/1.3\n")
+
+        output_folder = tmp_path / "deps"
+        output_folder.mkdir()
+
+        finder = ConanFinder(
+            conanfile=conanfile,
+            output_folder=output_folder,
+        )
+        finder.sync_profile()
+
+        def mock_run(cmd, **kwargs):
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with (
+            patch.object(finder, "is_available", return_value=True),
+            patch("subprocess.run", side_effect=mock_run),
+            pytest.raises(RuntimeError, match=re.escape(str(output_folder))),
+        ):
+            finder.install()
 
 
 class TestConanFinderCaching:

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -455,8 +455,7 @@ Cflags: -I/opt/bar/include
         build/<build_type>/generators (single-config) or build/generators
         (multi-config, i.e. MSVC on Windows). Discovery previously only looked
         at the former, so on Windows nothing was found and the package dict came
-        back empty (KeyError 'nanobind' on use). pkg-config is also typically
-        unavailable on Windows, so this exercises the manual-parse fallback too.
+        back empty (KeyError 'nanobind' on use).
         """
         gen_dir = tmp_path / gen_relpath
         gen_dir.mkdir(parents=True)
@@ -468,16 +467,51 @@ Cflags: -I/opt/nanobind/include
         )
 
         finder = ConanFinder(output_folder=tmp_path)
-        # Force the pkg-config-unavailable fallback (the Windows situation).
-        with patch(
-            "pcons.packages.finders.conan.PkgConfigFinder.is_available",
-            return_value=False,
-        ):
-            packages = finder._parse_pkgconfig_files()
+        packages = finder._parse_pkgconfig_files()
 
         assert "nanobind" in packages
         assert packages["nanobind"].version == "2.12.0"
         assert "/opt/nanobind/include" in packages["nanobind"].include_dirs
+
+    def test_parse_is_independent_of_system_pkgconfig(self, tmp_path: Path) -> None:
+        """Conan .pc files are parsed deterministically, not via pkg-config.
+
+        Regression: GitHub's windows-latest runners carry Strawberry Perl's old
+        pkg-config on PATH, and it failed to resolve nanobind's transitive
+        ``Requires`` — silently dropping the package (KeyError 'nanobind'
+        downstream). The same build worked on machines with no pkg-config. The
+        finder must parse its own generated files itself so the result is the
+        same everywhere, including merging transitive Requires and stripping the
+        quotes Conan puts around paths.
+        """
+        gen = tmp_path / "build" / "generators"
+        gen.mkdir(parents=True)
+        (gen / "nanobind.pc").write_text(
+            "prefix=/p/nanobind\n"
+            "includedir=${prefix}/include\n"
+            "Name: nanobind\n"
+            "Version: 2.12.0\n"
+            'Cflags: -I"${includedir}"\n'
+            "Requires: tsl-robin-map\n"
+        )
+        (gen / "tsl-robin-map.pc").write_text(
+            "prefix=/p/robin\n"
+            "includedir=${prefix}/include\n"
+            "Name: tsl-robin-map\n"
+            "Version: 1.4.0\n"
+            'Cflags: -I"${includedir}"\n'
+        )
+
+        finder = ConanFinder(output_folder=tmp_path)
+        packages = finder._parse_pkgconfig_files()
+
+        assert "nanobind" in packages
+        nb = packages["nanobind"]
+        # Own include dir, with Conan's surrounding quotes stripped.
+        assert "/p/nanobind/include" in nb.include_dirs
+        # Transitive include from tsl-robin-map merged in (what pkg-config
+        # --cflags would have done).
+        assert "/p/robin/include" in nb.include_dirs
 
 
 class TestConanFinderFind:

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -380,11 +380,35 @@ Libs: -L${libdir} -ltest -lpthread
         assert pkg is not None
         assert pkg.name == "test"
         assert pkg.version == "1.2.3"
+        assert pkg.prefix == "/usr/local"
         assert "/usr/local/include" in pkg.include_dirs
         assert "TEST_DEFINE" in pkg.defines
         assert "/usr/local/lib" in pkg.library_dirs
         assert "test" in pkg.libraries
         assert "pthread" in pkg.libraries
+
+    def test_parse_single_pc_file_quoted_paths(self, tmp_path: Path) -> None:
+        """Conan's PkgConfigDeps quotes path values, quotes must be stripped."""
+        pc_file = tmp_path / "nanobind.pc"
+        pc_file.write_text(
+            """prefix=C:/Users/me/.conan2/p/nanob123/p
+libdir=${prefix}/lib
+includedir=${prefix}/nanobind/include
+
+Name: nanobind
+Version: 2.12.0
+Libs: -L"${libdir}"
+Cflags: -I"${includedir}"
+"""
+        )
+
+        finder = ConanFinder(output_folder=tmp_path)
+        pkg = finder._parse_single_pc_file(pc_file)
+
+        assert pkg is not None
+        assert pkg.prefix == "C:/Users/me/.conan2/p/nanob123/p"
+        assert pkg.include_dirs == ["C:/Users/me/.conan2/p/nanob123/p/nanobind/include"]
+        assert pkg.library_dirs == ["C:/Users/me/.conan2/p/nanob123/p/lib"]
 
     def test_parse_pc_files_manually(self, tmp_path: Path) -> None:
         """Test manual .pc file parsing."""

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -413,6 +413,48 @@ Cflags: -I/opt/bar/include
         assert "bar" in packages["bar"].libraries
         assert "/opt/bar/include" in packages["bar"].include_dirs
 
+    @pytest.mark.parametrize(
+        "gen_relpath",
+        [
+            # single-config (Make/Ninja, e.g. gcc): build/<build_type>/generators
+            "build/Release/generators",
+            # multi-config (MSVC/Xcode): build/generators — the Windows layout
+            "build/generators",
+        ],
+    )
+    def test_parse_discovers_pc_files_across_cmake_layouts(
+        self, tmp_path: Path, gen_relpath: str
+    ) -> None:
+        """.pc files must be found in whichever generators/ subfolder they land.
+
+        Regression: cmake_layout puts the generated .pc files in
+        build/<build_type>/generators (single-config) or build/generators
+        (multi-config, i.e. MSVC on Windows). Discovery previously only looked
+        at the former, so on Windows nothing was found and the package dict came
+        back empty (KeyError 'nanobind' on use). pkg-config is also typically
+        unavailable on Windows, so this exercises the manual-parse fallback too.
+        """
+        gen_dir = tmp_path / gen_relpath
+        gen_dir.mkdir(parents=True)
+        (gen_dir / "nanobind.pc").write_text(
+            """Name: nanobind
+Version: 2.12.0
+Cflags: -I/opt/nanobind/include
+"""
+        )
+
+        finder = ConanFinder(output_folder=tmp_path)
+        # Force the pkg-config-unavailable fallback (the Windows situation).
+        with patch(
+            "pcons.packages.finders.conan.PkgConfigFinder.is_available",
+            return_value=False,
+        ):
+            packages = finder._parse_pkgconfig_files()
+
+        assert "nanobind" in packages
+        assert packages["nanobind"].version == "2.12.0"
+        assert "/opt/nanobind/include" in packages["nanobind"].include_dirs
+
 
 class TestConanFinderFind:
     """Tests for find() method."""

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -136,7 +136,9 @@ class TestImportedTarget:
         assert "TEST_DEFINE" in target.public.defines
         assert "-DEXTRA_FLAG" in target.public.compile_flags
         assert "testlib" in target.public.link_libs
-        assert "-L/opt/test/lib" in target.public.link_flags
+        # Library dirs propagate as link_dirs so the consuming toolchain can
+        # apply the right prefix (-L for GCC/Clang, /LIBPATH: for MSVC).
+        assert Path("/opt/test/lib") in target.public.link_dirs
         assert "-Wl,-rpath,/opt/test/lib" in target.public.link_flags
 
     def test_public_requirements_frameworks_macos(self, test_project):  # noqa: F811
@@ -229,4 +231,6 @@ class TestImportedTarget:
         assert Path("/usr/include/openssl") in reqs.include_dirs
         assert "ssl" in reqs.link_libs
         assert "crypto" in reqs.link_libs
-        assert "-L/usr/lib" in reqs.link_flags
+        # Library dirs propagate as link_dirs
+        # (the toolchain applies -L or /LIBPATH:), not as pre-prefixed link_flags.
+        assert Path("/usr/lib") in reqs.link_dirs

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -691,16 +691,9 @@ def _example_template_vars() -> dict[str, str]:
     }
 
 
-def _substitute_variables(path: str, extra: dict[str, str] | None = None) -> str:
-    """Substitute ``${VAR}`` placeholders in a string.
-
-    *extra* supplies example-defined variables from the ``[test.variables]``
-    section, which take precedence over the built-in platform-derived ones and
-    let a test.toml factor out long inline scripts (see ``examples/50_pyproject``).
-    """
+def _substitute_variables(path: str) -> str:
+    """Substitute ``${VAR}`` platform-derived placeholders in a string."""
     table = _example_template_vars()
-    if extra:
-        table = {**table, **extra}
 
     def replacer(match: re.Match) -> str:
         var_name = match.group(1)
@@ -990,18 +983,14 @@ def run_example(
     has_platform_override = f"commands_{current_platform}" in verify_config
     verify_commands = get_platform_value(verify_config, "commands", [])
 
-    # Example-defined [test.variables] are available as ${name} placeholders in
-    # verify commands, letting a test.toml factor out long inline scripts.
-    test_variables = verify_config.get("variables", {})
-
     for cmd_config in verify_commands:
         run_cmd = cmd_config.get("run")
         if not run_cmd:
             continue
 
-        # Expand ${...} placeholders (platform vars + [test.variables]) before
-        # any command adaptation or path resolution.
-        run_cmd = _substitute_variables(run_cmd, extra=test_variables)
+        # Expand ${...} platform placeholders before any command adaptation
+        # or path resolution.
+        run_cmd = _substitute_variables(run_cmd)
 
         # Adapt command for Windows if no platform-specific override exists
         if IS_WINDOWS and not has_platform_override:


### PR DESCRIPTION
### Summary :memo:

Follow up of #37 - gets the `50_pyproject` nanobind example building on **Windows**, where there's usually no `pkg-config` around.

The example now builds a wheel end-to-end on Linux, macOS and Windows.

### Details

1. **Find Conan's `.pc` files whatever the CMake layout** (`conan.py`): single-config backends (Make/Ninja) put them in `build/<build_type>/generators/`, multi-config ones (MSVC/Xcode) in `build/generators/`. Rather than guessing build types, we just search recursively and prefer a `generators` dir.
2. **Fix the manual `.pc` parser** (the fallback when there's no `pkg-config`): it now reads from where the files actually are, keeps the package prefix, strips quotes off `-I`/`-L` paths, and follows transitive `Requires:` so `nanobind` pulls in `tsl-robin-map`.
3. **Pass library dirs as `link_dirs`, not hardcoded `-L`** (`imported.py`, `requirements.py`): so MSVC gets `/LIBPATH:` and GCC/Clang get `-L`.
4. **Use real Python scripts for the wheel/sdist/editable checks**: the old inline multiline strings in `test.toml` don't work on Windows.
5. Tests for all of the above.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
