### PR TITLE
Feature/link libs rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,15 @@ test:             ## Run tests.
 
 .PHONY: test-cov
 test-cov:         ## Run tests with coverage report.
-	uv run pytest --cov=pcons --cov-report=html --cov-report=xml
+	uv run pytest --cov=pcons --cov-branch --cov-report=html --cov-report=xml
 	@echo "Coverage report: htmlcov/index.html"
+
+.PHONY: test-cov-main-diff
+test-cov-main-diff: test-cov   ## Show coverage diff with main branch.
+	uvx diff-cover coverage.xml --compare-branch=origin/main \
+		--format html:htmlcov/main-diff-cover.html \
+		--format markdown:htmlcov/main-diff-cover.md
+	@echo "Coverage diff report: htmlcov/main-diff-cover.html and htmlcov/main-diff-cover.md"
 
 .PHONY: watch
 watch:            ## Run tests on every change.

--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -42,14 +42,14 @@ libphysics.add_sources(["src/physics.c"])
 if sys.platform == "win32":
     # export symbols on Windows
     libphysics.private.defines.append("PHYSICS_BUILDING_DLL")
-libphysics.link(libmath)  # Gets libmath's public includes transitively
+libphysics.public.link_libs.append(libmath)  # Gets libmath's public includes transitively
 
 # -----------------------------------------------------------------------------
 # Program: simulator - main application
 # -----------------------------------------------------------------------------
 simulator = project.Program("simulator", env)
 simulator.add_sources(["src/main.c"])
-simulator.link(libphysics)  # Gets both libphysics and libmath includes
+simulator.private.link_libs.append(libphysics)  # Gets both libphysics and libmath includes
 
 # Generate Mermaid dependency diagram (after generate, which auto-resolves)
 mermaid_gen = MermaidGenerator(direction="LR")

--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -42,14 +42,18 @@ libphysics.add_sources(["src/physics.c"])
 if sys.platform == "win32":
     # export symbols on Windows
     libphysics.private.defines.append("PHYSICS_BUILDING_DLL")
-libphysics.public.link_libs.append(libmath)  # Gets libmath's public includes transitively
+libphysics.public.link_libs.append(
+    libmath
+)  # Gets libmath's public includes transitively
 
 # -----------------------------------------------------------------------------
 # Program: simulator - main application
 # -----------------------------------------------------------------------------
 simulator = project.Program("simulator", env)
 simulator.add_sources(["src/main.c"])
-simulator.private.link_libs.append(libphysics)  # Gets both libphysics and libmath includes
+simulator.private.link_libs.append(
+    libphysics
+)  # Gets both libphysics and libmath includes
 
 # Generate Mermaid dependency diagram (after generate, which auto-resolves)
 mermaid_gen = MermaidGenerator(direction="LR")

--- a/examples/13_subdirs/app/pcons-build.py
+++ b/examples/13_subdirs/app/pcons-build.py
@@ -18,4 +18,4 @@ assert libfoo is not None, (
 
 app = project.Program("app", env)
 app.add_sources(["src/main.c"])
-app.link(libfoo)
+app.public.link_libs.append(libfoo)

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -30,11 +30,11 @@ core_lib.public.include_dirs.append(src_dir)  # So dependents can #include "core
 # 2. Create shared library from wrapper.c, linking the static library
 #    wrapper.c includes "core.h" which should be found via core_lib's public includes
 wrapper_lib = project.SharedLibrary("wrapper", env, sources=[src_dir / "wrapper.c"])
-wrapper_lib.link(core_lib)
+wrapper_lib.public.link_libs.append(core_lib)
 
 # 3. Create executable that links the shared library
 prog = project.Program("demo", env, sources=[src_dir / "main.c"])
-prog.link(wrapper_lib)
+prog.private.link_libs.append(wrapper_lib)
 
 # install_dir() resolves the conventional subdir from the env's toolchain:
 # shared libs land in "lib" (or "bin" on DLL platforms), archives in "lib",

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -7,4 +7,5 @@ a = project.StaticLibrary("a", env, sources=["a.cppm"])
 # pick "aa" variable ("libaa") from the subdirectory aa/pcons-build.py
 (aa,) = add_subdirectory("aa", pick=["aa"])
 
-project.Program("a_app", env, sources=["a_main.cpp"]).link(a, aa)
+a_app = project.Program("a_app", env, sources=["a_main.cpp"])
+a_app.private.link_libs.extend([a, aa])

--- a/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
@@ -10,6 +10,5 @@ from pcons import context
 
 project = context.current_project
 env = project.default_environment
-project.Program("app", env).add_sources(["main.cpp"]).link(
-    *context.get_targets("a", "aa", "b", "bb")
-)
+app = project.Program("app", env, sources=["main.cpp"])
+app.private.link_libs.extend(context.get_targets("a", "aa", "b", "bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/bb/pcons-build.py
@@ -5,4 +5,5 @@ env = project.default_environment
 
 bb = project.StaticLibrary("bb", env, sources=["bb.cppm"])
 
-project.Program("bb_app", env, sources=["bb_main.cpp"]).link(bb)
+bb_app = project.Program("bb_app", env, sources=["bb_main.cpp"])
+bb_app.private.link_libs.extend([bb])

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -7,4 +7,5 @@ b = project.StaticLibrary("b", env, sources=["b.cppm"])
 # load the subdirectory's pcons-build.py as SimpleNamespace (with all variables defined in it)
 s = add_subdirectory("bb")
 
-project.Program("b_app", env, sources=["b_main.cpp"]).link(b, s.bb)
+b_app = project.Program("b_app", env, sources=["b_main.cpp"])
+b_app.private.link_libs.extend([b, s.bb])

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -60,6 +60,6 @@ lib3.private.compile_flags.extend(breaker_dialect)
 # A program to prove the shared interface links and runs end to end.
 app = project.Program("app", env, sources=["main.cpp"])
 app.private.compile_flags.extend(shared_dialect)
-app.link(lib1)
+app.private.link_libs.append(lib1)
 
 project.generate()

--- a/examples/50_pyproject/pcons-build.py
+++ b/examples/50_pyproject/pcons-build.py
@@ -127,7 +127,7 @@ hello_lib.private.defines.append("HELLO_LIB_EXPORTS")
 # e.g. pcons_hello_ext.cpython-314-x86_64-linux-gnu.so
 pcons_hello_ext.output_prefix = ""
 pcons_hello_ext.output_suffix = sysconfig.get_config_var("EXT_SUFFIX")
-pcons_hello_ext.link(python, nanobind, hello_lib)
+pcons_hello_ext.private.link_libs.extend([python, nanobind, hello_lib])
 
 subgen = Path(nanobind.package.prefix) / "nanobind" / "stubgen.py"
 assert subgen.is_file(), f"Stub generator not found at {subgen}"

--- a/pcons/_gen_stubs.py
+++ b/pcons/_gen_stubs.py
@@ -407,23 +407,27 @@ def generate_toolconfig_stubs() -> str:
 _USAGE_REQUIREMENT_TYPES: tuple[tuple[str, str, str | None], ...] = (
     (
         "include_dirs",
-        "list[Path | str]",
+        "MutableSequence[Path | str]",
         "directories added to dependents' include path",
     ),
     (
         "compile_flags",
-        "list[str | PathToken]",
+        "MutableSequence[str | PathToken]",
         "flags propagated to dependents (strings + path tokens)",
     ),
     (
         "link_flags",
-        "list[str | PathToken]",
+        "MutableSequence[str | PathToken]",
         "flags propagated to dependents (strings + path tokens)",
     ),
-    ("defines", "list[str]", "preprocessor defines propagated to dependents"),
+    (
+        "defines",
+        "MutableSequence[str]",
+        "preprocessor defines propagated to dependents",
+    ),
     (
         "link_libs",
-        "list[str | Target | PathToken]",
+        "MutableSequence[str | Target | PathToken]",
         "libraries propagated to dependents (str + Target + path tokens)",
     ),
 )
@@ -446,6 +450,7 @@ def generate_usage_requirements_stubs() -> str:
     return _format_attribute_stubs_file(
         module_doc=module_doc,
         extra_typecheck_imports=[
+            "from typing import MutableSequence",
             "from pcons.core.subst import PathToken",
             "from pcons.core.target import Target",
         ],

--- a/pcons/_gen_stubs.py
+++ b/pcons/_gen_stubs.py
@@ -412,19 +412,19 @@ _USAGE_REQUIREMENT_TYPES: tuple[tuple[str, str, str | None], ...] = (
     ),
     (
         "compile_flags",
-        "list[Any]",
-        "flags propagated to dependents (strings + subst tokens)",
+        "list[str | PathToken]",
+        "flags propagated to dependents (strings + path tokens)",
     ),
     (
         "link_flags",
-        "list[Any]",
-        "flags propagated to dependents (strings + subst tokens)",
+        "list[str | PathToken]",
+        "flags propagated to dependents (strings + path tokens)",
     ),
     ("defines", "list[str]", "preprocessor defines propagated to dependents"),
     (
         "link_libs",
-        "list[Any]",
-        "libraries propagated to dependents (str + Target + tokens)",
+        "list[str | Target | PathToken]",
+        "libraries propagated to dependents (str + Target + path tokens)",
     ),
 )
 
@@ -445,7 +445,10 @@ def generate_usage_requirements_stubs() -> str:
     entries: list[tuple[str, str, str | None]] = list(_USAGE_REQUIREMENT_TYPES)
     return _format_attribute_stubs_file(
         module_doc=module_doc,
-        extra_typecheck_imports=[],
+        extra_typecheck_imports=[
+            "from pcons.core.subst import PathToken",
+            "from pcons.core.target import Target",
+        ],
         class_name="_UsageRequirementsStubs",
         class_doc="Typed mixin for UsageRequirements (TYPE_CHECKING-only).",
         entries=entries,

--- a/pcons/_gen_stubs.py
+++ b/pcons/_gen_stubs.py
@@ -413,12 +413,12 @@ _USAGE_REQUIREMENT_TYPES: tuple[tuple[str, str, str | None], ...] = (
     (
         "compile_flags",
         "MutableSequence[str | PathToken]",
-        "flags propagated to dependents (strings + path tokens)",
+        "flags propagated to dependents (strings, or PathToken for embedded paths)",
     ),
     (
         "link_flags",
         "MutableSequence[str | PathToken]",
-        "flags propagated to dependents (strings + path tokens)",
+        "flags propagated to dependents (strings, or PathToken for embedded paths)",
     ),
     (
         "defines",
@@ -427,8 +427,8 @@ _USAGE_REQUIREMENT_TYPES: tuple[tuple[str, str, str | None], ...] = (
     ),
     (
         "link_libs",
-        "MutableSequence[str | Target | PathToken]",
-        "libraries propagated to dependents (str + Target + path tokens)",
+        "MutableSequence[str | Target]",
+        "libraries propagated to dependents (names or Target objects)",
     ),
 )
 

--- a/pcons/builders/test.py
+++ b/pcons/builders/test.py
@@ -248,6 +248,6 @@ class TestBuilder:
         # it first (its output_nodes must exist before the factory runs)
         # and so the Ninja `test-build` phony pulls it in transitively.
         if isinstance(program, Target):
-            target.dependencies.append(program)
+            target.add_dependency(program)
 
         return target

--- a/pcons/core/_usage_requirements_stubs.py
+++ b/pcons/core/_usage_requirements_stubs.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         """Typed mixin for UsageRequirements (TYPE_CHECKING-only)."""
 
         include_dirs: MutableSequence[Path | str]  # directories added to dependents' include path
-        compile_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings + path tokens)
-        link_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings + path tokens)
+        compile_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings, or PathToken for embedded paths)
+        link_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings, or PathToken for embedded paths)
         defines: MutableSequence[str]  # preprocessor defines propagated to dependents
-        link_libs: MutableSequence[str | Target | PathToken]  # libraries propagated to dependents (str + Target + path tokens)
+        link_libs: MutableSequence[str | Target]  # libraries propagated to dependents (names or Target objects)

--- a/pcons/core/_usage_requirements_stubs.py
+++ b/pcons/core/_usage_requirements_stubs.py
@@ -17,12 +17,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from pcons.core.subst import PathToken
+    from pcons.core.target import Target
 
     class _UsageRequirementsStubs:
         """Typed mixin for UsageRequirements (TYPE_CHECKING-only)."""
 
         include_dirs: list[Path | str]  # directories added to dependents' include path
-        compile_flags: list[Any]  # flags propagated to dependents (strings + subst tokens)
-        link_flags: list[Any]  # flags propagated to dependents (strings + subst tokens)
+        compile_flags: list[str | PathToken]  # flags propagated to dependents (strings + path tokens)
+        link_flags: list[str | PathToken]  # flags propagated to dependents (strings + path tokens)
         defines: list[str]  # preprocessor defines propagated to dependents
-        link_libs: list[Any]  # libraries propagated to dependents (str + Target + tokens)
+        link_libs: list[str | Target | PathToken]  # libraries propagated to dependents (str + Target + path tokens)

--- a/pcons/core/_usage_requirements_stubs.py
+++ b/pcons/core/_usage_requirements_stubs.py
@@ -17,14 +17,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from typing import MutableSequence
     from pcons.core.subst import PathToken
     from pcons.core.target import Target
 
     class _UsageRequirementsStubs:
         """Typed mixin for UsageRequirements (TYPE_CHECKING-only)."""
 
-        include_dirs: list[Path | str]  # directories added to dependents' include path
-        compile_flags: list[str | PathToken]  # flags propagated to dependents (strings + path tokens)
-        link_flags: list[str | PathToken]  # flags propagated to dependents (strings + path tokens)
-        defines: list[str]  # preprocessor defines propagated to dependents
-        link_libs: list[str | Target | PathToken]  # libraries propagated to dependents (str + Target + path tokens)
+        include_dirs: MutableSequence[Path | str]  # directories added to dependents' include path
+        compile_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings + path tokens)
+        link_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings + path tokens)
+        defines: MutableSequence[str]  # preprocessor defines propagated to dependents
+        link_libs: MutableSequence[str | Target | PathToken]  # libraries propagated to dependents (str + Target + path tokens)

