### PR TITLE
Fix/meta target dup

### DIFF
--- a/examples/42_nested_metadata/child/grandchild/pcons-build.py
+++ b/examples/42_nested_metadata/child/grandchild/pcons-build.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Grandchild sub-project (third nesting level).
+
+Creates its own Project and one Program. Reached via add_subdirectory from
+the child project.
+"""
+
+from pcons import Project, find_c_toolchain
+
+project = Project("nested_grandchild")
+
+if project.is_top_level:
+    env = project.Environment(toolchain=find_c_toolchain())
+else:
+    # Reuse the top-level toolchain rather than re-detecting one per level.
+    env = Project.top_level().default_environment
+
+grandchild_app = project.Program("grandchild_app", env, sources=["src/grandchild.c"])

--- a/examples/42_nested_metadata/child/grandchild/src/grandchild.c
+++ b/examples/42_nested_metadata/child/grandchild/src/grandchild.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#include <stdio.h>
+
+int main(void) {
+    printf("grandchild\n");
+    return 0;
+}

--- a/examples/42_nested_metadata/child/pcons-build.py
+++ b/examples/42_nested_metadata/child/pcons-build.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Child sub-project (second nesting level).
+
+Creates its own Project, one Program, and nests a grandchild project via
+add_subdirectory.
+"""
+
+from pcons import Project, add_subdirectory, find_c_toolchain
+
+project = Project("nested_child")
+
+if project.is_top_level:
+    env = project.Environment(toolchain=find_c_toolchain())
+else:
+    # Reuse the top-level toolchain rather than re-detecting one per level.
+    env = Project.top_level().default_environment
+
+child_app = project.Program("child_app", env, sources=["src/child.c"])
+
+add_subdirectory("grandchild")

--- a/examples/42_nested_metadata/child/src/child.c
+++ b/examples/42_nested_metadata/child/src/child.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#include <stdio.h>
+
+int main(void) {
+    printf("child\n");
+    return 0;
+}

--- a/examples/42_nested_metadata/pcons-build.py
+++ b/examples/42_nested_metadata/pcons-build.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Nested projects metadata example.
+
+Three levels of nested Project() instances, each created via
+add_subdirectory:
+
+    nested_root              (this file)
+    +-- nested_child         (child/pcons-build.py)
+        +-- nested_grandchild (child/grandchild/pcons-build.py)
+
+Every level creates its OWN Project and defines one Program. This exercises
+the IDE metadata generator (pcons_metadata.json): each project must get its
+own entry, and each entry must list only its own targets - no target may
+appear under an ancestor project.
+
+Validated by test_metadata.py via the example test runner.
+"""
+
+from pathlib import Path
+
+from pcons import (
+    Generator,
+    MetadataGenerator,
+    Project,
+    add_subdirectory,
+    find_c_toolchain,
+)
+
+project = Project("nested_root", root_dir=Path(__file__).parent)
+env = project.Environment(toolchain=find_c_toolchain())
+
+root_app = project.Program("root_app", env, sources=["src/root.c"])
+
+add_subdirectory("child")
+
+# Run the structural generator selected by PCONS_GENERATOR, and always also
+# emit the IDE metadata so the example can be validated regardless of which
+# backend is used.
+Generator().generate(project)
+MetadataGenerator().generate(project)

--- a/examples/42_nested_metadata/src/root.c
+++ b/examples/42_nested_metadata/src/root.c
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+#include <stdio.h>
+
+int main(void) {
+    printf("root\n");
+    return 0;
+}

--- a/examples/42_nested_metadata/test.toml
+++ b/examples/42_nested_metadata/test.toml
@@ -1,0 +1,24 @@
+# Test configuration for the 42_nested_metadata example
+
+[test]
+description = "Nested Project() instances each get their own metadata entry with no duplicated targets"
+
+# We don't use the expected_outputs field here because we want to validate the metadata, not the build output.
+# The test_metadata.py script will load the pcons_metadata.json file and validate that the nested projects
+# are represented correctly without duplicated or missing targets.
+# expected_outputs = [
+#     "build/root_app",
+#     "build/child/child_app",
+#     "build/child/grandchild/grandchild_app",
+# ]
+
+[verify]
+# Custom validation: load pcons_metadata.json and assert nested projects are
+# represented without duplicated or missing targets.
+commands = [
+    { run = "uv run python test_metadata.py" },
+]
+
+[skip]
+# Metadata is generator-independent, validate it once with ninja.
+generators = ["xcode", "make"]

--- a/examples/42_nested_metadata/test_metadata.py
+++ b/examples/42_nested_metadata/test_metadata.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+"""Validate the IDE metadata produced for nested projects.
+
+Loads build/pcons_metadata.json and checks that nested Project() instances
+are represented correctly:
+
+  - every nested project has its own entry, with the right parent link;
+  - each project entry lists only its own targets;
+  - no target is duplicated across project entries.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+META = Path(__file__).parent / "build" / "pcons_metadata.json"
+
+data = json.loads(META.read_text())
+projects = {p["name"]: p for p in data["projects"]}
+
+errors = []
+
+# 1. Every nested project gets its own entry.
+expected = {"nested_root", "nested_child", "nested_grandchild"}
+missing = expected - projects.keys()
+if missing:
+    errors.append(f"Missing project entries: {sorted(missing)}")
+
+# 2. Parent links form the expected root -> child -> grandchild chain.
+chain = {
+    "nested_root": None,
+    "nested_child": "nested_root",
+    "nested_grandchild": "nested_child",
+}
+for name, parent in chain.items():
+    if name not in projects:
+        continue  # already reported as missing above
+    got = projects[name]["parent"]
+    if got != parent:
+        errors.append(f"{name} parent is {got!r}, expected {parent!r}")
+
+# 3. Each project lists only its own target.
+own = {
+    "nested_root": ["root_app"],
+    "nested_child": ["child_app"],
+    "nested_grandchild": ["grandchild_app"],
+}
+for name, names in own.items():
+    if name not in projects:
+        continue  # already reported as missing above
+    got = sorted(t["name"] for t in projects[name]["targets"])
+    if got != sorted(names):
+        errors.append(f"{name} targets are {got}, expected {sorted(names)}")
+
+# 4. No target appears in more than one project entry.
+seen: dict[str, str] = {}
+for p in data["projects"]:
+    for t in p["targets"]:
+        q = t["qualified_name"]
+        if q in seen:
+            errors.append(f"Duplicate target {q} in {seen[q]!r} and {p['name']!r}")
+        else:
+            seen[q] = p["name"]
+
+if errors:
+    print("FAIL:", file=sys.stderr)
+    for e in errors:
+        print("  -", e, file=sys.stderr)
+    sys.exit(1)

--- a/pcons/generators/metadata.py
+++ b/pcons/generators/metadata.py
@@ -42,14 +42,20 @@ class MetadataGenerator(BaseGenerator):
             "schema_version": 2,
             "generator": self.name,
             "projects": [
-                self._serialize_project(project),
-                *[self._serialize_project(p) for p in project._children],
+                self._serialize_project(p) for p in self._walk_projects(project)
             ],
         }
 
         with open(output_file, "w", encoding="utf-8") as f:
             json.dump(metadata, f, indent=2)
             f.write("\n")
+
+    def _walk_projects(self, project: Project) -> list[Project]:
+        """Flatten the project tree depth-first (root before descendants)."""
+        result = [project]
+        for child in project._children:
+            result.extend(self._walk_projects(child))
+        return result
 
     def _serialize_project(self, project: Project) -> dict[str, Any]:
         """Serialize project-level metadata."""