--- a/pcons/core/environment.py
+++ b/pcons/core/environment.py
@@ -914,7 +914,7 @@ class Environment(_EnvironmentStubs):
             # Add as dependencies to ensure correct build order
             for src_target in target_sources:
                 if src_target not in cmd_target.dependencies:
-                    cmd_target.dependencies.append(src_target)
+                    cmd_target.add_dependency(src_target)
 
         # Apply extra implicit dependencies
         if depends is not None:

--- a/pcons/core/flags.py
+++ b/pcons/core/flags.py
@@ -15,6 +15,7 @@ as a parameter, allowing toolchain-specific behavior.
 
 from __future__ import annotations
 
+from collections.abc import MutableSequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -172,7 +173,7 @@ def deduplicate_flags(
 
 
 def merge_flags(
-    existing: list[str],
+    existing: MutableSequence[str],
     new: Sequence[str | FlagPair],
     separated_arg_flags: frozenset[str] | None = None,
 ) -> None:

--- a/pcons/core/flags.py
+++ b/pcons/core/flags.py
@@ -23,6 +23,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator, Sequence
     from typing import Any
 
+    from pcons.core.subst import PathToken
+
 
 @dataclass(frozen=True)
 class FlagPair:
@@ -57,7 +59,7 @@ DEFAULT_SEPARATED_ARG_FLAGS: frozenset[str] = frozenset()
 
 
 def is_separated_arg_flag(
-    flag: str, separated_arg_flags: frozenset[str] | None = None
+    flag: str | PathToken, separated_arg_flags: frozenset[str] | None = None
 ) -> bool:
     """Check if a flag takes its argument as a separate token.
 
@@ -173,8 +175,8 @@ def deduplicate_flags(
 
 
 def merge_flags(
-    existing: MutableSequence[str],
-    new: Sequence[str | FlagPair],
+    existing: MutableSequence[str | PathToken],
+    new: Sequence[str | FlagPair | PathToken],
     separated_arg_flags: frozenset[str] | None = None,
 ) -> None:
     """Merge new flags into existing list, avoiding duplicates.
@@ -203,9 +205,9 @@ def merge_flags(
     if separated_arg_flags is None:
         separated_arg_flags = DEFAULT_SEPARATED_ARG_FLAGS
 
-    # Build a set of what's already in existing
-    # existing should only contain strings at this point
-    existing_items: set[str | tuple[str, str]] = set()
+    # Build a set of what's already in existing. Entries are normally strings
+    # (or flag/arg tuples), but a PathToken may appear as a complete token.
+    existing_items: set[Any] = set()
     i = 0
     while i < len(existing):
         flag = existing[i]

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -13,9 +13,9 @@ import re
 import sys
 import warnings
 from collections import UserList
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 if sys.version_info >= (3, 13):
     from warnings import deprecated
@@ -25,12 +25,17 @@ else:
         def decorator(func):
             @functools.wraps(func)
             def wrapper(*args, **kwargs):
-                warnings.warn(f"{func.__name__} is deprecated: {msg}", DeprecationWarning, stacklevel=2)
+                warnings.warn(
+                    f"{func.__name__} is deprecated: {msg}",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
                 return func(*args, **kwargs)
 
             return wrapper
 
         return decorator
+
 
 from pcons.core.flags import merge_flags
 
@@ -56,39 +61,35 @@ else:
 
 __all__ = ["SourceSpec", "UsageRequirements", "Target", "ImportedTarget"]
 
-ListLike: TypeAlias = list | UserList
+_T = TypeVar("_T")
+ListLike: TypeAlias = list[_T] | UserList[_T]
 
 
-class UniqueList(UserList):
-    def __init__(self, initlist: ListLike | None = None, owner: Target | None = None):
+class UniqueList(UserList[_T]):
+    def __init__(self, initlist: ListLike[_T] | None = None) -> None:
         super().__init__(initlist or [])
-        self.owner = owner
 
-    def append(self, item):
+    def append(self, item: _T):
         if item not in self.data:
             self.data.append(item)
-        return self.owner
 
-    def extend(self, other):
+    def extend(self, other: Iterable[_T]):
         for item in other:
             self.append(item)
-        return self.owner
 
 
-class ValidatedUniqueList(UniqueList):
+class ValidatedUniqueList(UniqueList[_T]):
     def __init__(
         self,
-        initlist: ListLike | None = None,
-        owner: Target | None = None,
-        validator: Callable[[Any], bool] | None = None,
-    ):
-        super().__init__(initlist, owner)
+        initlist: ListLike[_T] | None = None,
+        validator: Callable[[_T], bool] | None = None,
+    ) -> None:
+        super().__init__(initlist)
         self.validator = validator
 
-    def append(self, item):
+    def append(self, item: _T):
         if self.validator is None or self.validator(item):
-            return super().append(item)
-        return self.owner
+            super().append(item)
 
 
 class UsageRequirements(_UsageRequirementsStubs):
@@ -104,27 +105,21 @@ class UsageRequirements(_UsageRequirementsStubs):
     use any names they need (e.g., python_packages, data_schemas).
     """
 
-    # type hints
-    include_dirs: ListLike[str]
-    defines: ListLike[str]
-    compile_flags: ListLike[str]
-    link_flags: ListLike[str]
-    link_libs: ListLike[str | Target]
-    link_dirs: ListLike[str]
+    _data: dict[str, list[Any] | UserList[Any]]
 
-    _data: dict[str, ListLike]
-
-    def __init__(self, **kwargs: ListLike) -> None:
+    def __init__(self, **kwargs: list[Any] | UserList[Any]) -> None:
         object.__setattr__(self, "_data", {})
         for k, v in kwargs.items():
             self._data[k] = v
 
-    def __getattr__(self, name: str) -> ListLike:
+    def __getattr__(self, name: str) -> list[Any] | UserList[Any]:
         """Return the named list, creating it on first access."""
-        data: dict[str, ListLike] = object.__getattribute__(self, "_data")
+        data: dict[str, list[Any] | UserList[Any]] = object.__getattribute__(
+            self, "_data"
+        )
         return data.setdefault(name, [])
 
-    def __setattr__(self, name: str, value: ListLike) -> None:  # type: ignore[override]
+    def __setattr__(self, name: str, value: list[Any] | UserList[Any]) -> None:  # type: ignore[override]
         if name.startswith("_"):
             object.__setattr__(self, name, value)
         else:
@@ -171,7 +166,7 @@ class UsageRequirements(_UsageRequirementsStubs):
             result._data[k] = type(v)(v)
         return result
 
-    def items(self) -> list[tuple[str, ListLike]]:
+    def items(self) -> list[tuple[str, list[Any] | UserList[Any]]]:
         """Return all (name, list) pairs."""
         return list(self._data.items())
 
@@ -360,20 +355,20 @@ class Target:
         self._sources: list[Node] = []
         self._dependencies: list[Target] = []
         self.public = UsageRequirements()
-        self.public.defines = UniqueList([], owner=self)
-        self.public.include_dirs = UniqueList([], owner=self)
-        self.public.link_dirs = UniqueList([], owner=self)
+        self.public.defines = UniqueList([])  # type: ignore
+        self.public.include_dirs = UniqueList([])  # type: ignore
+        self.public.link_dirs = UniqueList([])
         self.public.link_flags = []
-        self.public.link_libs = ValidatedUniqueList(
-            [], validator=self.__link_libs_validator, owner=self
+        self.public.link_libs = ValidatedUniqueList(  # type: ignore
+            [], validator=self.__link_libs_validator
         )
         self.private = UsageRequirements()
-        self.private.defines = UniqueList([], owner=self)
-        self.private.include_dirs = UniqueList([], owner=self)
-        self.private.link_dirs = UniqueList([], owner=self)
+        self.private.defines = UniqueList([])  # type: ignore
+        self.private.include_dirs = UniqueList([])  # type: ignore
+        self.private.link_dirs = UniqueList([])
         self.private.link_flags = []
-        self.private.link_libs = ValidatedUniqueList(
-            [], validator=self.__link_libs_validator, owner=self
+        self.private.link_libs = ValidatedUniqueList(  # type: ignore
+            [], validator=self.__link_libs_validator
         )
         self.required_languages: set[str] = set()
         self.defined_at = defined_at or get_caller_location()

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -165,13 +165,6 @@ class UsageRequirements(_UsageRequirementsStubs):
                                If None, uses default (empty set).
         """
         for key, values in other._data.items():
-            if not isinstance(values, (list, UserList)):
-                raise TypeError(
-                    f"Usage requirement '{key}' must be a list, "
-                    f"got {type(values).__name__}. "
-                    f'Use target.public.{key} = ["{values}"] or '
-                    f'target.public.{key}.append("{values}").'
-                )
             # Reuse the source list's concrete type so dedup behaviour carries over.
             # A ValidatedUniqueList is rebuilt without its validator: the
             # validator is bound to the owning Target (self-link / post-resolve checks),

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -874,6 +874,11 @@ class Target:
                     _collect(dep)
                     result.append(dep)
 
+        # collect public libs of private link_libs
+        for t in self.private.link_libs:
+            if isinstance(t, Target):
+                _collect(t)
+
         _collect(self)
         return result
 

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -130,7 +130,15 @@ class UsageRequirements(_UsageRequirementsStubs):
                     f"Use target.public.{name}.append(value) to add items, "
                     f"or target.public.{name} = [value] to replace."
                 )
-            self._data[name] = value
+            existing = self._data.get(name)
+            if isinstance(existing, UserList):
+                # preserve behavior of existing list type (e.g., UniqueList, ValidatedUniqueList) on assignment,
+                # by clearing and extending it instead of replacing it.
+                # This allows users to replace an entire list while keeping dedup/validation behavior.
+                existing.clear()
+                existing.extend(value)
+            else:
+                self._data[name] = value
 
     def merge(
         self,

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -244,6 +244,19 @@ def is_qualified_name(name: str) -> bool:
     return project is not None
 
 
+def _make_default_requirements(
+    link_libs_validator: Callable[[Any], bool],
+) -> UsageRequirements:
+    """Create a default UsageRequirements with standard C/C++ fields."""
+    reqs = UsageRequirements()
+    reqs.defines = UniqueList([])
+    reqs.include_dirs = UniqueList([])
+    reqs.link_dirs = UniqueList([])
+    reqs.link_flags = []
+    reqs.link_libs = ValidatedUniqueList([], validator=link_libs_validator)
+    return reqs
+
+
 class Target:
     """A named build target with usage requirements.
 
@@ -354,22 +367,8 @@ class Target:
         self.builder = builder
         self._sources: list[Node] = []
         self._dependencies: list[Target] = []
-        self.public = UsageRequirements()
-        self.public.defines = UniqueList([])  # type: ignore
-        self.public.include_dirs = UniqueList([])  # type: ignore
-        self.public.link_dirs = UniqueList([])
-        self.public.link_flags = []
-        self.public.link_libs = ValidatedUniqueList(  # type: ignore
-            [], validator=self.__link_libs_validator
-        )
-        self.private = UsageRequirements()
-        self.private.defines = UniqueList([])  # type: ignore
-        self.private.include_dirs = UniqueList([])  # type: ignore
-        self.private.link_dirs = UniqueList([])
-        self.private.link_flags = []
-        self.private.link_libs = ValidatedUniqueList(  # type: ignore
-            [], validator=self.__link_libs_validator
-        )
+        self.public = _make_default_requirements(self.__link_libs_validator)
+        self.private = _make_default_requirements(self.__link_libs_validator)
         self.required_languages: set[str] = set()
         self.defined_at = defined_at or get_caller_location()
         self._collected_requirements: UsageRequirements | None = None

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -557,7 +557,7 @@ class Target:
         if self._resolved:
             raise RuntimeError(
                 f"Cannot modify target '{self.name}' after resolve(). "
-                f"Call link() before project.resolve() or project.generate()."
+                f"Add link_libs before project.resolve() or project.generate()."
             )
         for target in targets:
             if isinstance(target, (list, tuple)):
@@ -579,10 +579,27 @@ class Target:
         return self
 
     def add_dependency(self, *targets: Target) -> Target:
+        """Add Targets as build dependencies of this target.
+
+        Each becomes a full dependency: it is included in
+        ``transitive_dependencies()`` and ``dependencies``, so its public
+        usage requirements propagate here. Unlike ``link_libs``, this does not
+        treat the targets as libraries to link, use ``target.{public,private}
+        .link_libs`` for that. Duplicates are ignored.
+
+        Args:
+            *targets: Targets to depend on.
+
+        Returns:
+            self for method chaining.
+
+        Raises:
+            RuntimeError: If called after the target has been resolved.
+        """
         if self._resolved:
             raise RuntimeError(
                 f"Cannot modify target '{self.name}' after resolve(). "
-                f"Call link() before project.resolve() or project.generate()."
+                f"Add dependencies before project.resolve() or project.generate()."
             )
         for target in targets:
             if target not in self._dependencies:

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -7,13 +7,30 @@ and carries "usage requirements" that propagate to consumers (CMake-style).
 
 from __future__ import annotations
 
+import functools
 import logging
 import re
+import sys
+import warnings
 from collections import UserList
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias
-from warnings import deprecated
+
+if sys.version_info >= (3, 13):
+    from warnings import deprecated
+else:
+
+    def deprecated(msg: str):  # type: ignore[no-redef]
+        def decorator(func):
+            @functools.wraps(func)
+            def wrapper(*args, **kwargs):
+                warnings.warn(f"{func.__name__} is deprecated: {msg}", DeprecationWarning, stacklevel=2)
+                return func(*args, **kwargs)
+
+            return wrapper
+
+        return decorator
 
 from pcons.core.flags import merge_flags
 

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -228,7 +228,7 @@ class Target:
         "name",
         "builder",
         "_sources",
-        "dependencies",
+        "_dependencies",
         "public",
         "private",
         "required_languages",
@@ -297,7 +297,7 @@ class Target:
         self.name = name
         self.builder = builder
         self._sources: list[Node] = []
-        self.dependencies: list[Target] = []
+        self._dependencies: list[Target] = []
         self.public = UsageRequirements()
         self.private = UsageRequirements()
         self.required_languages: set[str] = set()
@@ -358,6 +358,17 @@ class Target:
             The qualified name, in the form "<project>::<target>".
         """
         return f"{self.project.name}::{self.name}"
+
+    @property
+    def dependencies(self):
+        """Get the list of Target dependencies for this target."""
+        linked_public_targets = [
+            t for t in self.public.link_libs if isinstance(t, Target)
+        ]
+        linked_private_targets = [
+            t for t in self.private.link_libs if isinstance(t, Target)
+        ]
+        return (*self._dependencies, *linked_public_targets, *linked_private_targets)
 
     @property
     def sources(self) -> list[Node]:
@@ -456,10 +467,24 @@ class Target:
                 )
             if target is self:
                 raise ValueError(f"Target '{self.name}' cannot link itself.")
-            if target not in self.dependencies:
-                self.dependencies.append(target)
+            if target not in self.public.link_libs:
+                self.public.link_libs.append(target)
         # Invalidate cached requirements
         self._collected_requirements = None
+        return self
+
+    def add_dependency(self, *targets: Target) -> Target:
+        if self._resolved:
+            raise RuntimeError(
+                f"Cannot modify target '{self.name}' after resolve(). "
+                f"Call link() before project.resolve() or project.generate()."
+            )
+        for target in targets:
+            if target not in self._dependencies:
+                self._dependencies.append(target)
+        # Invalidate cached requirements
+        self._collected_requirements = None
+
         return self
 
     def depends(
@@ -573,8 +598,8 @@ class Target:
                 self._pending_sources = []
             self._pending_sources.append(source)
             # Add as dependency to ensure correct build order
-            if source not in self.dependencies:
-                self.dependencies.append(source)
+            if source not in self._dependencies:
+                self._dependencies.append(source)
         else:
             node = self._to_node(source)
             self._sources.append(node)
@@ -630,8 +655,8 @@ class Target:
                     self._pending_sources = []
                 self._pending_sources.append(source)
                 # Add as dependency to ensure correct build order
-                if source not in self.dependencies:
-                    self.dependencies.append(source)
+                if source not in self._dependencies:
+                    self._dependencies.append(source)
             else:
                 if base_path and isinstance(source, (str, Path)):
                     path = Path(source)
@@ -739,7 +764,7 @@ class Target:
 
     def _collect_from_deps(self, result: UsageRequirements, visited: set[str]) -> None:
         """Recursively collect public requirements from dependencies."""
-        for dep in self.dependencies:
+        for dep in self.transitive_dependencies():
             if dep.name in visited:
                 continue
             visited.add(dep.name)
@@ -777,11 +802,16 @@ class Target:
         Returns:
             List of all transitive dependencies (not including self).
         """
-        result: list[Target] = []
+        result: list[Target] = [
+            t for t in self.private.link_libs if isinstance(t, Target)
+        ]
         visited: set[str] = set()
 
         def _collect(target: Target) -> None:
-            for dep in target.dependencies:
+            public_linked_targets = [
+                t for t in target.public.link_libs if isinstance(t, Target)
+            ]
+            for dep in [*target._dependencies, *public_linked_targets]:
                 if dep.name not in visited:
                     visited.add(dep.name)
                     _collect(dep)

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -260,9 +260,10 @@ def _make_default_requirements(
     """Create a default UsageRequirements with standard C/C++ fields."""
     reqs = UsageRequirements()
     reqs.defines = UniqueList([])
+    reqs.compile_flags = UniqueList([])
     reqs.include_dirs = UniqueList([])
     reqs.link_dirs = UniqueList([])
-    reqs.link_flags = []
+    reqs.link_flags = UniqueList([])
     reqs.link_libs = ValidatedUniqueList([], validator=link_libs_validator)
     return reqs
 

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -269,10 +269,14 @@ def _make_default_requirements(
     """Create a default UsageRequirements with standard C/C++ fields."""
     reqs = UsageRequirements()
     reqs.defines = UniqueList([])
-    reqs.compile_flags = UniqueList([])
     reqs.include_dirs = UniqueList([])
     reqs.link_dirs = UniqueList([])
-    reqs.link_flags = UniqueList([])
+    # compile_flags/link_flags are plain lists, NOT UniqueList: token-level
+    # dedup corrupts paired flags (-framework Foo -framework Bar, -Xlinker, -arch,
+    # repeated -L/-F). Flag dedup is pair-aware and happens via merge_flags() when
+    # usage requirements are merged. Direct appends are preserved verbatim.
+    reqs.compile_flags = []
+    reqs.link_flags = []
     reqs.link_libs = ValidatedUniqueList([], on_append=link_libs_validator)
     return reqs
 

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -82,14 +82,15 @@ class ValidatedUniqueList(UniqueList[_T]):
     def __init__(
         self,
         initlist: ListLike[_T] | None = None,
-        validator: Callable[[_T], bool] | None = None,
+        on_append: Callable[[_T], None] | None = None,
     ) -> None:
         super().__init__(initlist)
-        self.validator = validator
+        self._on_append = on_append
 
     def append(self, item: _T):
-        if self.validator is None or self.validator(item):
-            super().append(item)
+        if self._on_append is not None:
+            self._on_append(item)
+        super().append(item)
 
 
 class UsageRequirements(_UsageRequirementsStubs):
@@ -103,6 +104,13 @@ class UsageRequirements(_UsageRequirementsStubs):
     define its own requirement names. C/C++ toolchains use include_dirs,
     defines, compile_flags, link_flags, link_libs. Other toolchains can
     use any names they need (e.g., python_packages, data_schemas).
+
+    A field may use a special list type (``UniqueList`` dedup, or
+    ``ValidatedUniqueList`` whose ``on_append`` hook enforces invariants and
+    invalidates caches). Whole-list assignment preserves those semantics:
+    ``__setattr__`` replaces an existing list's *contents* in place (clear +
+    extend through ``append``), so ``reqs.link_libs = [a, b]`` behaves like
+    repeated ``.append()`` instead of swapping in a plain list.
     """
 
     _data: dict[str, list[Any] | UserList[Any]]
@@ -132,9 +140,9 @@ class UsageRequirements(_UsageRequirementsStubs):
                 )
             existing = self._data.get(name)
             if isinstance(existing, UserList):
-                # preserve behavior of existing list type (e.g., UniqueList, ValidatedUniqueList) on assignment,
-                # by clearing and extending it instead of replacing it.
-                # This allows users to replace an entire list while keeping dedup/validation behavior.
+                # Replace contents in place so the existing list type's
+                # behavior (UniqueList dedup, ValidatedUniqueList.on_append)
+                # is preserved across assignment.
                 existing.clear()
                 existing.extend(value)
             else:
@@ -263,7 +271,7 @@ def is_qualified_name(name: str) -> bool:
 
 
 def _make_default_requirements(
-    link_libs_validator: Callable[[Any], bool],
+    link_libs_validator: Callable[[Any], None],
 ) -> UsageRequirements:
     """Create a default UsageRequirements with standard C/C++ fields."""
     reqs = UsageRequirements()
@@ -272,7 +280,7 @@ def _make_default_requirements(
     reqs.include_dirs = UniqueList([])
     reqs.link_dirs = UniqueList([])
     reqs.link_flags = UniqueList([])
-    reqs.link_libs = ValidatedUniqueList([], validator=link_libs_validator)
+    reqs.link_libs = ValidatedUniqueList([], on_append=link_libs_validator)
     return reqs
 
 
@@ -520,14 +528,13 @@ class Target:
         """All build nodes for this target (intermediate + output)."""
         return self.intermediate_nodes + self.output_nodes
 
-    def __link_libs_validator(self, target: Target) -> bool:
+    def __link_libs_validator(self, target: Target):
         if self._resolved:
             raise RuntimeError(f"Cannot modify target '{self.name}' after resolve(). ")
         if target is self:
             raise ValueError(f"Target '{self.name}' cannot link itself.")
         # Invalidate cached requirements
         self._collected_requirements = None
-        return True
 
     @deprecated("Use target.{public,private}.link_libs instead")
     def link(self, *targets: Target) -> Target:

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -881,27 +881,26 @@ class Target:
         Returns:
             List of all transitive dependencies (not including self).
         """
-        result: list[Target] = [
-            t for t in self.private.link_libs if isinstance(t, Target)
-        ]
+        result: list[Target] = []
         visited: set[str] = set()
 
-        def _collect(target: Target) -> None:
-            public_linked_targets = [
-                t for t in target.public.link_libs if isinstance(t, Target)
-            ]
-            for dep in [*target._dependencies, *public_linked_targets]:
+        def direct_deps(target: Target, *, include_private: bool) -> list[Target]:
+            # A dependency's *private* link_libs do not propagate to consumers,
+            # so we only follow public ones when recursing.
+            deps = list(target._dependencies)
+            deps += [t for t in target.public.link_libs if isinstance(t, Target)]
+            if include_private:
+                deps += [t for t in target.private.link_libs if isinstance(t, Target)]
+            return deps
+
+        def _collect(target: Target, *, include_private: bool) -> None:
+            for dep in direct_deps(target, include_private=include_private):
                 if dep.name not in visited:
                     visited.add(dep.name)
-                    _collect(dep)
+                    _collect(dep, include_private=False)
                     result.append(dep)
 
-        # collect public libs of private link_libs
-        for t in self.private.link_libs:
-            if isinstance(t, Target):
-                _collect(t)
-
-        _collect(self)
+        _collect(self, include_private=True)
         return result
 
     def __str__(self) -> str:

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -43,30 +43,35 @@ ListLike: TypeAlias = list | UserList
 
 
 class UniqueList(UserList):
-    def __init__(self, initlist: ListLike | None = None):
+    def __init__(self, initlist: ListLike | None = None, owner: Target | None = None):
         super().__init__(initlist or [])
+        self.owner = owner
 
     def append(self, item):
         if item not in self.data:
             self.data.append(item)
+        return self.owner
 
     def extend(self, other):
         for item in other:
             self.append(item)
+        return self.owner
 
 
 class ValidatedUniqueList(UniqueList):
     def __init__(
         self,
         initlist: ListLike | None = None,
+        owner: Target | None = None,
         validator: Callable[[Any], bool] | None = None,
     ):
-        super().__init__(initlist or [])
+        super().__init__(initlist, owner)
         self.validator = validator
 
     def append(self, item):
         if self.validator is None or self.validator(item):
-            super().append(item)
+            return super().append(item)
+        return self.owner
 
 
 class UsageRequirements(_UsageRequirementsStubs):
@@ -338,17 +343,21 @@ class Target:
         self._sources: list[Node] = []
         self._dependencies: list[Target] = []
         self.public = UsageRequirements()
-        self.public.defines = UniqueList([])
-        self.public.include_dirs = UniqueList([])
-        self.public.link_dirs = UniqueList([])
+        self.public.defines = UniqueList([], owner=self)
+        self.public.include_dirs = UniqueList([], owner=self)
+        self.public.link_dirs = UniqueList([], owner=self)
         self.public.link_flags = []
-        self.public.link_libs = ValidatedUniqueList([], self.__link_libs_validator)
+        self.public.link_libs = ValidatedUniqueList(
+            [], validator=self.__link_libs_validator, owner=self
+        )
         self.private = UsageRequirements()
-        self.private.defines = UniqueList([])
-        self.private.include_dirs = UniqueList([])
-        self.private.link_dirs = UniqueList([])
+        self.private.defines = UniqueList([], owner=self)
+        self.private.include_dirs = UniqueList([], owner=self)
+        self.private.link_dirs = UniqueList([], owner=self)
         self.private.link_flags = []
-        self.private.link_libs = ValidatedUniqueList([], self.__link_libs_validator)
+        self.private.link_libs = ValidatedUniqueList(
+            [], validator=self.__link_libs_validator, owner=self
+        )
         self.required_languages: set[str] = set()
         self.defined_at = defined_at or get_caller_location()
         self._collected_requirements: UsageRequirements | None = None
@@ -486,6 +495,8 @@ class Target:
             raise RuntimeError(f"Cannot modify target '{self.name}' after resolve(). ")
         if target is self:
             raise ValueError(f"Target '{self.name}' cannot link itself.")
+        # Invalidate cached requirements
+        self._collected_requirements = None
         return True
 
     @deprecated("Use target.{public,private}.link_libs instead")

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -912,11 +912,20 @@ class Target:
 
         return languages
 
-    def transitive_dependencies(self) -> list[Target]:
+    def transitive_dependencies(self, *, for_link: bool = False) -> list[Target]:
         """Return all dependencies transitively (DFS, no duplicates).
 
         Returns dependencies in the order they are discovered via DFS,
         which means dependencies are listed before their dependents.
+
+        Args:
+            for_link: When True, collect link inputs rather than propagated
+                usage requirements. A static library does not link its own
+                dependencies in, so its *private* link_libs must still reach
+                the final link line.
+                This follows private link_libs through static-library targets.
+                Usage-requirement propagation (for_link=False) never follows
+                private deps.
 
         Returns:
             List of all transitive dependencies (not including self).
@@ -937,7 +946,11 @@ class Target:
             for dep in direct_deps(target, include_private=include_private):
                 if dep.name not in visited:
                     visited.add(dep.name)
-                    _collect(dep, include_private=False)
+                    # A static library's private link deps are not baked into the
+                    # archive, so they must follow through to the link line. Shared
+                    # libraries and other targets resolve their own private deps.
+                    recurse_private = for_link and dep.target_type == "static_library"
+                    _collect(dep, include_private=recurse_private)
                     result.append(dep)
 
         _collect(self, include_private=True)

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -9,9 +9,11 @@ from __future__ import annotations
 
 import logging
 import re
-from collections.abc import Sequence
+from collections import UserList
+from collections.abc import Callable, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypeAlias
+from warnings import deprecated
 
 from pcons.core.flags import merge_flags
 
@@ -37,6 +39,35 @@ else:
 
 __all__ = ["SourceSpec", "UsageRequirements", "Target", "ImportedTarget"]
 
+ListLike: TypeAlias = list | UserList
+
+
+class UniqueList(UserList):
+    def __init__(self, initlist: ListLike | None = None):
+        super().__init__(initlist or [])
+
+    def append(self, item):
+        if item not in self.data:
+            self.data.append(item)
+
+    def extend(self, other):
+        for item in other:
+            self.append(item)
+
+
+class ValidatedUniqueList(UniqueList):
+    def __init__(
+        self,
+        initlist: ListLike | None = None,
+        validator: Callable[[Any], bool] | None = None,
+    ):
+        super().__init__(initlist or [])
+        self.validator = validator
+
+    def append(self, item):
+        if self.validator is None or self.validator(item):
+            super().append(item)
+
 
 class UsageRequirements(_UsageRequirementsStubs):
     """Requirements that propagate from a target to its consumers.
@@ -51,23 +82,31 @@ class UsageRequirements(_UsageRequirementsStubs):
     use any names they need (e.g., python_packages, data_schemas).
     """
 
-    _data: dict[str, list]
+    # type hints
+    include_dirs: ListLike[str]
+    defines: ListLike[str]
+    compile_flags: ListLike[str]
+    link_flags: ListLike[str]
+    link_libs: ListLike[str | Target]
+    link_dirs: ListLike[str]
 
-    def __init__(self, **kwargs: list) -> None:
+    _data: dict[str, ListLike]
+
+    def __init__(self, **kwargs: ListLike) -> None:
         object.__setattr__(self, "_data", {})
         for k, v in kwargs.items():
-            self._data[k] = list(v)
+            self._data[k] = v
 
-    def __getattr__(self, name: str) -> list:
+    def __getattr__(self, name: str) -> ListLike:
         """Return the named list, creating it on first access."""
-        data: dict[str, list] = object.__getattribute__(self, "_data")
+        data: dict[str, ListLike] = object.__getattribute__(self, "_data")
         return data.setdefault(name, [])
 
-    def __setattr__(self, name: str, value: list) -> None:  # type: ignore[override]
+    def __setattr__(self, name: str, value: ListLike) -> None:  # type: ignore[override]
         if name.startswith("_"):
             object.__setattr__(self, name, value)
         else:
-            if not isinstance(value, list):
+            if not isinstance(value, (list, UserList)):
                 raise TypeError(
                     f"Usage requirement '{name}' must be a list, "
                     f"got {type(value).__name__}. "
@@ -93,24 +132,24 @@ class UsageRequirements(_UsageRequirementsStubs):
                                If None, uses default (empty set).
         """
         for key, values in other._data.items():
-            if not isinstance(values, list):
+            if not isinstance(values, (list, UserList)):
                 raise TypeError(
                     f"Usage requirement '{key}' must be a list, "
                     f"got {type(values).__name__}. "
                     f'Use target.public.{key} = ["{values}"] or '
                     f'target.public.{key}.append("{values}").'
                 )
-            mine = self._data.setdefault(key, [])
+            mine = self._data.setdefault(key, type(values)())
             merge_flags(mine, values, separated_arg_flags)
 
     def clone(self) -> UsageRequirements:
         """Create a copy of this UsageRequirements."""
         result = UsageRequirements()
         for k, v in self._data.items():
-            result._data[k] = list(v)
+            result._data[k] = type(v)(v)
         return result
 
-    def items(self) -> list[tuple[str, list]]:
+    def items(self) -> list[tuple[str, ListLike]]:
         """Return all (name, list) pairs."""
         return list(self._data.items())
 
@@ -299,7 +338,17 @@ class Target:
         self._sources: list[Node] = []
         self._dependencies: list[Target] = []
         self.public = UsageRequirements()
+        self.public.defines = UniqueList([])
+        self.public.include_dirs = UniqueList([])
+        self.public.link_dirs = UniqueList([])
+        self.public.link_flags = []
+        self.public.link_libs = ValidatedUniqueList([], self.__link_libs_validator)
         self.private = UsageRequirements()
+        self.private.defines = UniqueList([])
+        self.private.include_dirs = UniqueList([])
+        self.private.link_dirs = UniqueList([])
+        self.private.link_flags = []
+        self.private.link_libs = ValidatedUniqueList([], self.__link_libs_validator)
         self.required_languages: set[str] = set()
         self.defined_at = defined_at or get_caller_location()
         self._collected_requirements: UsageRequirements | None = None
@@ -432,6 +481,14 @@ class Target:
         """All build nodes for this target (intermediate + output)."""
         return self.intermediate_nodes + self.output_nodes
 
+    def __link_libs_validator(self, target: Target) -> bool:
+        if self._resolved:
+            raise RuntimeError(f"Cannot modify target '{self.name}' after resolve(). ")
+        if target is self:
+            raise ValueError(f"Target '{self.name}' cannot link itself.")
+        return True
+
+    @deprecated("Use target.{public,private}.link_libs instead")
     def link(self, *targets: Target) -> Target:
         """Add targets as dependencies (fluent API).
 

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -156,11 +156,21 @@ class UsageRequirements(_UsageRequirementsStubs):
                     f'Use target.public.{key} = ["{values}"] or '
                     f'target.public.{key}.append("{values}").'
                 )
+            # Reuse the source list's concrete type so dedup behaviour carries over.
+            # A ValidatedUniqueList is rebuilt without its validator: the
+            # validator is bound to the owning Target (self-link / post-resolve checks),
+            # and merge() only targets a detached snapshot, so it has nothing to guard.
             mine = self._data.setdefault(key, type(values)())
             merge_flags(mine, values, separated_arg_flags)
 
     def clone(self) -> UsageRequirements:
-        """Create a copy of this UsageRequirements."""
+        """Create a copy of this UsageRequirements.
+
+        Each list keeps its concrete type (so dedup behaviour is preserved), but
+        a ValidatedUniqueList is rebuilt without its validator. That validator is
+        bound to the owning Target. A clone is a detached snapshot that is read,
+        not user-mutated, so the owner-specific guard does not apply to it.
+        """
         result = UsageRequirements()
         for k, v in self._data.items():
             result._data[k] = type(v)(v)

--- a/pcons/core/types.py
+++ b/pcons/core/types.py
@@ -137,7 +137,7 @@ class TargetLike(Protocol):
         """Add targets as dependencies."""
         ...
 
-    def transitive_dependencies(self) -> list[Any]:
+    def transitive_dependencies(self, *, for_link: bool = False) -> list[Any]:
         """Return all dependencies transitively."""
         ...
 

--- a/pcons/generators/compile_commands.py
+++ b/pcons/generators/compile_commands.py
@@ -254,6 +254,8 @@ class CompileCommandsGenerator(BaseGenerator):
                     parts.append(f"{context.include_prefix}{inc}")
                 for define in context.defines:
                     parts.append(f"{context.define_prefix}{define}")
+                # PathToken flags fall back to their plain string form; the
+                # compile_commands generator does not relativize like ninja.
                 parts.extend(str(f) for f in context.flags)
 
         parts.extend(["-o", str(output.path), str(source.path)])

--- a/pcons/generators/compile_commands.py
+++ b/pcons/generators/compile_commands.py
@@ -254,7 +254,7 @@ class CompileCommandsGenerator(BaseGenerator):
                     parts.append(f"{context.include_prefix}{inc}")
                 for define in context.defines:
                     parts.append(f"{context.define_prefix}{define}")
-                parts.extend(context.flags)
+                parts.extend(str(f) for f in context.flags)
 
         parts.extend(["-o", str(output.path), str(source.path)])
 

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -946,16 +946,22 @@ class XcodeGenerator(BaseGenerator):
                 target_name=target.name,
             )
 
+        from pcons.core.target import Target
+
         # Collect link flags
         ldflags: list[str] = []
         ldflags.extend(str(f) for f in target.public.link_flags)
         ldflags.extend(str(f) for f in target.private.link_flags)
 
-        # Add link libraries as -l flags
+        # Add link libraries as -l flags.Target instances (library deps) are
+        # handled separately via the frameworks link phase / dependency graph,
+        # so only string/system libs become -l flags here.
         for lib in target.public.link_libs:
-            ldflags.append(f"-l{lib}")
+            if not isinstance(lib, Target):
+                ldflags.append(f"-l{lib}")
         for lib in target.private.link_libs:
-            ldflags.append(f"-l{lib}")
+            if not isinstance(lib, Target):
+                ldflags.append(f"-l{lib}")
 
         if ldflags:
             self._xcode_project.set_flags(

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -918,8 +918,8 @@ class XcodeGenerator(BaseGenerator):
 
         # Collect compiler flags
         cflags: list[str] = []
-        cflags.extend(target.public.compile_flags)
-        cflags.extend(target.private.compile_flags)
+        cflags.extend(str(f) for f in target.public.compile_flags)
+        cflags.extend(str(f) for f in target.private.compile_flags)
 
         # Get flags from environment if available
         if env is not None:
@@ -946,8 +946,8 @@ class XcodeGenerator(BaseGenerator):
 
         # Collect link flags
         ldflags: list[str] = []
-        ldflags.extend(target.public.link_flags)
-        ldflags.extend(target.private.link_flags)
+        ldflags.extend(str(f) for f in target.public.link_flags)
+        ldflags.extend(str(f) for f in target.private.link_flags)
 
         # Add link libraries as -l flags
         for lib in target.public.link_libs:

--- a/pcons/generators/xcode.py
+++ b/pcons/generators/xcode.py
@@ -918,6 +918,8 @@ class XcodeGenerator(BaseGenerator):
 
         # Collect compiler flags
         cflags: list[str] = []
+        # PathToken flags fall back to their plain string form here; the Xcode
+        # generator does not do $topdir-style relativization (unlike ninja).
         cflags.extend(str(f) for f in target.public.compile_flags)
         cflags.extend(str(f) for f in target.private.compile_flags)
 

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -268,10 +268,12 @@ class MsvcCompileLinkContext(CompileLinkContext):
             # MSVC uses full library names (kernel32.lib, not -lkernel32)
             formatted_libs = []
             for lib in self.libs:
-                if lib.endswith(".lib"):
+                if isinstance(lib, str) and lib.endswith(".lib"):
                     formatted_libs.append(lib)
-                else:
+                elif isinstance(lib, str):
                     formatted_libs.append(f"{lib}.lib")
+                else:
+                    formatted_libs.append(lib)
             result["libs"] = formatted_libs
         if self.link_flags:
             # Merge with base flags from env.link.flags (same as base class)
@@ -323,7 +325,7 @@ class MsvcCompileLinkContext(CompileLinkContext):
             defines=list(effective.defines),
             flags=list(effective.compile_flags),
             link_flags=list(effective.link_flags),
-            libs=list(effective.link_libs),
+            libs=[lib for lib in effective.link_libs if not isinstance(lib, Target)],
             libdirs=[str(p) for p in effective.link_dirs],
             linker_cmd=None,
             mode=mode,

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -207,12 +207,16 @@ class CompileLinkContext:
                     if flag not in link_flags:
                         link_flags.append(flag)
 
+        from pcons.core.target import Target
+
         return cls(
             includes=[str(p) for p in effective.includes],
             defines=list(effective.defines),
             flags=list(effective.compile_flags),
             link_flags=link_flags,
-            libs=list(effective.link_libs),
+            # link_libs now can contain both Target instances and strings.
+            # just filter out Target instances, they are handled somewhere else
+            libs=[lib for lib in effective.link_libs if not isinstance(lib, Target)],
             libdirs=[str(p) for p in effective.link_dirs],
             linker_cmd=linker_cmd,
             mode=mode,

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
+    from pcons.core.subst import PathToken
     from pcons.core.target import Target
     from pcons.tools.requirements import EffectiveRequirements
 
@@ -54,8 +55,8 @@ class CompileLinkContext:
 
     includes: list[str] = field(default_factory=list)
     defines: list[str] = field(default_factory=list)
-    flags: list[str] = field(default_factory=list)
-    link_flags: list[str] = field(default_factory=list)
+    flags: list[str | PathToken] = field(default_factory=list)
+    link_flags: list[str | PathToken] = field(default_factory=list)
     libs: list[str] = field(default_factory=list)
     libdirs: list[str] = field(default_factory=list)
     linker_cmd: str | None = None  # Override for link.cmd (e.g., "clang++" for C++)

--- a/pcons/toolchains/unix.py
+++ b/pcons/toolchains/unix.py
@@ -20,7 +20,10 @@ from pcons.core.subst import TargetPath
 from pcons.tools.toolchain import BaseToolchain
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from pcons.core.environment import Environment
+    from pcons.core.subst import PathToken
     from pcons.core.target import Target
     from pcons.tools.toolchain import SourceHandler
 
@@ -190,7 +193,7 @@ class UnixToolchain(BaseToolchain):
         self,
         target: Target,
         output_name: str,
-        existing_flags: list[str],
+        existing_flags: Sequence[str | PathToken],
     ) -> list[str]:
         """Return install_name (macOS) or SONAME (Linux) for shared libraries.
 

--- a/pcons/tools/compile_link.py
+++ b/pcons/tools/compile_link.py
@@ -615,7 +615,7 @@ class CompileLinkFactory:
         import sys
 
         result: list[FileNode] = []
-        for dep in target.transitive_dependencies():
+        for dep in target.transitive_dependencies(for_link=True):
             for node in dep.output_nodes:
                 if sys.platform == "win32" and dep.target_type == "shared_library":
                     build_info = getattr(node, "_build_info", {})

--- a/pcons/tools/compile_link.py
+++ b/pcons/tools/compile_link.py
@@ -611,11 +611,15 @@ class CompileLinkFactory:
 
         For SharedLibrary dependencies on Windows, returns the import library
         (.lib) instead of the DLL (.dll) since that's what the linker needs.
+
+        transitive_dependencies() lists dependencies before dependents. Static
+        linkers (GNU ld) resolve symbols left-to-right and need the reverse:
+        a library must precede the libraries it depends on, so we reverse here.
         """
         import sys
 
         result: list[FileNode] = []
-        for dep in target.transitive_dependencies(for_link=True):
+        for dep in reversed(target.transitive_dependencies(for_link=True)):
             for node in dep.output_nodes:
                 if sys.platform == "win32" and dep.target_type == "shared_library":
                     build_info = getattr(node, "_build_info", {})

--- a/pcons/tools/requirements.py
+++ b/pcons/tools/requirements.py
@@ -16,11 +16,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pcons.core.flags import get_separated_arg_flags_from_toolchains, merge_flags
-from pcons.core.target import Target
 
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
-    from pcons.core.target import UsageRequirements
+    from pcons.core.subst import PathToken
+    from pcons.core.target import Target, UsageRequirements
 
 logger = logging.getLogger(__name__)
 
@@ -48,8 +48,8 @@ class EffectiveRequirements:
 
     includes: list[Path] = field(default_factory=list)
     defines: list[str] = field(default_factory=list)
-    compile_flags: list[str] = field(default_factory=list)
-    link_flags: list[str] = field(default_factory=list)
+    compile_flags: list[str | PathToken] = field(default_factory=list)
+    link_flags: list[str | PathToken] = field(default_factory=list)
     link_libs: list[str | Target] = field(default_factory=list)
     link_dirs: list[Path] = field(default_factory=list)
     separated_arg_flags: frozenset[str] = field(default_factory=frozenset)
@@ -72,17 +72,11 @@ class EffectiveRequirements:
             if define not in self.defines:
                 self.defines.append(define)
         # Use flag-aware merge for compile and link flags
-        merge_flags(
-            self.compile_flags,
-            [str(f) for f in reqs.compile_flags],
-            self.separated_arg_flags,
-        )
-        merge_flags(
-            self.link_flags, [str(f) for f in reqs.link_flags], self.separated_arg_flags
-        )
+        merge_flags(self.compile_flags, reqs.compile_flags, self.separated_arg_flags)
+        merge_flags(self.link_flags, reqs.link_flags, self.separated_arg_flags)
         for lib in reqs.link_libs:
             if lib not in self.link_libs:
-                self.link_libs.append(str(lib) if not isinstance(lib, Target) else lib)
+                self.link_libs.append(lib)
         for lib_dir in reqs.link_dirs:
             dir_path = Path(lib_dir) if isinstance(lib_dir, str) else lib_dir
             if dir_path not in self.link_dirs:

--- a/pcons/tools/requirements.py
+++ b/pcons/tools/requirements.py
@@ -16,10 +16,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pcons.core.flags import get_separated_arg_flags_from_toolchains, merge_flags
+from pcons.core.target import Target
 
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
-    from pcons.core.target import Target, UsageRequirements
+    from pcons.core.target import UsageRequirements
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,7 @@ class EffectiveRequirements:
     defines: list[str] = field(default_factory=list)
     compile_flags: list[str] = field(default_factory=list)
     link_flags: list[str] = field(default_factory=list)
-    link_libs: list[str] = field(default_factory=list)
+    link_libs: list[str | Target] = field(default_factory=list)
     link_dirs: list[Path] = field(default_factory=list)
     separated_arg_flags: frozenset[str] = field(default_factory=frozenset)
 
@@ -71,11 +72,17 @@ class EffectiveRequirements:
             if define not in self.defines:
                 self.defines.append(define)
         # Use flag-aware merge for compile and link flags
-        merge_flags(self.compile_flags, reqs.compile_flags, self.separated_arg_flags)
-        merge_flags(self.link_flags, reqs.link_flags, self.separated_arg_flags)
+        merge_flags(
+            self.compile_flags,
+            [str(f) for f in reqs.compile_flags],
+            self.separated_arg_flags,
+        )
+        merge_flags(
+            self.link_flags, [str(f) for f in reqs.link_flags], self.separated_arg_flags
+        )
         for lib in reqs.link_libs:
             if lib not in self.link_libs:
-                self.link_libs.append(lib)
+                self.link_libs.append(str(lib) if not isinstance(lib, Target) else lib)
         for lib_dir in reqs.link_dirs:
             dir_path = Path(lib_dir) if isinstance(lib_dir, str) else lib_dir
             if dir_path not in self.link_dirs:

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -473,7 +473,7 @@ class Toolchain(Protocol):
         self,
         target: Target,
         output_name: str,
-        existing_flags: list[str],
+        existing_flags: Sequence[str | PathToken],
     ) -> list[str]:
         """Return additional link flags for a specific target.
 

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import shutil
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
@@ -17,6 +17,7 @@ from pcons.core.subst import TargetPath
 
 if TYPE_CHECKING:
     from pcons.core.environment import Environment
+    from pcons.core.subst import PathToken
     from pcons.core.target import Target
     from pcons.tools.tool import BaseTool, Tool
 
@@ -996,7 +997,7 @@ class BaseToolchain(ABC):
         self,
         target: Target,
         output_name: str,
-        existing_flags: list[str],
+        existing_flags: Sequence[str | PathToken],
     ) -> list[str]:
         """Return additional link flags for a specific target.
 

--- a/tests/core/test_build_context.py
+++ b/tests/core/test_build_context.py
@@ -142,6 +142,33 @@ class TestCompileLinkContext:
             assert flags.count("-fsanitize=address") == 1
             assert "-pthread" in flags
 
+    def test_toolchain_injected_flag_deduplicated(self) -> None:
+        """Toolchain-injected link flags already present are not duplicated."""
+        from pcons.tools.requirements import EffectiveRequirements
+
+        class _StubToolchain:
+            def get_link_flags_for_target(self, target, output_name, existing_flags):
+                # "-Wl,-soname,libfoo.so" duplicates an existing flag; "-Wl,-z" is new.
+                return ["-Wl,-soname,libfoo.so", "-Wl,-z"]
+
+        class _StubEnv:
+            _toolchain = _StubToolchain()
+
+            def has_tool(self, name: str) -> bool:
+                return False
+
+        effective = EffectiveRequirements(link_flags=["-Wl,-soname,libfoo.so"])
+        ctx = CompileLinkContext.from_effective_requirements(
+            effective,
+            mode="link",
+            env=_StubEnv(),  # type: ignore[arg-type]
+            target=object(),  # type: ignore[arg-type]
+            output_name="libfoo.so",
+        )
+
+        assert ctx.link_flags.count("-Wl,-soname,libfoo.so") == 1
+        assert "-Wl,-z" in ctx.link_flags
+
     def test_compile_overrides_merge_with_env_flags(self) -> None:
         """Verify compile flags are merged with env.{tool}.flags.
 
@@ -274,6 +301,25 @@ class TestMsvcCompileLinkContext:
 
         # MSVC adds .lib suffix if missing
         assert overrides["libs"] == ["kernel32.lib", "user32.lib"]
+
+    def test_msvc_link_overrides_passes_through_non_string_libs(self) -> None:
+        """Non-string libs (e.g. PathToken) are passed through unchanged.
+
+        Only plain string lib names get the .lib suffix logic,
+        other token types must be forwarded as-is.
+        """
+        from pcons.core.subst import PathToken
+
+        token = PathToken(prefix="", path="vendor/foo.lib", path_type="project")
+        ctx = MsvcCompileLinkContext(
+            libs=["kernel32", token],
+            mode="link",
+        )
+        overrides = ctx.get_env_overrides()
+
+        libs = overrides["libs"]
+        assert "kernel32.lib" in libs  # string gets .lib suffix
+        assert token in libs  # token forwarded unchanged
 
     def test_msvc_link_overrides_merge_with_env_link_flags(self) -> None:
         """Verify MSVC link_flags are merged with env.link.flags.

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -29,9 +29,9 @@ class TestTopologicalSortTargets:
         # A depends on B depends on C
         c = Target("C")
         b = Target("B")
-        b.link(c)
+        b.private.link_libs.append(c)
         a = Target("A")
-        a.link(b)
+        a.private.link_libs.append(b)
 
         result = topological_sort_targets([a, b, c])
 
@@ -43,12 +43,12 @@ class TestTopologicalSortTargets:
         # A depends on B and C, both depend on D
         d = Target("D")
         b = Target("B")
-        b.link(d)
+        b.private.link_libs.append(d)
         c = Target("C")
-        c.link(d)
+        c.private.link_libs.append(d)
         a = Target("A")
-        a.link(b)
-        a.link(c)
+        a.private.link_libs.append(b)
+        a.private.link_libs.append(c)
 
         result = topological_sort_targets([a, b, c, d])
 
@@ -61,8 +61,8 @@ class TestTopologicalSortTargets:
     def test_cycle_raises_error(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
-        a.link(b)
-        b.link(a)
+        a.private.link_libs.append(b)
+        b.private.link_libs.append(a)
 
         with pytest.raises(DependencyCycleError):
             topological_sort_targets([a, b])
@@ -72,7 +72,7 @@ class TestDetectCycles:
     def test_no_cycle(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
-        a.link(b)
+        a.private.link_libs.append(b)
 
         cycles = detect_cycles_in_targets([a, b])
         assert cycles == []
@@ -80,8 +80,8 @@ class TestDetectCycles:
     def test_simple_cycle(self, test_project):  # noqa: F811
         a = Target("A")
         b = Target("B")
-        a.link(b)
-        b.link(a)
+        a.private.link_libs.append(b)
+        b.private.link_libs.append(a)
 
         cycles = detect_cycles_in_targets([a, b])
         assert len(cycles) == 1
@@ -92,19 +92,19 @@ class TestDetectCycles:
         a = Target("A")
         # Self-link is now caught early by link() validation
         with pytest.raises(ValueError, match="cannot link itself"):
-            a.link(a)
+            a.private.link_libs.append(a)
 
     def test_multiple_cycles(self, test_project):  # noqa: F811
         # Two separate cycles: A<->B and C<->D
         a = Target("A")
         b = Target("B")
-        a.link(b)
-        b.link(a)
+        a.private.link_libs.append(b)
+        b.private.link_libs.append(a)
 
         c = Target("C")
         d = Target("D")
-        c.link(d)
-        d.link(c)
+        c.private.link_libs.append(d)
+        d.private.link_libs.append(c)
 
         cycles = detect_cycles_in_targets([a, b, c, d])
         assert len(cycles) == 2
@@ -168,7 +168,7 @@ class TestCollectAllNodes:
         app_out = FileNode("app")
         app.add_source(app_src)
         app.output_nodes.append(app_out)
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         nodes = collect_all_nodes([app])
 
@@ -187,7 +187,7 @@ class TestCollectBuildOrder:
     def test_with_dependencies(self, test_project):  # noqa: F811
         lib = Target("lib")
         app = Target("app")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         order = collect_build_order(app)
 
@@ -196,12 +196,12 @@ class TestCollectBuildOrder:
     def test_diamond_dependency(self, test_project):  # noqa: F811
         base = Target("base")
         left = Target("left")
-        left.link(base)
+        left.private.link_libs.append(base)
         right = Target("right")
-        right.link(base)
+        right.private.link_libs.append(base)
         top = Target("top")
-        top.link(left)
-        top.link(right)
+        top.private.link_libs.append(left)
+        top.private.link_libs.append(right)
 
         order = collect_build_order(top)
 

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -291,8 +291,8 @@ class TestProjectValidation:
         project = Project("myproject")
         a = Target("A")
         b = Target("B")
-        a.link(b)
-        b.link(a)
+        a.private.link_libs.append(b)
+        b.private.link_libs.append(a)
 
         errors = project.validate()
         assert len(errors) > 0
@@ -304,7 +304,7 @@ class TestProjectBuildOrder:
         project = Project("myproject")
         lib = Target("lib")
         app = Target("app")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         order = project.build_order()
 
@@ -322,7 +322,7 @@ class TestProjectAllNodes:
         app = Target("app")
         app.add_source(FileNode("main.c"))
         app.output_nodes.append(FileNode("app"))
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         nodes = project.all_nodes()
 
@@ -424,7 +424,7 @@ class TestGeneratePcFile:
         zlib = ImportedTarget.from_package(pkg)
 
         target = Target("mylib")
-        target.link(zlib)
+        target.private.link_libs.append(zlib)
 
         pc = project.generate_pc_file(target, version="1.0")
         content = pc.read_text()

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -204,7 +204,7 @@ class TestComputeEffectiveRequirements:
         libB = Target("libB", target_type="static_library")
         libB._env = env
         libB.public.include_dirs.append(Path("libB/include"))
-        libB.link(libA)
+        libB.public.link_libs.append(libA)
 
         target = Target("app", target_type="program")
         target._env = env

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -183,7 +183,7 @@ class TestComputeEffectiveRequirements:
         # Create the target that depends on it
         target = Target("mylib", target_type="static_library")
         target._env = env
-        target.link(dep)
+        target.private.link_libs.append(dep)
 
         effective = compute_effective_requirements(target, env)
 
@@ -208,7 +208,7 @@ class TestComputeEffectiveRequirements:
 
         target = Target("app", target_type="program")
         target._env = env
-        target.link(libB)
+        target.private.link_libs.append(libB)
 
         effective = compute_effective_requirements(target, env)
 
@@ -231,7 +231,7 @@ class TestComputeEffectiveRequirements:
         # Create the target that depends on it
         target = Target("app", target_type="program")
         target._env = env
-        target.link(dep)
+        target.private.link_libs.append(dep)
 
         effective = compute_effective_requirements(target, env)
 

--- a/tests/core/test_requirements.py
+++ b/tests/core/test_requirements.py
@@ -85,6 +85,30 @@ class TestEffectiveRequirementsMerge:
 
         assert eff.includes == [Path("inc1"), Path("inc2"), Path("inc3")]
 
+    def test_merge_preserves_pathtoken_in_flags(self):
+        """PathToken flags must survive merge as objects, not be stringified."""
+        from pcons.core.subst import PathToken
+
+        compile_tok = PathToken(prefix="-I", path="src/inc", path_type="project")
+        link_tok = PathToken(
+            prefix="-Wl,-force_load,", path="libs/libfoo.a", path_type="project"
+        )
+        eff = EffectiveRequirements()
+        usage = UsageRequirements(
+            compile_flags=[compile_tok],
+            link_flags=[link_tok],
+        )
+        eff.merge(usage)
+
+        # The exact PathToken object is preserved (not a stringified copy).
+        assert compile_tok in eff.compile_flags
+        assert link_tok in eff.link_flags
+        # And relativization still works on the preserved token.
+        assert (
+            link_tok.relativize(lambda p: f"$topdir/{p}")
+            == "-Wl,-force_load,$topdir/libs/libfoo.a"
+        )
+
 
 class TestEffectiveRequirementsHashable:
     def test_as_hashable_tuple(self):

--- a/tests/core/test_resolver.py
+++ b/tests/core/test_resolver.py
@@ -139,7 +139,7 @@ class TestResolverTransitiveRequirements:
 
         # Create app that links to library
         app = project.Program("myapp", env, sources=[str(app_src)])
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         project.resolve()
 
@@ -170,7 +170,7 @@ class TestResolverHeaderOnlyLibrary:
 
         # Create app that uses header-only library
         app = project.Program("myapp", env, sources=[str(src_file)])
-        app.link(header_lib)
+        app.private.link_libs.append(header_lib)
 
         project.resolve()
 
@@ -1173,7 +1173,7 @@ class TestResolverCxxLinker:
         imported = ImportedTarget.from_package(pkg)
 
         lib = project.StaticLibrary("mylib", env, sources=[str(src_file)])
-        lib.link(imported)
+        lib.public.link_libs.append(imported)
         project.resolve()
 
         assert lib._resolved

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -36,6 +36,21 @@ class TestUsageRequirements:
         assert req.link_libs == ["foo"]
         assert req.defines == ["DEBUG"]
 
+    def test_items_returns_all_pairs(self):
+        req = UsageRequirements(
+            include_dirs=[Path("include")],
+            defines=["DEBUG"],
+        )
+
+        items = dict(req.items())
+
+        # items() exposes each populated requirement list keyed by name.
+        assert items["include_dirs"] == [Path("include")]
+        assert items["defines"] == ["DEBUG"]
+        # The return value is a list of (name, list) tuples.
+        assert isinstance(req.items(), list)
+        assert all(isinstance(pair, tuple) and len(pair) == 2 for pair in req.items())
+
     def test_merge(self):
         req1 = UsageRequirements(
             include_dirs=[Path("inc1")],
@@ -106,14 +121,15 @@ class TestUsageRequirements:
         with pytest.raises(ValueError, match="bad item not allowed"):
             req.link_libs = ["good", "bad", "ok"]
 
-    def test_assignment_replaces_contents(self):
-        """Reassignment replaces the old contents rather than appending."""
+    def test_protected_assignment_bypasses(self):
+        """Protected assignment (`req._some_protected_stuff`) bypasses the rules."""
         req = UsageRequirements()
-        req.defines = UniqueList(["OLD"])
+        req._some_protected_stuff = UniqueList(["OLD"])
 
-        req.defines = ["NEW"]
+        req._some_protected_stuff = ["NEW"]
 
-        assert req.defines == ["NEW"]
+        assert req._some_protected_stuff == ["NEW"]
+        assert isinstance(req._some_protected_stuff, list)
 
     def test_assignment_to_plain_list_replaces_object(self):
         """When the existing value is a plain list, assignment replaces it."""
@@ -353,6 +369,18 @@ class TestFluentAPI:
 
         assert result is app
         assert lib in app.dependencies
+
+    def test_link_avoids_duplicates(self, test_project):  # noqa: F811
+        """link() does not add the same target to public.link_libs twice."""
+        lib = Target("lib")
+        app = Target("app")
+
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            app.link(lib)
+            app.link(lib)  # same lib again — must be ignored
+
+        assert app.public.link_libs.count(lib) == 1
 
     def test_add_source_returns_self(self, tmp_path, test_project):  # noqa: F811
         """add_source() returns self for chaining."""
@@ -626,6 +654,93 @@ class TestTargetDepends:
         dep = target._extra_implicit_deps[0]
         # project.node() canonicalizes the path
         assert dep is project.node("tools/codegen.py")
+
+
+class TestTargetAddDependency:
+    """Tests for target.add_dependency()."""
+
+    def test_adds_single_dependency(self, test_project):  # noqa: F811
+        """add_dependency() records the target as a build dependency."""
+        app = Target("app")
+        lib = Target("lib")
+
+        app.add_dependency(lib)
+
+        assert lib in app._dependencies
+        assert lib in app.dependencies
+
+    def test_returns_self_for_chaining(self, test_project):  # noqa: F811
+        """add_dependency() returns self for fluent chaining."""
+        app = Target("app")
+        a = Target("a")
+        b = Target("b")
+
+        result = app.add_dependency(a).add_dependency(b)
+
+        assert result is app
+        assert app._dependencies == [a, b]
+
+    def test_adds_multiple_in_one_call(self, test_project):  # noqa: F811
+        """add_dependency() accepts several targets at once."""
+        app = Target("app")
+        a = Target("a")
+        b = Target("b")
+
+        app.add_dependency(a, b)
+
+        assert app._dependencies == [a, b]
+
+    def test_ignores_duplicates(self, test_project):  # noqa: F811
+        """add_dependency() ignores already-present targets."""
+        app = Target("app")
+        lib = Target("lib")
+
+        app.add_dependency(lib)
+        app.add_dependency(lib, lib)
+
+        assert app._dependencies.count(lib) == 1
+
+    def test_not_treated_as_link_lib(self, test_project):  # noqa: F811
+        """add_dependency() does not add the target as a library to link."""
+        app = Target("app")
+        lib = Target("lib")
+
+        app.add_dependency(lib)
+
+        assert lib not in app.public.link_libs
+        assert lib not in app.private.link_libs
+
+    def test_propagates_to_transitive_dependencies(self, test_project):  # noqa: F811
+        """Dependencies added via add_dependency() are transitively collected."""
+        app = Target("app")
+        lib = Target("lib")
+        sublib = Target("sublib")
+
+        lib.add_dependency(sublib)
+        app.add_dependency(lib)
+
+        transitive = app.transitive_dependencies()
+        assert lib in transitive
+        assert sublib in transitive
+
+    def test_invalidates_cached_requirements(self, test_project):  # noqa: F811
+        """add_dependency() clears the collected-requirements cache."""
+        app = Target("app")
+        lib = Target("lib")
+        app._collected_requirements = UsageRequirements()  # pretend a cache exists
+
+        app.add_dependency(lib)
+
+        assert app._collected_requirements is None
+
+    def test_raises_after_resolve(self, test_project):  # noqa: F811
+        """add_dependency() fails once the target is resolved."""
+        app = Target("app")
+        lib = Target("lib")
+        app._resolved = True
+
+        with pytest.raises(RuntimeError, match="after resolve"):
+            app.add_dependency(lib)
 
 
 class TestTargetSubdir:

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -11,7 +11,9 @@ from pcons.core.project import Project
 from pcons.core.target import (
     ImportedTarget,
     Target,
+    UniqueList,
     UsageRequirements,
+    ValidatedUniqueList,
     is_qualified_name,
     split_qualified_name,
 )
@@ -75,6 +77,54 @@ class TestUsageRequirements:
         # Modifying clone doesn't affect original
         clone.include_dirs.append(Path("other"))
         assert Path("other") not in req.include_dirs
+
+    def test_assignment_preserves_unique_list_type(self):
+        """Assigning a plain list keeps an existing UniqueList's type and dedup."""
+        req = UsageRequirements()
+        req.defines = UniqueList(["A"])
+        original = req.defines
+
+        # Reassign with a plain list (including a duplicate).
+        req.defines = ["B", "C", "C"]
+
+        # Same list object is reused (cleared + extended, not replaced)...
+        assert req.defines is original
+        assert isinstance(req.defines, UniqueList)
+        # ...so dedup behavior still applies to the new contents.
+        assert req.defines == ["B", "C"]
+
+    def test_assignment_preserves_validator(self):
+        """Assigning to a ValidatedUniqueList keeps validation on new contents."""
+        req = UsageRequirements()
+        req.link_libs = ValidatedUniqueList([], validator=lambda x: x != "bad")
+        original = req.link_libs
+
+        req.link_libs = ["good", "bad", "ok"]
+
+        assert req.link_libs is original
+        assert isinstance(req.link_libs, ValidatedUniqueList)
+        # The validator rejects "bad" even on full reassignment.
+        assert req.link_libs == ["good", "ok"]
+
+    def test_assignment_replaces_contents(self):
+        """Reassignment replaces the old contents rather than appending."""
+        req = UsageRequirements()
+        req.defines = UniqueList(["OLD"])
+
+        req.defines = ["NEW"]
+
+        assert req.defines == ["NEW"]
+
+    def test_assignment_to_plain_list_replaces_object(self):
+        """When the existing value is a plain list, assignment replaces it."""
+        req = UsageRequirements(defines=["A"])
+        assert not isinstance(req.defines, UniqueList)
+
+        new_list = ["B"]
+        req.defines = new_list
+
+        # Plain lists are replaced outright (no clear/extend).
+        assert req.defines is new_list
 
 
 class TestQualifiedName:

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.core.target."""
 
+import warnings
 from pathlib import Path
 
 import pytest
@@ -269,7 +270,9 @@ class TestFluentAPI:
         lib = Target("lib")
         app = Target("app")
 
-        result = app.private.link_libs.append(lib)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            result = app.link(lib)
 
         assert result is app
         assert lib in app.dependencies
@@ -337,7 +340,9 @@ class TestFluentAPI:
         src = tmp_path / "main.c"
         src.touch()
 
-        result = app.add_source(src).private.link_libs.append(lib)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            result = app.add_source(src).link(lib)
 
         assert result is app
         assert len(app.sources) == 1

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -240,6 +240,19 @@ class TestTarget:
         assert lib.public.defines == ["LIB_API"]
         assert lib.private.defines == ["LIB_BUILDING"]
 
+    def test_paired_flags_not_deduped_by_token(self, test_project):  # noqa: F811
+        # compile_flags/link_flags must preserve repeated tokens of paired
+        # flags: -framework Foo -framework Bar, -arch x86_64 -arch arm64.
+        # Token-level dedup (UniqueList) would drop the second flag token.
+        lib = Target("lib")
+        for tok in ("-framework", "Foo", "-framework", "Bar"):
+            lib.public.link_flags.append(tok)
+        for tok in ("-arch", "x86_64", "-arch", "arm64"):
+            lib.public.compile_flags.append(tok)
+
+        assert lib.public.link_flags == ["-framework", "Foo", "-framework", "Bar"]
+        assert lib.public.compile_flags == ["-arch", "x86_64", "-arch", "arm64"]
+
     def test_collect_usage_requirements(self, test_project):  # noqa: F811
         """Test transitive requirement collection."""
         # Create a dependency chain: app -> libB -> libA

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -230,6 +230,31 @@ class TestTarget:
         assert set(deps) == {leaf, mid}
         assert deps.index(leaf) < deps.index(mid)
 
+    def test_transitive_link_deps_follow_static_lib_private_deps(self, test_project):  # noqa: F811
+        # exe -> libA (static, public) -> libB (static, PRIVATE).
+        # A static archive does not link its deps in, so libB must reach the
+        # final link line even though it is a private dep of libA.
+        libB = Target("libB", target_type="static_library")
+        libA = Target("libA", target_type="static_library")
+        libA.private.link_libs.append(libB)
+        exe = Target("exe", target_type="program")
+        exe.private.link_libs.append(libA)
+
+        # Usage-requirement propagation must NOT pull in libB.
+        assert set(exe.transitive_dependencies()) == {libA}
+        # Link-input collection must include libB.
+        assert set(exe.transitive_dependencies(for_link=True)) == {libA, libB}
+
+    def test_transitive_link_deps_stop_at_shared_lib(self, test_project):  # noqa: F811
+        # A shared library resolves its own private deps, so libB stays hidden.
+        libB = Target("libB", target_type="static_library")
+        libA = Target("libA", target_type="shared_library")
+        libA.private.link_libs.append(libB)
+        exe = Target("exe", target_type="program")
+        exe.private.link_libs.append(libA)
+
+        assert set(exe.transitive_dependencies(for_link=True)) == {libA}
+
     def test_usage_requirements(self, test_project):  # noqa: F811
         lib = Target("lib")
         lib.public.include_dirs.append(Path("include"))

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -103,7 +103,7 @@ class TestTarget:
         assert target.name == "mylib"
         assert target.nodes == []
         assert target.sources == []
-        assert target.dependencies == []
+        assert len(target.dependencies) == 0
 
     def test_tracks_source_location(self, test_project):  # noqa: F811
         target = Target("mylib")

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -121,8 +121,8 @@ class TestTarget:
         lib2 = Target("lib2")
         app = Target("app")
 
-        app.link(lib1)
-        app.link(lib2)
+        app.private.link_libs.append(lib1)
+        app.private.link_libs.append(lib2)
 
         assert lib1 in app.dependencies
         assert lib2 in app.dependencies
@@ -131,8 +131,8 @@ class TestTarget:
         lib = Target("lib")
         app = Target("app")
 
-        app.link(lib)
-        app.link(lib)  # Same lib again
+        app.private.link_libs.append(lib)
+        app.private.link_libs.append(lib)  # Same lib again
 
         assert app.dependencies.count(lib) == 1
 
@@ -155,11 +155,11 @@ class TestTarget:
 
         libB = Target("libB")
         libB.public.include_dirs.append(Path("libB/include"))
-        libB.link(libA)
+        libB.public.link_libs.append(libA)
 
         app = Target("app")
         app.private.defines.append("APP_PRIVATE")
-        app.link(libB)
+        app.private.link_libs.append(libB)
 
         requirements = app.collect_usage_requirements()
 
@@ -173,7 +173,7 @@ class TestTarget:
         """Test that collection is cached."""
         lib = Target("lib")
         app = Target("app")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         req1 = app.collect_usage_requirements()
         req2 = app.collect_usage_requirements()
@@ -186,12 +186,12 @@ class TestTarget:
         lib2 = Target("lib2")
         lib2.public.defines.append("LIB2")
         app = Target("app")
-        app.link(lib1)
+        app.private.link_libs.append(lib1)
 
         req1 = app.collect_usage_requirements()
         assert "LIB2" not in req1.defines
 
-        app.link(lib2)
+        app.private.link_libs.append(lib2)
         req2 = app.collect_usage_requirements()
 
         assert req2 is not req1
@@ -203,7 +203,7 @@ class TestTarget:
 
         app = Target("app")
         app.required_languages.add("cxx")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         langs = app.get_all_languages()
         assert "c" in langs
@@ -255,7 +255,7 @@ class TestImportedTarget:
         zlib.public.link_libs.append("z")
 
         app = Target("app")
-        app.link(zlib)
+        app.private.link_libs.append(zlib)
 
         requirements = app.collect_usage_requirements()
         assert "z" in requirements.link_libs
@@ -269,7 +269,7 @@ class TestFluentAPI:
         lib = Target("lib")
         app = Target("app")
 
-        result = app.link(lib)
+        result = app.private.link_libs.append(lib)
 
         assert result is app
         assert lib in app.dependencies
@@ -337,7 +337,7 @@ class TestFluentAPI:
         src = tmp_path / "main.c"
         src.touch()
 
-        result = app.add_source(src).link(lib)
+        result = app.add_source(src).private.link_libs.append(lib)
 
         assert result is app
         assert len(app.sources) == 1

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -137,6 +137,33 @@ class TestTarget:
 
         assert app.dependencies.count(lib) == 1
 
+    def test_transitive_deps_no_duplicate_private_and_public(self, test_project):  # noqa: F811
+        common = Target("common")
+        mid = Target("mid")
+        mid.public.link_libs.append(common)
+        app = Target("app")
+        app.private.link_libs.append(common)
+        app.public.link_libs.append(mid)
+
+        deps = app.transitive_dependencies()
+
+        assert deps.count(common) == 1
+        assert set(deps) == {common, mid}
+
+    def test_transitive_deps_order_dependencies_before_dependents(self, test_project):  # noqa: F811
+        # leaf <- mid <- app, where mid is a *private* dep of app.
+        # leaf (and mid's transitively-public leaf) must precede mid.
+        leaf = Target("leaf")
+        mid = Target("mid")
+        mid.public.link_libs.append(leaf)
+        app = Target("app")
+        app.private.link_libs.append(mid)
+
+        deps = app.transitive_dependencies()
+
+        assert set(deps) == {leaf, mid}
+        assert deps.index(leaf) < deps.index(mid)
+
     def test_usage_requirements(self, test_project):  # noqa: F811
         lib = Target("lib")
         lib.public.include_dirs.append(Path("include"))

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -96,15 +96,15 @@ class TestUsageRequirements:
     def test_assignment_preserves_validator(self):
         """Assigning to a ValidatedUniqueList keeps validation on new contents."""
         req = UsageRequirements()
-        req.link_libs = ValidatedUniqueList([], validator=lambda x: x != "bad")
-        original = req.link_libs
 
-        req.link_libs = ["good", "bad", "ok"]
+        def __bad_raises(item):
+            if item == "bad":
+                raise ValueError("bad item not allowed")
 
-        assert req.link_libs is original
-        assert isinstance(req.link_libs, ValidatedUniqueList)
-        # The validator rejects "bad" even on full reassignment.
-        assert req.link_libs == ["good", "ok"]
+        req.link_libs = ValidatedUniqueList([], on_append=__bad_raises)
+
+        with pytest.raises(ValueError, match="bad item not allowed"):
+            req.link_libs = ["good", "bad", "ok"]
 
     def test_assignment_replaces_contents(self):
         """Reassignment replaces the old contents rather than appending."""

--- a/tests/generators/test_mermaid.py
+++ b/tests/generators/test_mermaid.py
@@ -89,7 +89,7 @@ class TestMermaidGeneratorGraph:
         physics_obj.depends([physics_src])
         libphysics.intermediate_nodes.append(physics_obj)
         libphysics.output_nodes.append(physics_lib)
-        libphysics.link(libmath)
+        libphysics.public.link_libs.append(libmath)
 
         # Create app depending on libphysics
         app = Target("app", target_type="program")
@@ -99,7 +99,7 @@ class TestMermaidGeneratorGraph:
         app_obj.depends([app_src])
         app.intermediate_nodes.append(app_obj)
         app.output_nodes.append(app_exe)
-        app.link(libphysics)
+        app.private.link_libs.append(libphysics)
 
         gen = MermaidGenerator()
         gen.generate(project)
@@ -221,7 +221,7 @@ class TestMermaidGeneratorIntegration:
         app_obj.depends([app_src])
         app.intermediate_nodes.append(app_obj)
         app.output_nodes.append(app_exe)
-        app.link(libmath)
+        app.private.link_libs.append(libmath)
 
         gen = MermaidGenerator()
         gen.generate(project)

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -52,7 +52,7 @@ class TestMetadataGenerator:
         )
         app.output_nodes.append(FileNode("build/app"))
         app.add_source("src/main.c")
-        app.dependencies.append(lib)
+        app.add_dependency(lib)
 
         project.Default(app)
         project.Alias("all", app)

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -193,7 +193,7 @@ class TestXcodeGeneratorDependencies:
 
         # Create app that depends on lib
         app = Target("myapp", target_type="program")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -331,8 +331,8 @@ class TestXcodeGeneratorMultiTarget:
         lib2 = Target("libphysics", target_type="static_library")
         app = Target("app", target_type="program")
 
-        lib2.link(lib1)
-        app.link(lib2)
+        lib2.public.link_libs.append(lib1)
+        app.private.link_libs.append(lib2)
 
         gen = XcodeGenerator()
         gen.generate(project)

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -234,6 +234,38 @@ class TestXcodeGeneratorDependencies:
             for s in frameworks_sections
         ), "PBXFrameworksBuildPhase for app has no files (library not linked)"
 
+    def test_target_lib_not_stringified_into_ldflags(self, tmp_path):
+        """Library Target deps must not leak into OTHER_LDFLAGS as -l flags."""
+        project = Project("myapp", build_dir=tmp_path)
+
+        lib = Target("mylib", target_type="static_library")
+        app = Target("myapp", target_type="program")
+        app.private.link_libs.append(lib)
+
+        gen = XcodeGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
+        # "Type: static_library" only appears via Target.__str__, i.e. if a
+        # Target object leaked into a stringified flag.
+        assert "Type: static_library" not in content
+        assert "-lTarget" not in content
+
+    def test_string_libs_become_l_flags(self, tmp_path):
+        """Non-Target (system) libs in link_libs must still become -l flags."""
+        project = Project("myapp", build_dir=tmp_path)
+
+        app = Target("myapp", target_type="program")
+        app.private.link_libs.append("m")
+
+        gen = XcodeGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
+        assert "-lm" in content
+
 
 class TestXcodeGeneratorBuildPhases:
     """Tests for build phases."""

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -213,7 +213,7 @@ class TestXcodeGeneratorDependencies:
         lib = Target("mylib", target_type="static_library")
 
         app = Target("myapp", target_type="program")
-        app.link(lib)
+        app.private.link_libs.append(lib)
 
         gen = XcodeGenerator()
         gen.generate(project)

--- a/tests/generators/test_xcode.py
+++ b/tests/generators/test_xcode.py
@@ -238,9 +238,11 @@ class TestXcodeGeneratorDependencies:
         """Library Target deps must not leak into OTHER_LDFLAGS as -l flags."""
         project = Project("myapp", build_dir=tmp_path)
 
-        lib = Target("mylib", target_type="static_library")
+        pub_lib = Target("publib", target_type="static_library")
+        priv_lib = Target("privlib", target_type="static_library")
         app = Target("myapp", target_type="program")
-        app.private.link_libs.append(lib)
+        app.public.link_libs.append(pub_lib)
+        app.private.link_libs.append(priv_lib)
 
         gen = XcodeGenerator()
         gen.generate(project)
@@ -253,18 +255,23 @@ class TestXcodeGeneratorDependencies:
         assert "-lTarget" not in content
 
     def test_string_libs_become_l_flags(self, tmp_path):
-        """Non-Target (system) libs in link_libs must still become -l flags."""
+        """Non-Target (system) libs in link_libs must still become -l flags.
+
+        Covers both the public and private link_libs branches.
+        """
         project = Project("myapp", build_dir=tmp_path)
 
         app = Target("myapp", target_type="program")
-        app.private.link_libs.append("m")
+        app.public.link_libs.append("pubsys")
+        app.private.link_libs.append("privsys")
 
         gen = XcodeGenerator()
         gen.generate(project)
         BaseGenerator._generate_pending(project)
 
         content = (tmp_path / "myapp.xcodeproj" / "project.pbxproj").read_text()
-        assert "-lm" in content
+        assert "-lpubsys" in content
+        assert "-lprivsys" in content
 
 
 class TestXcodeGeneratorBuildPhases:

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -217,11 +217,11 @@ class TestImportedTarget:
                 defines=["CPPHTTPLIB_OPENSSL_SUPPORT"],
             )
         )
-        httplib.link(openssl)
+        httplib.public.link_libs.append(openssl)
 
         # A target that links httplib should get openssl transitively
         app = Target("app")
-        app.link(httplib)
+        app.private.link_libs.append(httplib)
 
         reqs = app.collect_usage_requirements()
         # httplib's own requirements

--- a/tests/test_user_errors.py
+++ b/tests/test_user_errors.py
@@ -330,8 +330,8 @@ class TestDependencyMistakes:
         project, env = project_env
         lib_a = project.StaticLibrary("liba", env, sources=["src/lib.c"])
         lib_b = project.StaticLibrary("libb", env, sources=["src/main.c"])
-        lib_a.link(lib_b)
-        lib_b.link(lib_a)
+        lib_a.public.link_libs.append(lib_b)
+        lib_b.public.link_libs.append(lib_a)
         errors = project.validate()
         assert any(isinstance(e, DependencyCycleError) for e in errors)
 
@@ -340,8 +340,8 @@ class TestDependencyMistakes:
         project, env = project_env
         lib_a = project.StaticLibrary("liba", env, sources=["src/lib.c"])
         lib_b = project.StaticLibrary("libb", env, sources=["src/main.c"])
-        lib_a.link(lib_b)
-        lib_b.link(lib_a)
+        lib_a.public.link_libs.append(lib_b)
+        lib_b.public.link_libs.append(lib_a)
         with pytest.raises(PconsError):
             project.resolve(strict=True)
 
@@ -350,7 +350,7 @@ class TestDependencyMistakes:
         project, env = project_env
         app = project.Program("app", env, sources=["src/main.c"])
         with pytest.raises((DependencyCycleError, ValueError), match="self|cycle"):
-            app.link(app)
+            app.private.link_libs.append(app)
 
     def test_depends_on_self(self, project_env):
         """Target depends on itself."""
@@ -364,8 +364,8 @@ class TestDependencyMistakes:
         project, env = project_env
         lib = project.StaticLibrary("mylib", env, sources=["src/lib.c"])
         app = project.Program("app", env, sources=["src/main.c"])
-        app.link(lib)
-        app.link(lib)
+        app.private.link_libs.append(lib)
+        app.private.link_libs.append(lib)
         # Should not crash and lib should appear only once
         assert app.dependencies.count(lib) == 1
 

--- a/tests/test_user_errors.py
+++ b/tests/test_user_errors.py
@@ -69,7 +69,10 @@ class TestWrongArgumentTypes:
         """User passes a string library name instead of a Target object."""
         project, env = project_env
         app = project.Program("app", env, sources=["src/main.c"])
-        with pytest.raises(TypeError, match="[Tt]arget"):
+        with (
+            pytest.raises(TypeError, match="[Tt]arget"),
+            pytest.warns(DeprecationWarning, match="link"),
+        ):
             app.link("mylib")
 
     def test_link_list_instead_of_varargs(self, project_env):
@@ -77,7 +80,7 @@ class TestWrongArgumentTypes:
         project, env = project_env
         lib = project.StaticLibrary("mylib", env, sources=["src/lib.c"])
         app = project.Program("app", env, sources=["src/main.c"])
-        with pytest.raises(TypeError):
+        with pytest.raises(TypeError), pytest.warns(DeprecationWarning, match="link"):
             app.link([lib])
 
     def test_add_sources_string_not_list(self, project_env):
@@ -252,7 +255,7 @@ class TestWrongApiOrder:
         project.resolve()
         # Linking after resolve should warn or raise
         with pytest.raises((PconsError, RuntimeError), match="resolve"):
-            app.link(lib)
+            app.public.link_libs.append(lib)
 
     def test_modify_flags_before_resolve_is_ok(self, project_env):
         """Modifying flags after target creation but before resolve is valid.
@@ -368,6 +371,14 @@ class TestDependencyMistakes:
         app.private.link_libs.append(lib)
         # Should not crash and lib should appear only once
         assert app.dependencies.count(lib) == 1
+
+    def test_link_now_deprecated(self, project_env):
+        """Using the old link() method should raise a DeprecationWarning."""
+        project, env = project_env
+        lib = project.StaticLibrary("mylib", env, sources=["src/lib.c"])
+        app = project.Program("app", env, sources=["src/main.c"])
+        with pytest.warns(DeprecationWarning, match="link"):
+            app.link(lib)
 
 
 # =============================================================================


### PR DESCRIPTION
### Summary :memo:

Replaces the fluent `target.link(...)` / `target.dependencies.append(...)` API  with a CMake-style usage-requirements model: dependencies are expressed by appending `Target` objects (or names) directly to `target.public.link_libs` / `target.private.link_libs`. The scope (`public` vs `private`) now drives requirement propagation directly, exactly like every other usage requirement  (`include_dirs`, `defines`, `compile_flags`, ...).

```python
# Before
libphysics.link(libmath)            # implicitly public
simulator.link(libphysics)

# After
libphysics.public.link_libs.append(libmath)     # propagates to consumers
simulator.private.link_libs.append(libphysics)  # local to simulator
```

`target.link()` stays as a `@deprecated` shim so existing scripts keep working (emitting a deprecation warning).
This makes the dependency model uniform, one propagation rule for everything, `private` link dependencies become expressible.

### Details

1. **New list primitives** (`pcons/core/target.py`): `UniqueList` /
   `ValidatedUniqueList` (`UserList` subclasses) back the dedup-and-validate behavior of usage-requirement lists. `UsageRequirements` preserves each field's concrete list type through `merge()`, `clone()`, and whole-list assignment.
   > **_NOTE:_** ValidatedUniqueList looses its validation callback on `merge()` and `clone()` which is OK here since we actually dont want that validation once merged or cloned.
2. **`_make_default_requirements()`** builds the standard C/C++ requirement fields in one place so `public`/`private` can't drift, all six fields now dedup  uniformly.
3. **Typing**: usage-requirement fields are `MutableSequence[...]` so `UserList` subtypes is accepted. `link_libs` is `MutableSequence[str | Target]`.
4. **Compatibility**: `@deprecated` shim for `target.link()`, with a Python <3.13 fallback for `warnings.deprecated`.
5. **Migration**: all examples and tests moved to the new API.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