@@ -61,7 +67,7 @@ class MetadataGenerator(BaseGenerator):
             "build_dir": project.build_dir.as_posix(),
             "targets": [
                 self._serialize_target(target, project, default_target_names)
-                for target in sorted(project.targets, key=lambda t: t.name)
+                for target in sorted(project._targets, key=lambda t: t.name)
             ],
             "aliases": [
                 self._serialize_alias(name, project) for name in sorted(project.aliases)

--- a/tests/generators/test_metadata.py
+++ b/tests/generators/test_metadata.py
@@ -137,6 +137,48 @@ class TestMetadataGenerator:
         assert proj_by_name["parent"]["parent"] is None
         assert proj_by_name["child"]["parent"] == "parent"
 
+    def test_child_targets_not_duplicated_in_parent(self, tmp_path):
+        """Each project entry lists only its own targets, not descendants'."""
+        parent = Project("parent", root_dir=tmp_path, build_dir="build")
+        papp = Target("papp", target_type="program")
+        papp.output_nodes.append(FileNode("build/papp"))
+
+        child = Project("child", root_dir=tmp_path / "sub")
+        capp = Target("capp", target_type="program")
+        capp.output_nodes.append(FileNode("build/capp"))
+        assert capp.project is child  # registered to the child project
+
+        MetadataGenerator().generate(parent)
+        BaseGenerator._generate_pending(parent)
+
+        content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
+        proj_by_name = {p["name"]: p for p in content["projects"]}
+        assert [t["name"] for t in proj_by_name["parent"]["targets"]] == ["papp"]
+        assert [t["name"] for t in proj_by_name["child"]["targets"]] == ["capp"]
+
+        qnames = [
+            t["qualified_name"] for p in content["projects"] for t in p["targets"]
+        ]
+        assert sorted(qnames) == sorted(set(qnames))  # no duplicates
+
+    def test_grandchild_project_in_projects_list(self, tmp_path):
+        """Nested grandchildren get their own project entry with targets."""
+        parent = Project("parent", root_dir=tmp_path, build_dir="build")
+        Project("child", root_dir=tmp_path / "sub")
+        grandchild = Project("grandchild", root_dir=tmp_path / "sub" / "deep")
+        gapp = Target("gapp", target_type="program")
+        gapp.output_nodes.append(FileNode("build/gapp"))
+        assert gapp.project is grandchild
+
+        MetadataGenerator().generate(parent)
+        BaseGenerator._generate_pending(parent)
+
+        content = json.loads((tmp_path / "build" / "pcons_metadata.json").read_text())
+        proj_by_name = {p["name"]: p for p in content["projects"]}
+        assert set(proj_by_name) == {"parent", "child", "grandchild"}
+        assert proj_by_name["grandchild"]["parent"] == "child"
+        assert [t["name"] for t in proj_by_name["grandchild"]["targets"]] == ["gapp"]
+
     def test_test_target_embeds_testspec(self, tmp_path, gcc_toolchain):
         """Test() targets get an embedded `test` block for IDE integration."""
         src = tmp_path / "main.c"


### PR DESCRIPTION
### Summary :memo:
Fix duplicate targets in the JSON metadata for nested projects. IDE integrations reading `pcons_metadata.json` saw every target of a sub-project listed once per ancestor, which surfaced as duplicated entries in the VSCode extension's target pickers.

### Details
`Project.targets` is recursive: it returns a project's own targets plus all descendants'. The metadata generator built one project entry for the top-level project from that recursive set, then another entry per child (also recursive).

As a result every child target appeared both in its own project entry and in every ancestor's.

A second, latent bug: the projects list only walked direct children, so a grandchild project never got its own entry while its targets still leaked into ancestors.

1. Walk the full project tree depth-first so every descendant gets its own project entry.
2. Serialize each project's own direct targets only (`project._targets`) instead of the recursive `project.targets`.
3. Added regression tests for target non-duplication and grandchild nesting.
4. Added the `42_nested_metadata` example (three nesting levels) with a custom `test_metadata.py` that loads `pcons_metadata.json` and asserts each project has its own entry, the right parent chain, only its own targets, and no duplicates.

### Bugfixes :bug:
- Targets of nested sub-projects no longer appear multiple times in
  `pcons_metadata.json`.
- Grandchild projects now get their own entry in the `projects` list.

### Checks
- [ ] Closed #
- [x] Tested Changes
- [ ] Stakeholder Approval
