### PR TITLE
Feature/code dedup

### DIFF
--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -14,6 +14,7 @@ Build graph:
 import sys
 
 from pcons import Project, find_c_toolchain
+from pcons.generators.dot import DotGenerator
 from pcons.generators.mermaid import MermaidGenerator
 
 # =============================================================================
@@ -55,10 +56,13 @@ simulator.private.link_libs.append(
     libphysics
 )  # Gets both libphysics and libmath includes
 
-# Generate Mermaid dependency diagram (after generate, which auto-resolves)
+# Generate dependency diagrams (after generate, which auto-resolves)
 mermaid_gen = MermaidGenerator(direction="LR")
 mermaid_gen.generate(project)
+dot_gen = DotGenerator(rankdir="LR")
+dot_gen.generate(project)
 
 print("Generated 'build.ninja'")
 print("Generated 'compile_commands.json'")
 print("Generated 'deps.mmd'")
+print("Generated 'deps.dot'")

--- a/examples/05_multi_library/test.toml
+++ b/examples/05_multi_library/test.toml
@@ -10,6 +10,7 @@ expected_outputs = [
     "build/build.ninja",
     "build/compile_commands.json",
     "build/deps.mmd",
+    "build/deps.dot",
     "build/libmath.a",
     "build/libphysics.so",
     "build/simulator",
@@ -35,6 +36,12 @@ commands = [
     { run = "cat build/deps.mmd", expect_stdout = "libphysics" },
     { run = "cat build/deps.mmd", expect_stdout = "simulator" },
     { run = "cat build/deps.mmd", expect_stdout = "-->" },
+
+    # Verify deps.dot has the dependency graph
+    { run = "cat build/deps.dot", expect_stdout = "digraph" },
+    { run = "cat build/deps.dot", expect_stdout = "libmath" },
+    { run = "cat build/deps.dot", expect_stdout = "simulator" },
+    { run = "cat build/deps.dot", expect_stdout = "->" },
 ]
 
 # Windows needs different checks for deps.mmd since library names differ
@@ -54,6 +61,12 @@ commands_windows = [
     { run = "type build\\deps.mmd", expect_stdout = "physics" },
     { run = "type build\\deps.mmd", expect_stdout = "simulator" },
     { run = "type build\\deps.mmd", expect_stdout = "-->" },
+
+    # Verify deps.dot has the dependency graph
+    { run = "type build\\deps.dot", expect_stdout = "digraph" },
+    { run = "type build\\deps.dot", expect_stdout = "math" },
+    { run = "type build\\deps.dot", expect_stdout = "simulator" },
+    { run = "type build\\deps.dot", expect_stdout = "->" },
 ]
 
 [skip]

--- a/pcons/configure/checks.py
+++ b/pcons/configure/checks.py
@@ -103,6 +103,22 @@ class ToolChecks:
         compiler = self._get_compiler() or "unknown"
         return f"check:{self._tool_name}:{compiler}:{check_type}:{':'.join(args)}"
 
+    def _cached_or_compiler(self, cache_key: str) -> CheckResult | str:
+        """Shared preamble for the check_* methods.
+
+        Returns a CheckResult when the answer is already cached or no compiler
+        is configured (the caller returns it directly), otherwise the compiler
+        command to use.
+        """
+        cached = self._config.get(cache_key)
+        if cached is not None:
+            trace("configure", "  cached: %s", cached)
+            return CheckResult(success=cached, cached=True)
+        compiler = self._get_compiler()
+        if compiler is None:
+            return CheckResult(success=False, output="No compiler configured")
+        return compiler
+
     def try_compile(
         self,
         source: str,
@@ -149,14 +165,10 @@ class ToolChecks:
         )
         trace("configure", "  source: %s", self._source_preview(source))
         cache_key = self._cache_key("try_compile", code_hash, flags_str, link_str)
-        cached = self._config.get(cache_key)
-        if cached is not None:
-            trace("configure", "  cached: %s", cached)
-            return CheckResult(success=cached, cached=True)
-
-        compiler = self._get_compiler()
-        if compiler is None:
-            return CheckResult(success=False, output="No compiler configured")
+        outcome = self._cached_or_compiler(cache_key)
+        if isinstance(outcome, CheckResult):
+            return outcome
+        compiler = outcome
 
         cdir = self._make_check_dir()
         try:
@@ -201,14 +213,10 @@ class ToolChecks:
             self._caller_location(),
         )
         cache_key = self._cache_key("flag", flag)
-        cached = self._config.get(cache_key)
-        if cached is not None:
-            trace("configure", "  cached: %s", cached)
-            return CheckResult(success=cached, cached=True)
-
-        compiler = self._get_compiler()
-        if compiler is None:
-            return CheckResult(success=False, output="No compiler configured")
+        outcome = self._cached_or_compiler(cache_key)
+        if isinstance(outcome, CheckResult):
+            return outcome
+        compiler = outcome
 
         # Minimal C program
         source = "int main(void) { return 0; }\n"
@@ -265,14 +273,10 @@ class ToolChecks:
         if extra_flags:
             cache_parts.extend(sorted(extra_flags))
         cache_key = self._cache_key("header", *cache_parts)
-        cached = self._config.get(cache_key)
-        if cached is not None:
-            trace("configure", "  cached: %s", cached)
-            return CheckResult(success=cached, cached=True)
-
-        compiler = self._get_compiler()
-        if compiler is None:
-            return CheckResult(success=False, output="No compiler configured")
+        outcome = self._cached_or_compiler(cache_key)
+        if isinstance(outcome, CheckResult):
+            return outcome
+        compiler = outcome
 
         define_lines = ""
         if defines:
@@ -311,14 +315,10 @@ class ToolChecks:
             self._caller_location(),
         )
         cache_key = self._cache_key("type", type_name)
-        cached = self._config.get(cache_key)
-        if cached is not None:
-            trace("configure", "  cached: %s", cached)
-            return CheckResult(success=cached, cached=True)
-
-        compiler = self._get_compiler()
-        if compiler is None:
-            return CheckResult(success=False, output="No compiler configured")
+        outcome = self._cached_or_compiler(cache_key)
+        if isinstance(outcome, CheckResult):
+            return outcome
+        compiler = outcome
 
         includes = ""
         if headers:
@@ -472,14 +472,10 @@ PCONS_UNDEFINED
             self._caller_location(),
         )
         cache_key = self._cache_key("function", function)
-        cached = self._config.get(cache_key)
-        if cached is not None:
-            trace("configure", "  cached: %s", cached)
-            return CheckResult(success=cached, cached=True)
-
-        compiler = self._get_compiler()
-        if compiler is None:
-            return CheckResult(success=False, output="No compiler configured")
+        outcome = self._cached_or_compiler(cache_key)
+        if isinstance(outcome, CheckResult):
+            return outcome
+        compiler = outcome
 
         includes = ""
         if headers:

--- a/pcons/generators/dot.py
+++ b/pcons/generators/dot.py
@@ -11,15 +11,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
-from pcons.core.node import FileNode
-from pcons.generators.generator import BaseGenerator
+from pcons.generators.graph import GraphGenerator
 
 if TYPE_CHECKING:
     from pcons.core.project import Project
     from pcons.core.target import Target
 
 
-class DotGenerator(BaseGenerator):
+class DotGenerator(GraphGenerator):
     """Generator that produces GraphViz DOT diagrams.
 
     Generates the complete dependency graph showing all files:
@@ -75,32 +74,13 @@ class DotGenerator(BaseGenerator):
             output_filename: Name of the output file.
             output_dir: Override output directory (default: project.build_dir).
         """
-        super().__init__("dot")
-        self._include_headers = include_headers
+        super().__init__(
+            "dot",
+            include_headers=include_headers,
+            output_filename=output_filename,
+            output_dir=output_dir,
+        )
         self._rankdir = rankdir
-        self._output_filename = output_filename
-        self._output_dir_override = output_dir
-
-    def _resolve_output_dir(self, project: Project) -> Path:
-        """Use the override output_dir if set, otherwise default."""
-        if self._output_dir_override is not None:
-            return Path(self._output_dir_override)
-        return super()._resolve_output_dir(project)
-
-    def _generate_impl(self, project: Project, output_dir: Path) -> None:
-        """Generate DOT diagram file.
-
-        Args:
-            project: Configured project to visualize.
-            output_dir: Directory to write output file to.
-        """
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_file = output_dir / self._output_filename
-
-        with open(output_file, "w") as f:
-            self._write_header(f, project)
-            self._write_graph(f, project)
-            self._write_footer(f)
 
     def _write_header(self, f: TextIO, project: Project) -> None:
         """Write DOT header."""
@@ -114,145 +94,28 @@ class DotGenerator(BaseGenerator):
         """Write DOT footer."""
         f.write("}\n")
 
-    def _get_label(self, path: Path, build_dir: Path, root_dir: Path) -> str:
-        """Get a display label for a node path.
+    def _nodes_preamble(self) -> str:
+        return "  // Nodes\n"
 
-        Tries build_dir first, then root_dir, then returns as-is.
-        """
-        try:
-            return str(path.relative_to(build_dir))
-        except ValueError:
-            pass
-        try:
-            return str(path.relative_to(root_dir))
-        except ValueError:
-            return str(path)
+    def _edges_preamble(self) -> str:
+        return "\n  // Edges\n"
 
-    def _write_graph(self, f: TextIO, project: Project) -> None:
-        """Write the complete dependency graph.
+    def _source_node_line(self, node_id: str, label: str) -> str:
+        return f'  {node_id} [label="{label}" shape=note];\n'
 
-        Shows all files: sources, objects, libraries, programs.
-        """
-        build_dir = project.build_dir
-        root_dir = project.root_dir
-        written_nodes: set[str] = set()
-        edges: list[tuple[str, str]] = []
+    def _output_node_line(self, node_id: str, label: str, target: Target) -> str:
+        shape, style = self._get_output_shape(target)
+        style_attr = f" style={style}" if style else ""
+        return f'  {node_id} [label="{label}" shape={shape}{style_attr}];\n'
 
-        # Track output node paths and source dep paths for containment edges
-        output_node_paths: dict[Path, str] = {}
-        source_nodes: dict[Path, str] = {}
+    def _object_node_line(self, node_id: str, label: str) -> str:
+        return f'  {node_id} [label="{label}" shape=ellipse];\n'
 
-        def get_id(path: Path) -> str:
-            """Get a unique ID based on the display label."""
-            label = self._get_label(path, build_dir, root_dir)
-            return self._sanitize_id(label)
+    def _header_node_line(self, node_id: str, label: str) -> str:
+        return f'  {node_id} [label="{label}" shape=note];\n'
 
-        def write_source_node(dep: FileNode) -> str:
-            """Write a source dependency node, return its ID."""
-            dep_id = get_id(dep.path)
-            if dep_id not in written_nodes:
-                dep_label = self._get_label(dep.path, build_dir, root_dir)
-                f.write(f'  {dep_id} [label="{dep_label}" shape=note];\n')
-                written_nodes.add(dep_id)
-            source_nodes[dep.path] = dep_id
-            return dep_id
-
-        f.write("  // Nodes\n")
-        for target in project.targets:
-            # Output nodes (libraries, programs, command outputs)
-            for node in target.output_nodes:
-                if isinstance(node, FileNode):
-                    node_id = get_id(node.path)
-                    if node_id not in written_nodes:
-                        label = self._get_label(node.path, build_dir, root_dir)
-                        shape, style = self._get_output_shape(target)
-                        style_attr = f" style={style}" if style else ""
-                        f.write(
-                            f'  {node_id} [label="{label}" shape={shape}{style_attr}];\n'
-                        )
-                        written_nodes.add(node_id)
-                    output_node_paths[node.path] = node_id
-
-                    # Source dependencies directly on output_nodes (for Command targets)
-                    for dep in node.explicit_deps:
-                        if isinstance(dep, FileNode):
-                            dep_id = write_source_node(dep)
-                            edges.append((dep_id, node_id))
-
-            # Object nodes
-            for node in target.intermediate_nodes:
-                if isinstance(node, FileNode):
-                    node_id = get_id(node.path)
-                    if node_id not in written_nodes:
-                        label = self._get_label(node.path, build_dir, root_dir)
-                        f.write(f'  {node_id} [label="{label}" shape=ellipse];\n')
-                        written_nodes.add(node_id)
-
-                    # Source dependencies
-                    for dep in node.explicit_deps:
-                        if isinstance(dep, FileNode):
-                            dep_id = write_source_node(dep)
-                            edges.append((dep_id, node_id))
-
-                    # Header dependencies from .d files (if enabled)
-                    if self._include_headers:
-                        header_deps = self._parse_depfile(node.path)
-                        for header in header_deps:
-                            header_id = get_id(header)
-                            if header_id not in written_nodes:
-                                header_label = self._get_label(
-                                    header, build_dir, root_dir
-                                )
-                                f.write(
-                                    f'  {header_id} [label="{header_label}" shape=note];\n'
-                                )
-                                written_nodes.add(header_id)
-                            edges.append((header_id, node_id))
-
-            # Edges: objects → outputs
-            for output in target.output_nodes:
-                if isinstance(output, FileNode):
-                    output_id = get_id(output.path)
-                    for obj in target.intermediate_nodes:
-                        if isinstance(obj, FileNode):
-                            edges.append((get_id(obj.path), output_id))
-
-            # Edges: dependency libraries → this target's output
-            for output in target.output_nodes:
-                if isinstance(output, FileNode):
-                    output_id = get_id(output.path)
-                    for dep_target in target.dependencies:
-                        for dep_output in dep_target.output_nodes:
-                            if isinstance(dep_output, FileNode):
-                                edges.append((get_id(dep_output.path), output_id))
-
-        # Directory containment edges: connect output nodes to source dep
-        # nodes when the output path is inside the source path (directory).
-        # Normalize paths to labels for comparison since node paths may mix
-        # absolute and relative forms.
-        source_labels: dict[str, str] = {
-            self._get_label(p, build_dir, root_dir): sid
-            for p, sid in source_nodes.items()
-        }
-        output_labels: dict[str, str] = {
-            self._get_label(p, build_dir, root_dir): oid
-            for p, oid in output_node_paths.items()
-        }
-        for source_label, source_id in source_labels.items():
-            source_lpath = Path(source_label)
-            for output_label, output_id in output_labels.items():
-                if output_label != source_label:
-                    if Path(output_label).is_relative_to(source_lpath):
-                        edges.append((output_id, source_id))
-
-        f.write("\n  // Edges\n")
-
-        # Write edges (deduplicated)
-        seen_edges: set[tuple[str, str]] = set()
-        for src, dst in edges:
-            if (src, dst) not in seen_edges:
-                f.write(f"  {src} -> {dst};\n")
-                seen_edges.add((src, dst))
+    def _edge_line(self, src: str, dst: str) -> str:
+        return f"  {src} -> {dst};\n"
 
     def _get_output_shape(self, target: Target) -> tuple[str, str]:
         """Get DOT shape for output node based on target type.
@@ -273,43 +136,3 @@ class DotGenerator(BaseGenerator):
             return ("box", "rounded")  # Rounded box for command outputs
         else:
             return ("box", "")
-
-    def _parse_depfile(self, obj_path: Path) -> list[Path]:
-        """Parse a .d dependency file to extract header dependencies.
-
-        Args:
-            obj_path: Path to the object file (depfile is obj_path + ".d")
-
-        Returns:
-            List of header file paths found in the depfile.
-        """
-        depfile = Path(str(obj_path) + ".d")
-        if not depfile.exists():
-            return []
-
-        headers: list[Path] = []
-        try:
-            content = depfile.read_text()
-            # GCC/Clang .d format: "target: dep1 dep2 dep3 ..."
-            content = content.replace("\\\n", " ")
-            if ":" in content:
-                deps_part = content.split(":", 1)[1]
-                for dep in deps_part.split():
-                    dep_path = Path(dep)
-                    if dep_path.suffix in (".h", ".hpp", ".hxx", ".H"):
-                        dep_str = str(dep_path)
-                        if not dep_str.startswith(("/usr", "/Library", "/System")):
-                            headers.append(dep_path)
-        except (OSError, UnicodeDecodeError):
-            pass
-
-        return headers
-
-    def _sanitize_id(self, name: str) -> str:
-        """Sanitize a name for use as a DOT node ID."""
-        result = name.replace("/", "_").replace("\\", "_")
-        result = result.replace(".", "_").replace("-", "_")
-        result = result.replace(" ", "_").replace(":", "_")
-        if result and result[0].isdigit():
-            result = "n" + result
-        return result

--- a/pcons/generators/graph.py
+++ b/pcons/generators/graph.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: MIT
+"""Shared base for dependency-graph generators (DOT, Mermaid).
+
+DotGenerator and MermaidGenerator walk the resolved target graph identically;
+only the per-node and per-edge text differs. This base implements the traversal
+(`_write_graph`) plus the shared helpers (label resolution, depfile parsing, ID
+sanitization) and delegates formatting to abstract `_*_line` hooks.
+"""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from pathlib import Path
+from typing import TYPE_CHECKING, TextIO
+
+from pcons.core.node import FileNode
+from pcons.generators.generator import BaseGenerator
+
+if TYPE_CHECKING:
+    from pcons.core.project import Project
+    from pcons.core.target import Target
+
+
+class GraphGenerator(BaseGenerator):
+    """Base class for dependency-graph visualizers.
+
+    Subclasses provide the file header/footer and the format-specific node and
+    edge text; the traversal and helpers live here.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        include_headers: bool,
+        output_filename: str,
+        output_dir: Path | None,
+    ) -> None:
+        super().__init__(name)
+        self._include_headers = include_headers
+        self._output_filename = output_filename
+        self._output_dir_override = output_dir
+
+    def _resolve_output_dir(self, project: Project) -> Path:
+        """Use the override output_dir if set, otherwise default."""
+        if self._output_dir_override is not None:
+            return Path(self._output_dir_override)
+        return super()._resolve_output_dir(project)
+
+    def _generate_impl(self, project: Project, output_dir: Path) -> None:
+        """Generate the diagram file."""
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_file = output_dir / self._output_filename
+
+        with open(output_file, "w") as f:
+            self._write_header(f, project)
+            self._write_graph(f, project)
+            self._write_footer(f)
+
+    # --- format-specific hooks (override in subclasses) ---
+
+    @abstractmethod
+    def _write_header(self, f: TextIO, project: Project) -> None:
+        """Write the file header."""
+
+    def _write_footer(self, f: TextIO) -> None:
+        """Write the file footer (none by default)."""
+
+    def _nodes_preamble(self) -> str:
+        """Text emitted before the node block (empty by default)."""
+        return ""
+
+    def _edges_preamble(self) -> str:
+        """Text emitted before the edge block."""
+        return "\n"
+
+    @abstractmethod
+    def _source_node_line(self, node_id: str, label: str) -> str:
+        """Format a source-file node."""
+
+    @abstractmethod
+    def _output_node_line(self, node_id: str, label: str, target: Target) -> str:
+        """Format an output node (library, program, command output)."""
+
+    @abstractmethod
+    def _object_node_line(self, node_id: str, label: str) -> str:
+        """Format an intermediate object node."""
+
+    @abstractmethod
+    def _header_node_line(self, node_id: str, label: str) -> str:
+        """Format a header-dependency node."""
+
+    @abstractmethod
+    def _edge_line(self, src: str, dst: str) -> str:
+        """Format an edge between two node IDs."""
+
+    # --- shared traversal and helpers ---
+
+    def _get_label(self, path: Path, build_dir: Path, root_dir: Path) -> str:
+        """Get a display label for a node path.
+
+        Tries build_dir first, then root_dir, then returns as-is.
+        """
+        try:
+            return str(path.relative_to(build_dir))
+        except ValueError:
+            pass
+        try:
+            return str(path.relative_to(root_dir))
+        except ValueError:
+            return str(path)
+
+    def _write_graph(self, f: TextIO, project: Project) -> None:
+        """Write the complete dependency graph.
+
+        Shows all files: sources, objects, libraries, programs.
+        """
+        build_dir = project.build_dir
+        root_dir = project.root_dir
+        written_nodes: set[str] = set()
+        edges: list[tuple[str, str]] = []
+
+        # Track output node paths and source dep paths for containment edges
+        output_node_paths: dict[Path, str] = {}
+        source_nodes: dict[Path, str] = {}
+
+        def get_id(path: Path) -> str:
+            """Get a unique ID based on the display label."""
+            label = self._get_label(path, build_dir, root_dir)
+            return self._sanitize_id(label)
+
+        def write_source_node(dep: FileNode) -> str:
+            """Write a source dependency node, return its ID."""
+            dep_id = get_id(dep.path)
+            if dep_id not in written_nodes:
+                dep_label = self._get_label(dep.path, build_dir, root_dir)
+                f.write(self._source_node_line(dep_id, dep_label))
+                written_nodes.add(dep_id)
+            source_nodes[dep.path] = dep_id
+            return dep_id
+
+        f.write(self._nodes_preamble())
+        for target in project.targets:
+            # Output nodes (libraries, programs, command outputs)
+            for node in target.output_nodes:
+                if isinstance(node, FileNode):
+                    node_id = get_id(node.path)
+                    if node_id not in written_nodes:
+                        label = self._get_label(node.path, build_dir, root_dir)
+                        f.write(self._output_node_line(node_id, label, target))
+                        written_nodes.add(node_id)
+                    output_node_paths[node.path] = node_id
+
+                    # Source dependencies directly on output_nodes (for Command targets)
+                    for dep in node.explicit_deps:
+                        if isinstance(dep, FileNode):
+                            dep_id = write_source_node(dep)
+                            edges.append((dep_id, node_id))
+
+            # Object nodes
+            for node in target.intermediate_nodes:
+                if isinstance(node, FileNode):
+                    node_id = get_id(node.path)
+                    if node_id not in written_nodes:
+                        label = self._get_label(node.path, build_dir, root_dir)
+                        f.write(self._object_node_line(node_id, label))
+                        written_nodes.add(node_id)
+
+                    # Source dependencies
+                    for dep in node.explicit_deps:
+                        if isinstance(dep, FileNode):
+                            dep_id = write_source_node(dep)
+                            edges.append((dep_id, node_id))
+
+                    # Header dependencies from .d files (if enabled)
+                    if self._include_headers:
+                        header_deps = self._parse_depfile(node.path)
+                        for header in header_deps:
+                            header_id = get_id(header)
+                            if header_id not in written_nodes:
+                                header_label = self._get_label(
+                                    header, build_dir, root_dir
+                                )
+                                f.write(self._header_node_line(header_id, header_label))
+                                written_nodes.add(header_id)
+                            edges.append((header_id, node_id))
+
+            # Edges: objects → outputs
+            for output in target.output_nodes:
+                if isinstance(output, FileNode):
+                    output_id = get_id(output.path)
+                    for obj in target.intermediate_nodes:
+                        if isinstance(obj, FileNode):
+                            edges.append((get_id(obj.path), output_id))
+
+            # Edges: dependency libraries → this target's output
+            for output in target.output_nodes:
+                if isinstance(output, FileNode):
+                    output_id = get_id(output.path)
+                    for dep_target in target.dependencies:
+                        for dep_output in dep_target.output_nodes:
+                            if isinstance(dep_output, FileNode):
+                                edges.append((get_id(dep_output.path), output_id))
+
+        # Directory containment edges: connect output nodes to source dep
+        # nodes when the output path is inside the source path (directory).
+        # Normalize paths to labels for comparison since node paths may mix
+        # absolute and relative forms.
+        source_labels: dict[str, str] = {
+            self._get_label(p, build_dir, root_dir): sid
+            for p, sid in source_nodes.items()
+        }
+        output_labels: dict[str, str] = {
+            self._get_label(p, build_dir, root_dir): oid
+            for p, oid in output_node_paths.items()
+        }
+        for source_label, source_id in source_labels.items():
+            source_lpath = Path(source_label)
+            for output_label, output_id in output_labels.items():
+                if output_label != source_label:
+                    if Path(output_label).is_relative_to(source_lpath):
+                        edges.append((output_id, source_id))
+
+        f.write(self._edges_preamble())
+
+        # Write edges (deduplicated)
+        seen_edges: set[tuple[str, str]] = set()
+        for src, dst in edges:
+            if (src, dst) not in seen_edges:
+                f.write(self._edge_line(src, dst))
+                seen_edges.add((src, dst))
+
+    def _parse_depfile(self, obj_path: Path) -> list[Path]:
+        """Parse a .d dependency file to extract header dependencies.
+
+        Args:
+            obj_path: Path to the object file (depfile is obj_path + ".d")
+
+        Returns:
+            List of header file paths found in the depfile.
+        """
+        depfile = Path(str(obj_path) + ".d")
+        if not depfile.exists():
+            return []
+
+        headers: list[Path] = []
+        try:
+            content = depfile.read_text()
+            # GCC/Clang .d format: "target: dep1 dep2 dep3 ..."
+            content = content.replace("\\\n", " ")
+            if ":" in content:
+                deps_part = content.split(":", 1)[1]
+                for dep in deps_part.split():
+                    dep_path = Path(dep)
+                    if dep_path.suffix in (".h", ".hpp", ".hxx", ".H"):
+                        dep_str = str(dep_path)
+                        if not dep_str.startswith(("/usr", "/Library", "/System")):
+                            headers.append(dep_path)
+        except (OSError, UnicodeDecodeError):
+            pass
+
+        return headers
+
+    def _sanitize_id(self, name: str) -> str:
+        """Sanitize a name for use as a graph node ID."""
+        result = name.replace("/", "_").replace("\\", "_")
+        result = result.replace(".", "_").replace("-", "_")
+        result = result.replace(" ", "_").replace(":", "_")
+        if result and result[0].isdigit():
+            result = "n" + result
+        return result

--- a/pcons/generators/mermaid.py
+++ b/pcons/generators/mermaid.py
@@ -11,15 +11,14 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TextIO
 
-from pcons.core.node import FileNode
-from pcons.generators.generator import BaseGenerator
+from pcons.generators.graph import GraphGenerator
 
 if TYPE_CHECKING:
     from pcons.core.project import Project
     from pcons.core.target import Target
 
 
-class MermaidGenerator(BaseGenerator):
+class MermaidGenerator(GraphGenerator):
     """Generator that produces Mermaid flowchart diagrams.
 
     Generates the complete dependency graph showing all files:
@@ -71,31 +70,13 @@ class MermaidGenerator(BaseGenerator):
             output_filename: Name of the output file.
             output_dir: Override output directory (default: project.build_dir).
         """
-        super().__init__("mermaid")
-        self._include_headers = include_headers
+        super().__init__(
+            "mermaid",
+            include_headers=include_headers,
+            output_filename=output_filename,
+            output_dir=output_dir,
+        )
         self._direction = direction
-        self._output_filename = output_filename
-        self._output_dir_override = output_dir
-
-    def _resolve_output_dir(self, project: Project) -> Path:
-        """Use the override output_dir if set, otherwise default."""
-        if self._output_dir_override is not None:
-            return Path(self._output_dir_override)
-        return super()._resolve_output_dir(project)
-
-    def _generate_impl(self, project: Project, output_dir: Path) -> None:
-        """Generate Mermaid diagram file.
-
-        Args:
-            project: Configured project to visualize.
-            output_dir: Directory to write output file to.
-        """
-        output_dir.mkdir(parents=True, exist_ok=True)
-        output_file = output_dir / self._output_filename
-
-        with open(output_file, "w") as f:
-            self._write_header(f, project)
-            self._write_graph(f, project)
 
     def _write_header(self, f: TextIO, project: Project) -> None:
         """Write Mermaid header."""
@@ -104,139 +85,21 @@ class MermaidGenerator(BaseGenerator):
         f.write("---\n")
         f.write(f"flowchart {self._direction}\n")
 
-    def _get_label(self, path: Path, build_dir: Path, root_dir: Path) -> str:
-        """Get a display label for a node path.
+    def _source_node_line(self, node_id: str, label: str) -> str:
+        return f"  {node_id}>{label}]\n"
 
-        Tries build_dir first, then root_dir, then returns as-is.
-        """
-        try:
-            return str(path.relative_to(build_dir))
-        except ValueError:
-            pass
-        try:
-            return str(path.relative_to(root_dir))
-        except ValueError:
-            return str(path)
+    def _output_node_line(self, node_id: str, label: str, target: Target) -> str:
+        shape = self._get_output_shape(target)
+        return f"  {node_id}{shape[0]}{label}{shape[1]}\n"
 
-    def _write_graph(self, f: TextIO, project: Project) -> None:
-        """Write the complete dependency graph.
+    def _object_node_line(self, node_id: str, label: str) -> str:
+        return f"  {node_id}({label})\n"
 
-        Shows all files: sources, objects, libraries, programs.
-        """
-        build_dir = project.build_dir
-        root_dir = project.root_dir
-        written_nodes: set[str] = set()
-        edges: list[tuple[str, str]] = []
+    def _header_node_line(self, node_id: str, label: str) -> str:
+        return f"  {node_id}>{label}]\n"
 
-        # Track output node paths and source dep paths for containment edges
-        output_node_paths: dict[Path, str] = {}
-        source_nodes: dict[Path, str] = {}
-
-        def get_id(path: Path) -> str:
-            """Get a unique ID based on the display label."""
-            label = self._get_label(path, build_dir, root_dir)
-            return self._sanitize_id(label)
-
-        def write_source_node(dep: FileNode) -> str:
-            """Write a source dependency node, return its ID."""
-            dep_id = get_id(dep.path)
-            if dep_id not in written_nodes:
-                dep_label = self._get_label(dep.path, build_dir, root_dir)
-                f.write(f"  {dep_id}>{dep_label}]\n")
-                written_nodes.add(dep_id)
-            source_nodes[dep.path] = dep_id
-            return dep_id
-
-        for target in project.targets:
-            # Output nodes (libraries, programs, command outputs)
-            for node in target.output_nodes:
-                if isinstance(node, FileNode):
-                    node_id = get_id(node.path)
-                    if node_id not in written_nodes:
-                        label = self._get_label(node.path, build_dir, root_dir)
-                        shape = self._get_output_shape(target)
-                        f.write(f"  {node_id}{shape[0]}{label}{shape[1]}\n")
-                        written_nodes.add(node_id)
-                    output_node_paths[node.path] = node_id
-
-                    # Source dependencies directly on output_nodes (for Command targets)
-                    for dep in node.explicit_deps:
-                        if isinstance(dep, FileNode):
-                            dep_id = write_source_node(dep)
-                            edges.append((dep_id, node_id))
-
-            # Object nodes
-            for node in target.intermediate_nodes:
-                if isinstance(node, FileNode):
-                    node_id = get_id(node.path)
-                    if node_id not in written_nodes:
-                        label = self._get_label(node.path, build_dir, root_dir)
-                        f.write(f"  {node_id}({label})\n")
-                        written_nodes.add(node_id)
-
-                    # Source dependencies
-                    for dep in node.explicit_deps:
-                        if isinstance(dep, FileNode):
-                            dep_id = write_source_node(dep)
-                            edges.append((dep_id, node_id))
-
-                    # Header dependencies from .d files (if enabled)
-                    if self._include_headers:
-                        header_deps = self._parse_depfile(node.path)
-                        for header in header_deps:
-                            header_id = get_id(header)
-                            if header_id not in written_nodes:
-                                header_label = self._get_label(
-                                    header, build_dir, root_dir
-                                )
-                                f.write(f"  {header_id}>{header_label}]\n")
-                                written_nodes.add(header_id)
-                            edges.append((header_id, node_id))
-
-            # Edges: objects → outputs
-            for output in target.output_nodes:
-                if isinstance(output, FileNode):
-                    output_id = get_id(output.path)
-                    for obj in target.intermediate_nodes:
-                        if isinstance(obj, FileNode):
-                            edges.append((get_id(obj.path), output_id))
-
-            # Edges: dependency libraries → this target's output
-            for output in target.output_nodes:
-                if isinstance(output, FileNode):
-                    output_id = get_id(output.path)
-                    for dep_target in target.dependencies:
-                        for dep_output in dep_target.output_nodes:
-                            if isinstance(dep_output, FileNode):
-                                edges.append((get_id(dep_output.path), output_id))
-
-        # Directory containment edges: connect output nodes to source dep
-        # nodes when the output path is inside the source path (directory).
-        # Normalize paths to labels for comparison since node paths may mix
-        # absolute and relative forms.
-        source_labels: dict[str, str] = {
-            self._get_label(p, build_dir, root_dir): sid
-            for p, sid in source_nodes.items()
-        }
-        output_labels: dict[str, str] = {
-            self._get_label(p, build_dir, root_dir): oid
-            for p, oid in output_node_paths.items()
-        }
-        for source_label, source_id in source_labels.items():
-            source_lpath = Path(source_label)
-            for output_label, output_id in output_labels.items():
-                if output_label != source_label:
-                    if Path(output_label).is_relative_to(source_lpath):
-                        edges.append((output_id, source_id))
-
-        f.write("\n")
-
-        # Write edges (deduplicated)
-        seen_edges: set[tuple[str, str]] = set()
-        for src, dst in edges:
-            if (src, dst) not in seen_edges:
-                f.write(f"  {src} --> {dst}\n")
-                seen_edges.add((src, dst))
+    def _edge_line(self, src: str, dst: str) -> str:
+        return f"  {src} --> {dst}\n"
 
     def _get_output_shape(self, target: Target) -> tuple[str, str]:
         """Get Mermaid shape for output node based on target type."""
@@ -253,43 +116,3 @@ class MermaidGenerator(BaseGenerator):
             return ("([", "])")  # Rounded rectangle for command outputs
         else:
             return ("[", "]")
-
-    def _parse_depfile(self, obj_path: Path) -> list[Path]:
-        """Parse a .d dependency file to extract header dependencies.
-
-        Args:
-            obj_path: Path to the object file (depfile is obj_path + ".d")
-
-        Returns:
-            List of header file paths found in the depfile.
-        """
-        depfile = Path(str(obj_path) + ".d")
-        if not depfile.exists():
-            return []
-
-        headers: list[Path] = []
-        try:
-            content = depfile.read_text()
-            # GCC/Clang .d format: "target: dep1 dep2 dep3 ..."
-            content = content.replace("\\\n", " ")
-            if ":" in content:
-                deps_part = content.split(":", 1)[1]
-                for dep in deps_part.split():
-                    dep_path = Path(dep)
-                    if dep_path.suffix in (".h", ".hpp", ".hxx", ".H"):
-                        dep_str = str(dep_path)
-                        if not dep_str.startswith(("/usr", "/Library", "/System")):
-                            headers.append(dep_path)
-        except (OSError, UnicodeDecodeError):
-            pass
-
-        return headers
-
-    def _sanitize_id(self, name: str) -> str:
-        """Sanitize a name for use as a Mermaid node ID."""
-        result = name.replace("/", "_").replace("\\", "_")
-        result = result.replace(".", "_").replace("-", "_")
-        result = result.replace(" ", "_").replace(":", "_")
-        if result and result[0].isdigit():
-            result = "n" + result
-        return result

--- a/pcons/toolchains/_msvc_compat.py
+++ b/pcons/toolchains/_msvc_compat.py
@@ -178,18 +178,8 @@ class MsvcCompatibleToolchain(BaseToolchain):
             logger.warning("Unknown preset '%s' for MSVC toolchain", name)
             return
 
-        compile_flags = preset.get("compile_flags", [])
-        link_flags = preset.get("link_flags", [])
-
-        for tool_name in ("cc", "cxx"):
-            if env.has_tool(tool_name):
-                tool = getattr(env, tool_name)
-                if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                    tool.flags.extend(compile_flags)
-
-        if env.has_tool("link") and link_flags:
-            if isinstance(env.link.flags, list):
-                env.link.flags.extend(link_flags)
+        self._add_tool_flags(env, ("cc", "cxx"), preset.get("compile_flags", []))
+        self._add_tool_flags(env, ("link",), preset.get("link_flags", []))
 
     def apply_cross_preset(self, env: Environment, preset: Any) -> None:
         """Apply a cross-compilation preset with MSVC-style flags.
@@ -207,16 +197,10 @@ class MsvcCompatibleToolchain(BaseToolchain):
 
         # Apply extra compile/link flags and env_vars from base
         if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(preset.extra_compile_flags)
+            self._add_tool_flags(env, ("cc", "cxx"), preset.extra_compile_flags)
 
         if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(preset.extra_link_flags)
+            self._add_tool_flags(env, ("link",), preset.extra_link_flags)
 
         if hasattr(preset, "env_vars") and preset.env_vars:
             for var_name, value in preset.env_vars.items():

--- a/pcons/toolchains/_msvc_compat.py
+++ b/pcons/toolchains/_msvc_compat.py
@@ -243,10 +243,4 @@ class MsvcCompatibleToolchain(BaseToolchain):
         compile_flags.extend(extra_flags)
         defines.extend(extra_defines)
 
-        for tool_name in ("cc", "cxx"):
-            if env.has_tool(tool_name):
-                tool = getattr(env, tool_name)
-                if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                    tool.flags.extend(compile_flags)
-                if hasattr(tool, "defines") and isinstance(tool.defines, list):
-                    tool.defines.extend(defines)
+        self._add_compile_flags_and_defines(env, ("cc", "cxx"), compile_flags, defines)

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -129,7 +129,7 @@ class CompileLinkContext:
         if self.libdirs:
             result["libdirs"] = [ProjectPath(p) for p in self.libdirs]
         if self.libs:
-            result["libs"] = list(self.libs)
+            result["libs"] = self._format_libs(self.libs)
         if self.link_flags:
             # Merge with base flags from env.link.flags so that env-level
             # link flags (e.g., -fsanitize=address) are preserved alongside
@@ -139,6 +139,10 @@ class CompileLinkContext:
             result["cmd"] = self.linker_cmd
 
         return result
+
+    def _format_libs(self, libs: list[str]) -> list[str]:
+        """Format library names for the linker. Base passes them unchanged."""
+        return list(libs)
 
     @classmethod
     def from_effective_requirements(
@@ -261,74 +265,15 @@ class MsvcCompileLinkContext(CompileLinkContext):
     libdir_prefix: str = "/LIBPATH:"
     lib_prefix: str = ""  # MSVC uses full library names (foo.lib)
 
-    def _link_overrides(self) -> dict[str, object]:
-        """Return link-time overrides with MSVC-specific lib formatting."""
-        from pcons.core.subst import ProjectPath
-
-        result: dict[str, object] = {}
-
-        if self.libdirs:
-            result["libdirs"] = [ProjectPath(p) for p in self.libdirs]
-        if self.libs:
-            # MSVC uses full library names (kernel32.lib, not -lkernel32)
-            formatted_libs = []
-            for lib in self.libs:
-                if isinstance(lib, str) and lib.endswith(".lib"):
-                    formatted_libs.append(lib)
-                elif isinstance(lib, str):
-                    formatted_libs.append(f"{lib}.lib")
-                else:
-                    formatted_libs.append(lib)
-            result["libs"] = formatted_libs
-        if self.link_flags:
-            # Merge with base flags from env.link.flags (same as base class)
-            result["flags"] = self._merge_with_base_flags("link", self.link_flags)
-        if self.linker_cmd:
-            result["cmd"] = self.linker_cmd
-
-        return result
-
-    @classmethod
-    def from_effective_requirements(
-        cls,
-        effective: EffectiveRequirements,
-        *,
-        mode: str = "compile",
-        tool_name: str | None = None,
-        language: str | None = None,
-        env: Environment | None = None,
-        target: Target | None = None,
-        output_name: str | None = None,
-    ) -> MsvcCompileLinkContext:
-        """Create a MsvcCompileLinkContext from EffectiveRequirements.
-
-        This factory method bridges the current EffectiveRequirements system
-        to the new context-based approach, with MSVC-style prefixes.
-
-        Args:
-            effective: The computed effective requirements.
-            mode: Which overrides to return: "compile" or "link".
-            tool_name: The tool name for flag merging in compile mode.
-            language: Unused for MSVC (kept for interface compatibility).
-            env: Unused for MSVC (kept for interface compatibility).
-            target: Unused for MSVC (kept for interface compatibility).
-            output_name: Unused for MSVC (kept for interface compatibility).
-
-        Returns:
-            A MsvcCompileLinkContext populated from the requirements.
-        """
-        # MSVC always uses link.exe regardless of language (no linker_cmd override).
-        # Unlike GCC/Clang where g++/clang++ must be used as the linker driver for C++
-        # runtime linkage, MSVC link.exe handles all languages automatically.
-        return cls(
-            includes=[str(p) for p in effective.includes],
-            defines=list(effective.defines),
-            flags=list(effective.compile_flags),
-            link_flags=list(effective.link_flags),
-            libs=[lib for lib in effective.link_libs if not isinstance(lib, Target)],
-            libdirs=[str(p) for p in effective.link_dirs],
-            linker_cmd=None,
-            mode=mode,
-            _tool_name=tool_name,
-            _env=env,
-        )
+    def _format_libs(self, libs: list[str]) -> list[str]:
+        # MSVC uses full library names (kernel32.lib, not -lkernel32).
+        # Non-string entries (e.g. PathToken) pass through unchanged.
+        formatted: list[str] = []
+        for lib in libs:
+            if not isinstance(lib, str):
+                formatted.append(lib)
+            elif lib.endswith(".lib"):
+                formatted.append(lib)
+            else:
+                formatted.append(f"{lib}.lib")
+        return formatted

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -88,6 +88,20 @@ class CompileLinkContext:
             return self._link_overrides()
         return {}
 
+    def _merge_with_base_flags(
+        self, tool_name: str | None, flags: list[str | PathToken]
+    ) -> list[object]:
+        """Prepend env.<tool>.flags to `flags`, dropping duplicates.
+
+        Keeps env-level flags (e.g. -std=c++20, -fsanitize=address) ahead of
+        the target-specific flags from usage requirements.
+        """
+        base_flags: list[object] = []
+        if tool_name and self._env and self._env.has_tool(tool_name):
+            tool_cfg = getattr(self._env, tool_name, None)
+            base_flags = list(getattr(tool_cfg, "flags", None) or [])
+        return base_flags + [f for f in flags if f not in base_flags]
+
     def _compile_overrides(self) -> dict[str, object]:
         """Return compile-time overrides: includes, defines, flags."""
         from pcons.core.subst import ProjectPath
@@ -102,12 +116,7 @@ class CompileLinkContext:
             # Merge with base flags from env.{tool_name}.flags so that
             # language-specific flags (e.g., -std=c++20 on env.cxx.flags)
             # are preserved alongside effective-requirement flags.
-            base_flags: list[object] = []
-            if self._tool_name and self._env and self._env.has_tool(self._tool_name):
-                tool_cfg = getattr(self._env, self._tool_name, None)
-                base_flags = list(getattr(tool_cfg, "flags", None) or [])
-            merged = base_flags + [f for f in self.flags if f not in base_flags]
-            result["flags"] = merged
+            result["flags"] = self._merge_with_base_flags(self._tool_name, self.flags)
 
         return result
 
@@ -125,12 +134,7 @@ class CompileLinkContext:
             # Merge with base flags from env.link.flags so that env-level
             # link flags (e.g., -fsanitize=address) are preserved alongside
             # target-specific link flags from usage requirements.
-            base_flags: list[object] = []
-            if self._env and self._env.has_tool("link"):
-                link_cfg = getattr(self._env, "link", None)
-                base_flags = list(getattr(link_cfg, "flags", None) or [])
-            merged = base_flags + [f for f in self.link_flags if f not in base_flags]
-            result["flags"] = merged
+            result["flags"] = self._merge_with_base_flags("link", self.link_flags)
         if self.linker_cmd:
             result["cmd"] = self.linker_cmd
 
@@ -278,12 +282,7 @@ class MsvcCompileLinkContext(CompileLinkContext):
             result["libs"] = formatted_libs
         if self.link_flags:
             # Merge with base flags from env.link.flags (same as base class)
-            base_flags: list[object] = []
-            if self._env and self._env.has_tool("link"):
-                link_cfg = getattr(self._env, "link", None)
-                base_flags = list(getattr(link_cfg, "flags", None) or [])
-            merged = base_flags + [f for f in self.link_flags if f not in base_flags]
-            result["flags"] = merged
+            result["flags"] = self._merge_with_base_flags("link", self.link_flags)
         if self.linker_cmd:
             result["cmd"] = self.linker_cmd
 

--- a/pcons/toolchains/clang_cl.py
+++ b/pcons/toolchains/clang_cl.py
@@ -79,22 +79,9 @@ class ClangClCompiler(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
+        if not get_platform().is_windows:
             return None
-        platform = get_platform()
-        if not platform.is_windows:
-            return None
-        clang_cl = config.find_program("clang-cl")
-        if clang_cl is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig(self.name, cmd=str(clang_cl.path))
-        if clang_cl.version:
-            tool_config.version = clang_cl.version
-        return tool_config
+        return self._find_tool_config(config, "clang-cl", with_version=True)
 
 
 class ClangClCCompiler(ClangClCompiler):
@@ -163,22 +150,10 @@ class ClangClLibrarian(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        platform = get_platform()
-        if not platform.is_windows:
+        if not get_platform().is_windows:
             return None
         # Prefer llvm-lib, fall back to lib.exe
-        lib = config.find_program("llvm-lib", version_flag="")
-        if lib is None:
-            lib = config.find_program("lib.exe", version_flag="")
-        if lib is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("lib", cmd=str(lib.path))
+        return self._find_tool_config(config, "llvm-lib", "lib.exe", version_flag="")
 
 
 class ClangClLinker(BaseTool):
@@ -239,22 +214,10 @@ class ClangClLinker(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        platform = get_platform()
-        if not platform.is_windows:
+        if not get_platform().is_windows:
             return None
         # Prefer lld-link, fall back to link.exe
-        link = config.find_program("lld-link", version_flag="")
-        if link is None:
-            link = config.find_program("link.exe", version_flag="")
-        if link is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(link.path))
+        return self._find_tool_config(config, "lld-link", "link.exe", version_flag="")
 
 
 class ClangClToolchain(MsvcCompatibleToolchain):

--- a/pcons/toolchains/cuda.py
+++ b/pcons/toolchains/cuda.py
@@ -144,12 +144,7 @@ class CudaToolchain(BaseToolchain):
         defines.extend(extra_defines)
 
         # Apply to CUDA compiler
-        if env.has_tool("cuda"):
-            tool = env.cuda
-            if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                tool.flags.extend(compile_flags)
-            if hasattr(tool, "defines") and isinstance(tool.defines, list):
-                tool.defines.extend(defines)
+        self._add_compile_flags_and_defines(env, ("cuda",), compile_flags, defines)
 
     def _linker_for_language(self, language: str) -> str:
         """CUDA linking is typically handled by the host C++ compiler."""

--- a/pcons/toolchains/cxx_module_scanner.py
+++ b/pcons/toolchains/cxx_module_scanner.py
@@ -646,6 +646,35 @@ def bmi_key_for_flags(flags: list[str], spec: StdModuleFlagSpec) -> str:
     return hashlib.sha1(canonical.encode("utf-8")).hexdigest()[:12]
 
 
+def merge_scan_compile_flags(
+    base_flags: list[str],
+    context: Any,
+    extra_flags: tuple[str, ...] = (),
+) -> list[str]:
+    """Build a per-TU compile-flag list for module scanning.
+
+    Starts from *base_flags*, injects *extra_flags* (deduped, e.g. GCC's
+    ``-fmodules``), then appends the build context's flags (deduped), ``-I``
+    includes, and ``-D`` defines, in that order.
+    """
+    seen = set(base_flags)
+    compile_flags = list(base_flags)
+    for flag in extra_flags:
+        if flag not in seen:
+            compile_flags.append(flag)
+            seen.add(flag)
+    if context:
+        for flag in context.flags:
+            if flag not in seen:
+                compile_flags.append(flag)
+                seen.add(flag)
+        for inc in context.includes:
+            compile_flags.append(f"-I{inc}")
+        for define in context.defines:
+            compile_flags.append(f"-D{define}")
+    return compile_flags
+
+
 def wire_std_into_targets(
     project: Any,
     results: list[TuScanResult],

--- a/pcons/toolchains/cython.py
+++ b/pcons/toolchains/cython.py
@@ -120,7 +120,18 @@ class CythonTranspiler(BaseTool):
         return tool_config
 
 
-class CythonCCompiler(BaseTool):
+class _PythonInfoTool(BaseTool):
+    """BaseTool that lazily caches interpreter info from get_python_info()."""
+
+    _python_info: dict[str, str] | None = None
+
+    def _get_python_info(self) -> dict[str, str]:
+        if self._python_info is None:
+            self._python_info = get_python_info()
+        return self._python_info
+
+
+class CythonCCompiler(_PythonInfoTool):
     """C compiler configured for Cython extension modules.
 
     This is a C compiler with Python-specific settings for building
@@ -137,12 +148,6 @@ class CythonCCompiler(BaseTool):
 
     def __init__(self) -> None:
         super().__init__("cycc", language="c")
-        self._python_info: dict[str, str] | None = None
-
-    def _get_python_info(self) -> dict[str, str]:
-        if self._python_info is None:
-            self._python_info = get_python_info()
-        return self._python_info
 
     def default_vars(self) -> dict[str, object]:
         platform = get_platform()
@@ -228,7 +233,7 @@ class CythonCCompiler(BaseTool):
         return tool_config
 
 
-class CythonLinker(BaseTool):
+class CythonLinker(_PythonInfoTool):
     """Linker for Cython extension modules.
 
     Creates shared libraries (.so/.pyd) that Python can import.
@@ -244,12 +249,6 @@ class CythonLinker(BaseTool):
 
     def __init__(self) -> None:
         super().__init__("cylink")
-        self._python_info: dict[str, str] | None = None
-
-    def _get_python_info(self) -> dict[str, str]:
-        if self._python_info is None:
-            self._python_info = get_python_info()
-        return self._python_info
 
     def default_vars(self) -> dict[str, object]:
         platform = get_platform()

--- a/pcons/toolchains/emscripten.py
+++ b/pcons/toolchains/emscripten.py
@@ -20,18 +20,23 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
-from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
+from pcons.core.builder import MultiOutputBuilder, OutputSpec
 from pcons.core.subst import SourcePath, TargetPath
-from pcons.toolchains.unix import UnixToolchain
+from pcons.toolchains.gnu_common import (
+    gnu_archiver_builders,
+    gnu_archiver_vars,
+    gnu_compile_builders,
+    gnu_compile_vars,
+)
+from pcons.toolchains.wasm_common import WasmToolchain
 from pcons.tools.tool import BaseTool
 
 if TYPE_CHECKING:
     from pcons.core.builder import Builder
     from pcons.core.environment import Environment
     from pcons.core.toolconfig import ToolConfig
-    from pcons.tools.toolchain import SourceHandler
 
 logger = logging.getLogger(__name__)
 
@@ -120,41 +125,10 @@ class EmccCCompiler(BaseTool):
         super().__init__("cc", language="c")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "emcc",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cc.cmd",
-                "$cc.flags",
-                "${prefix(cc.iprefix, cc.includes)}",
-                "${prefix(cc.dprefix, cc.defines)}",
-                "$cc.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-        }
+        return gnu_compile_vars("emcc", "cc")
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cc",
-                "objcmd",
-                src_suffixes=[".c"],
-                target_suffixes=[".o"],
-                language="c",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cc", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -185,41 +159,10 @@ class EmccCxxCompiler(BaseTool):
         super().__init__("cxx", language="cxx")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "em++",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cxx.cmd",
-                "$cxx.flags",
-                "${prefix(cxx.iprefix, cxx.includes)}",
-                "${prefix(cxx.dprefix, cxx.defines)}",
-                "$cxx.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-        }
+        return gnu_compile_vars("em++", "cxx")
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cxx",
-                "objcmd",
-                src_suffixes=[".cpp", ".cxx", ".cc", ".C"],
-                target_suffixes=[".o"],
-                language="cxx",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cxx", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -250,23 +193,10 @@ class EmccArchiver(BaseTool):
         super().__init__("ar")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "emar",
-            "flags": ["rcs"],
-            "libcmd": ["$ar.cmd", "$ar.flags", TargetPath(), SourcePath()],
-        }
+        return gnu_archiver_vars("emar")
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "StaticLibrary": CommandBuilder(
-                "StaticLibrary",
-                "ar",
-                "libcmd",
-                src_suffixes=[".o"],
-                target_suffixes=[".a"],
-                single_source=False,
-            ),
-        }
+        return gnu_archiver_builders(object_suffix=".o", static_lib_suffix=".a")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -365,7 +295,7 @@ class EmccLinker(BaseTool):
 # =============================================================================
 
 
-class EmscriptenToolchain(UnixToolchain):
+class EmscriptenToolchain(WasmToolchain):
     """Emscripten toolchain for compiling C/C++ to WebAssembly + JavaScript.
 
     Uses Emscripten (emcc/em++) to produce ``.js`` + ``.wasm`` pairs.
@@ -379,51 +309,12 @@ class EmscriptenToolchain(UnixToolchain):
 
     TOOL_NAMES = ("cc", "cxx", "ar", "link")
 
+    program_suffix = ".js"
+    platform_label = "Emscripten"
+
     def __init__(self) -> None:
         super().__init__("emscripten")
         self._emsdk_path: Path | None = None
-
-    # -- Suffix / naming overrides ------------------------------------------
-
-    def get_output_prefix(self, target_type: str) -> str:
-        # Emscripten targets Unix-like wasm — always use "lib" prefix
-        # regardless of host platform (e.g., when cross-compiling from Windows).
-        if target_type in ("static_library", "shared_library"):
-            return "lib"
-        return ""
-
-    def get_output_suffix(self, target_type: str) -> str:
-        if target_type == "program":
-            return ".js"
-        if target_type == "shared_library":
-            raise NotImplementedError(
-                "Emscripten does not support shared libraries. "
-                "Use StaticLibrary instead, or target a native platform."
-            )
-        return ".a"  # static library
-
-    def get_compile_flags_for_target_type(self, target_type: str) -> list[str]:
-        # No -fPIC needed for WebAssembly
-        if target_type == "shared_library":
-            raise NotImplementedError("Emscripten does not support shared libraries.")
-        return []
-
-    # -- Source handler ------------------------------------------------------
-
-    def get_source_handler(self, suffix: str) -> SourceHandler | None:
-        """Handle C/C++ sources (no Objective-C or assembly for Emscripten)."""
-        from pcons.tools.toolchain import SourceHandler
-
-        depfile = TargetPath(suffix=".d")
-        # Check case-sensitive .C (C++ on Unix) before lowering
-        if suffix == ".C":
-            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
-        suffix_lower = suffix.lower()
-        if suffix_lower == ".c":
-            return SourceHandler("cc", "c", ".o", depfile, "gcc")
-        if suffix_lower in (".cpp", ".cxx", ".cc", ".c++"):
-            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
-        return None
 
     # -- Configuration -------------------------------------------------------
 
@@ -480,24 +371,6 @@ class EmscriptenToolchain(UnixToolchain):
                     env.cxx.cmd = str(emcc_dir / "em++")
                 if env.has_tool("ar"):
                     env.ar.cmd = str(emcc_dir / "emar")
-
-    # -- Variant / arch overrides -------------------------------------------
-
-    def apply_target_arch(self, env: Environment, arch: str, **kwargs: Any) -> None:
-        # wasm32 is the only architecture; ignore arch requests
-        super(UnixToolchain, self).apply_target_arch(env, "wasm32", **kwargs)
-
-    def apply_cross_preset(self, env: Environment, preset: Any) -> None:
-        if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(preset.extra_compile_flags)
-        if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(preset.extra_link_flags)
 
 
 # =============================================================================

--- a/pcons/toolchains/emscripten.py
+++ b/pcons/toolchains/emscripten.py
@@ -103,6 +103,15 @@ def _find_emcc_dir(emsdk_path: Path) -> Path | None:
     return None
 
 
+def _emsdk_hints() -> list[Path | str] | None:
+    """Search hints pointing at an emsdk's emcc directory, if one is found."""
+    emsdk = find_emsdk()
+    if not emsdk:
+        return None
+    emcc_dir = _find_emcc_dir(emsdk)
+    return [emcc_dir] if emcc_dir else None
+
+
 def is_emcc_available() -> bool:
     """Check whether emcc is available (either via emsdk or PATH)."""
     env_path = os.environ.get("EMSDK")
@@ -131,25 +140,9 @@ class EmccCCompiler(BaseTool):
         return gnu_compile_builders("cc", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        emsdk = find_emsdk()
-        if emsdk:
-            emcc_dir = _find_emcc_dir(emsdk)
-            hints: list[Path | str] = [emcc_dir] if emcc_dir else []
-            emcc = config.find_program("emcc", hints=hints)
-        else:
-            emcc = config.find_program("emcc")
-        if emcc is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cc", cmd=str(emcc.path))
-        if emcc.version:
-            tool_config.version = emcc.version
-        return tool_config
+        return self._find_tool_config(
+            config, "emcc", hints=_emsdk_hints(), with_version=True
+        )
 
 
 class EmccCxxCompiler(BaseTool):
@@ -165,25 +158,9 @@ class EmccCxxCompiler(BaseTool):
         return gnu_compile_builders("cxx", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        emsdk = find_emsdk()
-        if emsdk:
-            emcc_dir = _find_emcc_dir(emsdk)
-            hints: list[Path | str] = [emcc_dir] if emcc_dir else []
-            empp = config.find_program("em++", hints=hints)
-        else:
-            empp = config.find_program("em++")
-        if empp is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cxx", cmd=str(empp.path))
-        if empp.version:
-            tool_config.version = empp.version
-        return tool_config
+        return self._find_tool_config(
+            config, "em++", hints=_emsdk_hints(), with_version=True
+        )
 
 
 class EmccArchiver(BaseTool):
@@ -199,22 +176,7 @@ class EmccArchiver(BaseTool):
         return gnu_archiver_builders(object_suffix=".o", static_lib_suffix=".a")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        emsdk = find_emsdk()
-        if emsdk:
-            emcc_dir = _find_emcc_dir(emsdk)
-            hints: list[Path | str] = [emcc_dir] if emcc_dir else []
-            emar = config.find_program("emar", hints=hints)
-        else:
-            emar = config.find_program("emar")
-        if emar is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("ar", cmd=str(emar.path))
+        return self._find_tool_config(config, "emar", hints=_emsdk_hints())
 
 
 class EmccLinker(BaseTool):
@@ -272,22 +234,7 @@ class EmccLinker(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        emsdk = find_emsdk()
-        if emsdk:
-            emcc_dir = _find_emcc_dir(emsdk)
-            hints: list[Path | str] = [emcc_dir] if emcc_dir else []
-            emcc = config.find_program("emcc", hints=hints)
-        else:
-            emcc = config.find_program("emcc")
-        if emcc is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(emcc.path))
+        return self._find_tool_config(config, "emcc", hints=_emsdk_hints())
 
 
 # =============================================================================

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -17,10 +17,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pcons.configure.platform import get_platform
-from pcons.core.builder import CommandBuilder
 from pcons.core.node import FileNode
-from pcons.core.subst import PathToken, SourcePath, TargetPath
+from pcons.core.subst import PathToken, TargetPath
 from pcons.toolchains.gnu_common import (
+    gnu_archiver_builders,
+    gnu_archiver_vars,
+    gnu_compile_builders,
     gnu_compile_vars,
     gnu_link_builders,
     gnu_link_vars,
@@ -184,20 +186,7 @@ class GccCCompiler(BaseTool):
         return gnu_compile_vars("gcc", "cc")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cc",
-                "objcmd",
-                src_suffixes=[".c"],
-                target_suffixes=[platform.object_suffix],
-                language="c",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cc")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -240,20 +229,7 @@ class GccCxxCompiler(BaseTool):
         return gnu_compile_vars("g++", "cxx")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cxx",
-                "objcmd",
-                src_suffixes=[".cpp", ".cxx", ".cc", ".C"],
-                target_suffixes=[platform.object_suffix],
-                language="cxx",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cxx")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -288,24 +264,10 @@ class GccArchiver(BaseTool):
         super().__init__("ar")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "ar",
-            "flags": ["rcs"],
-            "libcmd": ["$ar.cmd", "$ar.flags", TargetPath(), SourcePath()],
-        }
+        return gnu_archiver_vars("ar")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "StaticLibrary": CommandBuilder(
-                "StaticLibrary",
-                "ar",
-                "libcmd",
-                src_suffixes=[platform.object_suffix],
-                target_suffixes=[platform.static_lib_suffix],
-                single_source=False,
-            ),
-        }
+        return gnu_archiver_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -421,6 +421,7 @@ class GccToolchain(UnixToolchain):
             build_keyed_entries,
             keyed_bmi_path,
             map_module_providers,
+            merge_scan_compile_flags,
             scan_translation_units,
             select_modules_scope,
             wire_std_into_targets,
@@ -478,20 +479,9 @@ class GccToolchain(UnixToolchain):
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
-            seen: set[str] = set(base_flags)
-            compile_flags = list(base_flags)
-            if modules_flag not in seen:
-                compile_flags.append(modules_flag)
-                seen.add(modules_flag)
-            if context:
-                for f in context.flags:
-                    if f not in seen:
-                        compile_flags.append(f)
-                        seen.add(f)
-                for inc in context.includes:
-                    compile_flags.append(f"-I{inc}")
-                for d in context.defines:
-                    compile_flags.append(f"-D{d}")
+            compile_flags = merge_scan_compile_flags(
+                base_flags, context, extra_flags=(modules_flag,)
+            )
 
             # For module interfaces, insert a scan step to generate the depfile.
             if src in module_src_paths:

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -189,23 +189,7 @@ class GccCCompiler(BaseTool):
         return gnu_compile_builders("cc")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        gcc = config.find_program("gcc")
-        if gcc is None:
-            gcc = config.find_program("cc")
-        if gcc is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cc", cmd=str(gcc.path))
-        if gcc.version:
-            tool_config.version = gcc.version
-        return tool_config
+        return self._find_tool_config(config, "gcc", "cc", with_version=True)
 
 
 class GccCxxCompiler(BaseTool):
@@ -232,23 +216,7 @@ class GccCxxCompiler(BaseTool):
         return gnu_compile_builders("cxx")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        gxx = config.find_program("g++")
-        if gxx is None:
-            gxx = config.find_program("c++")
-        if gxx is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cxx", cmd=str(gxx.path))
-        if gxx.version:
-            tool_config.version = gxx.version
-        return tool_config
+        return self._find_tool_config(config, "g++", "c++", with_version=True)
 
 
 class GccArchiver(BaseTool):
@@ -270,18 +238,7 @@ class GccArchiver(BaseTool):
         return gnu_archiver_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        ar = config.find_program("ar")
-        if ar is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("ar", cmd=str(ar.path))
+        return self._find_tool_config(config, "ar")
 
 
 class GccLinker(BaseTool):
@@ -312,20 +269,7 @@ class GccLinker(BaseTool):
         return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        gcc = config.find_program("gcc")
-        if gcc is None:
-            gcc = config.find_program("cc")
-        if gcc is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(gcc.path))
+        return self._find_tool_config(config, "gcc", "cc")
 
 
 def _build_scan_node(

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -17,10 +17,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pcons.configure.platform import get_platform
-from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
+from pcons.core.builder import CommandBuilder
 from pcons.core.node import FileNode
 from pcons.core.subst import PathToken, SourcePath, TargetPath
-from pcons.toolchains.gnu_common import gnu_compile_vars, gnu_link_vars
+from pcons.toolchains.gnu_common import (
+    gnu_compile_vars,
+    gnu_link_builders,
+    gnu_link_vars,
+)
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 
@@ -343,27 +347,7 @@ class GccLinker(BaseTool):
         return gnu_link_vars("gcc")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Program": CommandBuilder(
-                "Program",
-                "link",
-                "progcmd",
-                src_suffixes=[platform.object_suffix],
-                target_suffixes=[platform.exe_suffix],
-                single_source=False,
-            ),
-            "SharedLibrary": MultiOutputBuilder(
-                "SharedLibrary",
-                "link",
-                "sharedcmd",
-                outputs=[
-                    OutputSpec("primary", platform.shared_lib_suffix),
-                ],
-                src_suffixes=[platform.object_suffix],
-                single_source=False,
-            ),
-        }
+        return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/gcc.py
+++ b/pcons/toolchains/gcc.py
@@ -20,6 +20,7 @@ from pcons.configure.platform import get_platform
 from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
 from pcons.core.node import FileNode
 from pcons.core.subst import PathToken, SourcePath, TargetPath
+from pcons.toolchains.gnu_common import gnu_compile_vars, gnu_link_vars
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 
@@ -176,26 +177,7 @@ class GccCCompiler(BaseTool):
         super().__init__("cc", language="c")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "gcc",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cc.cmd",
-                "$cc.flags",
-                "${prefix(cc.iprefix, cc.includes)}",
-                "${prefix(cc.dprefix, cc.defines)}",
-                "$cc.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-        }
+        return gnu_compile_vars("gcc", "cc")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()
@@ -251,26 +233,7 @@ class GccCxxCompiler(BaseTool):
         super().__init__("cxx", language="cxx")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "g++",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cxx.cmd",
-                "$cxx.flags",
-                "${prefix(cxx.iprefix, cxx.includes)}",
-                "${prefix(cxx.dprefix, cxx.defines)}",
-                "$cxx.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-        }
+        return gnu_compile_vars("g++", "cxx")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()
@@ -377,44 +340,7 @@ class GccLinker(BaseTool):
         super().__init__("link")
 
     def default_vars(self) -> dict[str, object]:
-        platform = get_platform()
-        shared_flag = "-dynamiclib" if platform.is_macos else "-shared"
-        return {
-            "cmd": "gcc",
-            "flags": [],
-            "lprefix": "-l",
-            "libs": [],
-            "Lprefix": "-L",
-            "libdirs": [],
-            # Framework support (macOS only, but always defined for portability)
-            "Fprefix": "-F",
-            "frameworkdirs": [],
-            "fprefix": "-framework",
-            "frameworks": [],
-            "progcmd": [
-                "$link.cmd",
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-            "sharedcmd": [
-                "$link.cmd",
-                shared_flag,
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-        }
+        return gnu_link_vars("gcc")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()

--- a/pcons/toolchains/gfortran.py
+++ b/pcons/toolchains/gfortran.py
@@ -17,10 +17,10 @@ from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
 from pcons.configure.platform import get_platform
-from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
+from pcons.core.builder import CommandBuilder
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.toolchains.gcc import GccArchiver
-from pcons.toolchains.gnu_common import gnu_link_vars
+from pcons.toolchains.gnu_common import gnu_link_builders, gnu_link_vars
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 
@@ -160,27 +160,7 @@ class GfortranLinker(BaseTool):
         return gnu_link_vars("gfortran")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Program": CommandBuilder(
-                "Program",
-                "link",
-                "progcmd",
-                src_suffixes=[platform.object_suffix],
-                target_suffixes=[platform.exe_suffix],
-                single_source=False,
-            ),
-            "SharedLibrary": MultiOutputBuilder(
-                "SharedLibrary",
-                "link",
-                "sharedcmd",
-                outputs=[
-                    OutputSpec("primary", platform.shared_lib_suffix),
-                ],
-                src_suffixes=[platform.object_suffix],
-                single_source=False,
-            ),
-        }
+        return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/gfortran.py
+++ b/pcons/toolchains/gfortran.py
@@ -128,21 +128,7 @@ class GfortranCompiler(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        gfortran = config.find_program("gfortran")
-        if gfortran is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("fc", cmd=str(gfortran.path))
-        if gfortran.version:
-            tool_config.version = gfortran.version
-        return tool_config
+        return self._find_tool_config(config, "gfortran", with_version=True)
 
 
 class GfortranLinker(BaseTool):
@@ -163,18 +149,7 @@ class GfortranLinker(BaseTool):
         return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-
-        gfortran = config.find_program("gfortran")
-        if gfortran is None:
-            return None
-
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(gfortran.path))
+        return self._find_tool_config(config, "gfortran")
 
 
 class GfortranToolchain(UnixToolchain):

--- a/pcons/toolchains/gfortran.py
+++ b/pcons/toolchains/gfortran.py
@@ -20,6 +20,7 @@ from pcons.configure.platform import get_platform
 from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.toolchains.gcc import GccArchiver
+from pcons.toolchains.gnu_common import gnu_link_vars
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 
@@ -156,43 +157,7 @@ class GfortranLinker(BaseTool):
         super().__init__("link")
 
     def default_vars(self) -> dict[str, object]:
-        platform = get_platform()
-        shared_flag = "-dynamiclib" if platform.is_macos else "-shared"
-        return {
-            "cmd": "gfortran",
-            "flags": [],
-            "lprefix": "-l",
-            "libs": [],
-            "Lprefix": "-L",
-            "libdirs": [],
-            "Fprefix": "-F",
-            "frameworkdirs": [],
-            "fprefix": "-framework",
-            "frameworks": [],
-            "progcmd": [
-                "$link.cmd",
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-            "sharedcmd": [
-                "$link.cmd",
-                shared_flag,
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-        }
+        return gnu_link_vars("gfortran")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()

--- a/pcons/toolchains/gnu_common.py
+++ b/pcons/toolchains/gnu_common.py
@@ -4,8 +4,8 @@
 GCC, LLVM/Clang, and gfortran share the same option syntax: -I/-D for
 includes/defines, -l/-L for libraries, -F/-framework for macOS frameworks, and
 -MD/-MF for dependency generation. These factories build the `default_vars`
-dicts so each tool only specifies what differs (its command name and any extra
-keys).
+dicts and `builders()` maps so each tool only specifies what differs (its
+command name and any extra keys).
 """
 
 from __future__ import annotations
@@ -83,6 +83,80 @@ def gnu_link_vars(cmd: str) -> dict[str, object]:
         "frameworks": [],
         "progcmd": ["$link.cmd", "$link.flags", *_link_tail()],
         "sharedcmd": ["$link.cmd", shared_flag, "$link.flags", *_link_tail()],
+    }
+
+
+# src_suffixes and language for each compile namespace.
+_COMPILE_SOURCES: dict[str, tuple[list[str], str]] = {
+    "cc": ([".c"], "c"),
+    "cxx": ([".cpp", ".cxx", ".cc", ".C"], "cxx"),
+}
+
+
+def gnu_compile_builders(
+    ns: str, *, object_suffix: str | None = None
+) -> dict[str, Builder]:
+    """The {'Object': ...} builder for a GNU-style compile tool.
+
+    Args:
+        ns: Tool namespace ("cc" or "cxx").
+        object_suffix: Object-file suffix. Defaults to the host platform's
+            (".o"/".obj"); pass ".o" explicitly for wasm toolchains that always
+            emit ".o" regardless of host.
+    """
+    src_suffixes, language = _COMPILE_SOURCES[ns]
+    if object_suffix is None:
+        object_suffix = get_platform().object_suffix
+    return {
+        "Object": CommandBuilder(
+            "Object",
+            ns,
+            "objcmd",
+            src_suffixes=src_suffixes,
+            target_suffixes=[object_suffix],
+            language=language,
+            single_source=True,
+            depfile=TargetPath(suffix=".d"),
+            deps_style="gcc",
+        ),
+    }
+
+
+def gnu_archiver_vars(cmd: str) -> dict[str, object]:
+    """Default vars for a GNU-style archiver (ar, llvm-ar, emar).
+
+    Args:
+        cmd: Default archiver command.
+    """
+    return {
+        "cmd": cmd,
+        "flags": ["rcs"],
+        "libcmd": ["$ar.cmd", "$ar.flags", TargetPath(), SourcePath()],
+    }
+
+
+def gnu_archiver_builders(
+    *, object_suffix: str | None = None, static_lib_suffix: str | None = None
+) -> dict[str, Builder]:
+    """The {'StaticLibrary': ...} builder for a GNU-style archiver.
+
+    Suffixes default to the host platform's; pass ".o"/".a" explicitly for wasm
+    toolchains that use those regardless of host.
+    """
+    platform = get_platform()
+    if object_suffix is None:
+        object_suffix = platform.object_suffix
+    if static_lib_suffix is None:
+        static_lib_suffix = platform.static_lib_suffix
+    return {
+        "StaticLibrary": CommandBuilder(
+            "StaticLibrary",
+            "ar",
+            "libcmd",
+            src_suffixes=[object_suffix],
+            target_suffixes=[static_lib_suffix],
+            single_source=False,
+        ),
     }
 
 

--- a/pcons/toolchains/gnu_common.py
+++ b/pcons/toolchains/gnu_common.py
@@ -20,23 +20,28 @@ if TYPE_CHECKING:
     from pcons.core.builder import Builder
 
 
-def gnu_compile_vars(cmd: str, ns: str) -> dict[str, object]:
+def gnu_compile_vars(
+    cmd: str,
+    ns: str,
+    *,
+    target_tokens: list[str] | None = None,
+    extra_vars: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Default vars for a GNU-style compile tool (gcc/g++/clang/clang++).
 
     Args:
         cmd: Default compiler command (e.g. "gcc", "clang++").
         ns: Tool namespace ("cc" or "cxx"), used to build the $ns.* references.
+        target_tokens: Extra tokens inserted right after the command, before
+            flags (e.g. ["--target=wasm32-wasi", "$cc.sysroot_flag"] for WASI).
+        extra_vars: Additional default vars merged into the result (e.g. WASI's
+            "sysroot_flag" placeholder).
     """
-    return {
-        "cmd": cmd,
-        "flags": [],
-        "iprefix": "-I",
-        "includes": [],
-        "dprefix": "-D",
-        "defines": [],
-        "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-        "objcmd": [
-            f"${ns}.cmd",
+    objcmd: list[object] = [f"${ns}.cmd"]
+    if target_tokens:
+        objcmd.extend(target_tokens)
+    objcmd.extend(
+        [
             f"${ns}.flags",
             f"${{prefix({ns}.iprefix, {ns}.includes)}}",
             f"${{prefix({ns}.dprefix, {ns}.defines)}}",
@@ -45,8 +50,21 @@ def gnu_compile_vars(cmd: str, ns: str) -> dict[str, object]:
             "-o",
             TargetPath(),
             SourcePath(),
-        ],
+        ]
+    )
+    result: dict[str, object] = {
+        "cmd": cmd,
+        "flags": [],
+        "iprefix": "-I",
+        "includes": [],
+        "dprefix": "-D",
+        "defines": [],
+        "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
+        "objcmd": objcmd,
     }
+    if extra_vars:
+        result.update(extra_vars)
+    return result
 
 
 def _link_tail() -> list[object]:

--- a/pcons/toolchains/gnu_common.py
+++ b/pcons/toolchains/gnu_common.py
@@ -10,8 +10,14 @@ keys).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pcons.configure.platform import get_platform
+from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
 from pcons.core.subst import SourcePath, TargetPath
+
+if TYPE_CHECKING:
+    from pcons.core.builder import Builder
 
 
 def gnu_compile_vars(cmd: str, ns: str) -> dict[str, object]:
@@ -77,4 +83,33 @@ def gnu_link_vars(cmd: str) -> dict[str, object]:
         "frameworks": [],
         "progcmd": ["$link.cmd", "$link.flags", *_link_tail()],
         "sharedcmd": ["$link.cmd", shared_flag, "$link.flags", *_link_tail()],
+    }
+
+
+def gnu_link_builders() -> dict[str, Builder]:
+    """Program and SharedLibrary builders shared by GNU-style linkers.
+
+    Identical for gcc, clang, and gfortran: link object files into an
+    executable (progcmd) or a shared library (sharedcmd).
+    """
+    platform = get_platform()
+    return {
+        "Program": CommandBuilder(
+            "Program",
+            "link",
+            "progcmd",
+            src_suffixes=[platform.object_suffix],
+            target_suffixes=[platform.exe_suffix],
+            single_source=False,
+        ),
+        "SharedLibrary": MultiOutputBuilder(
+            "SharedLibrary",
+            "link",
+            "sharedcmd",
+            outputs=[
+                OutputSpec("primary", platform.shared_lib_suffix),
+            ],
+            src_suffixes=[platform.object_suffix],
+            single_source=False,
+        ),
     }

--- a/pcons/toolchains/gnu_common.py
+++ b/pcons/toolchains/gnu_common.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+"""Shared GNU-style command-line conventions for GCC, Clang, and gfortran.
+
+GCC, LLVM/Clang, and gfortran share the same option syntax: -I/-D for
+includes/defines, -l/-L for libraries, -F/-framework for macOS frameworks, and
+-MD/-MF for dependency generation. These factories build the `default_vars`
+dicts so each tool only specifies what differs (its command name and any extra
+keys).
+"""
+
+from __future__ import annotations
+
+from pcons.configure.platform import get_platform
+from pcons.core.subst import SourcePath, TargetPath
+
+
+def gnu_compile_vars(cmd: str, ns: str) -> dict[str, object]:
+    """Default vars for a GNU-style compile tool (gcc/g++/clang/clang++).
+
+    Args:
+        cmd: Default compiler command (e.g. "gcc", "clang++").
+        ns: Tool namespace ("cc" or "cxx"), used to build the $ns.* references.
+    """
+    return {
+        "cmd": cmd,
+        "flags": [],
+        "iprefix": "-I",
+        "includes": [],
+        "dprefix": "-D",
+        "defines": [],
+        "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
+        "objcmd": [
+            f"${ns}.cmd",
+            f"${ns}.flags",
+            f"${{prefix({ns}.iprefix, {ns}.includes)}}",
+            f"${{prefix({ns}.dprefix, {ns}.defines)}}",
+            f"${ns}.depflags",
+            "-c",
+            "-o",
+            TargetPath(),
+            SourcePath(),
+        ],
+    }
+
+
+def _link_tail() -> list[object]:
+    """Tokens shared by progcmd and sharedcmd (fresh instances per call)."""
+    return [
+        "-o",
+        TargetPath(),
+        SourcePath(),
+        "${prefix(link.Lprefix, link.libdirs)}",
+        "${prefix(link.lprefix, link.libs)}",
+        "${prefix(link.Fprefix, link.frameworkdirs)}",
+        "${pairwise(link.fprefix, link.frameworks)}",
+    ]
+
+
+def gnu_link_vars(cmd: str) -> dict[str, object]:
+    """Default vars for a GNU-style link tool (gcc/clang/gfortran).
+
+    Args:
+        cmd: Default linker command (e.g. "gcc", "clang", "gfortran").
+    """
+    shared_flag = "-dynamiclib" if get_platform().is_macos else "-shared"
+    return {
+        "cmd": cmd,
+        "flags": [],
+        "lprefix": "-l",
+        "libs": [],
+        "Lprefix": "-L",
+        "libdirs": [],
+        # Framework support (macOS only, but always defined for portability)
+        "Fprefix": "-F",
+        "frameworkdirs": [],
+        "fprefix": "-framework",
+        "frameworks": [],
+        "progcmd": ["$link.cmd", "$link.flags", *_link_tail()],
+        "sharedcmd": ["$link.cmd", shared_flag, "$link.flags", *_link_tail()],
+    }

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -440,6 +440,7 @@ class LlvmToolchain(UnixToolchain):
             build_keyed_entries,
             keyed_bmi_path,
             map_module_providers,
+            merge_scan_compile_flags,
             scan_translation_units,
             select_modules_scope,
             wire_std_into_targets,
@@ -493,17 +494,7 @@ class LlvmToolchain(UnixToolchain):
         for src, obj_node in all_cxx_pairs:
             bi = getattr(obj_node, "_build_info", None)
             context = bi.get("context") if bi else None
-            seen: set[str] = set(base_flags)
-            compile_flags = list(base_flags)
-            if context:
-                for f in context.flags:
-                    if f not in seen:
-                        compile_flags.append(f)
-                        seen.add(f)
-                for inc in context.includes:
-                    compile_flags.append(f"-I{inc}")
-                for d in context.defines:
-                    compile_flags.append(f"-D{d}")
+            compile_flags = merge_scan_compile_flags(base_flags, context)
 
             spec = TuScanSpec(
                 src=src.resolve(),

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -10,10 +10,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from pcons.configure.platform import get_platform
-from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
+from pcons.core.builder import CommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.subst import SourcePath, TargetPath
-from pcons.toolchains.gnu_common import gnu_compile_vars, gnu_link_vars
+from pcons.toolchains.gnu_common import (
+    gnu_compile_vars,
+    gnu_link_builders,
+    gnu_link_vars,
+)
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 from pcons.tools.toolchain import CXX_MODULE_INTERFACE_SUFFIXES
@@ -324,27 +328,7 @@ class LlvmLinker(BaseTool):
         return gnu_link_vars("clang")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Program": CommandBuilder(
-                "Program",
-                "link",
-                "progcmd",
-                src_suffixes=[platform.object_suffix],
-                target_suffixes=[platform.exe_suffix],
-                single_source=False,
-            ),
-            "SharedLibrary": MultiOutputBuilder(
-                "SharedLibrary",
-                "link",
-                "sharedcmd",
-                outputs=[
-                    OutputSpec("primary", platform.shared_lib_suffix),
-                ],
-                src_suffixes=[platform.object_suffix],
-                single_source=False,
-            ),
-        }
+        return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -188,19 +188,7 @@ class ClangCCompiler(BaseTool):
         return gnu_compile_builders("cc")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        clang = config.find_program("clang")
-        if clang is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cc", cmd=str(clang.path))
-        if clang.version:
-            tool_config.version = clang.version
-        return tool_config
+        return self._find_tool_config(config, "clang", with_version=True)
 
 
 class ClangCxxCompiler(BaseTool):
@@ -220,19 +208,7 @@ class ClangCxxCompiler(BaseTool):
         return gnu_compile_builders("cxx")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        clangxx = config.find_program("clang++")
-        if clangxx is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cxx", cmd=str(clangxx.path))
-        if clangxx.version:
-            tool_config.version = clangxx.version
-        return tool_config
+        return self._find_tool_config(config, "clang++", with_version=True)
 
 
 class LlvmArchiver(BaseTool):
@@ -252,18 +228,7 @@ class LlvmArchiver(BaseTool):
         return gnu_archiver_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        ar = config.find_program("llvm-ar")
-        if ar is None:
-            ar = config.find_program("ar")
-        if ar is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("ar", cmd=str(ar.path))
+        return self._find_tool_config(config, "llvm-ar", "ar")
 
 
 class LlvmLinker(BaseTool):
@@ -294,16 +259,7 @@ class LlvmLinker(BaseTool):
         return gnu_link_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        clang = config.find_program("clang")
-        if clang is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(clang.path))
+        return self._find_tool_config(config, "clang")
 
 
 class MetalCompiler(BaseTool):

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -14,6 +14,9 @@ from pcons.core.builder import CommandBuilder
 from pcons.core.environment import Environment
 from pcons.core.subst import SourcePath, TargetPath
 from pcons.toolchains.gnu_common import (
+    gnu_archiver_builders,
+    gnu_archiver_vars,
+    gnu_compile_builders,
     gnu_compile_vars,
     gnu_link_builders,
     gnu_link_vars,
@@ -182,20 +185,7 @@ class ClangCCompiler(BaseTool):
         return gnu_compile_vars("clang", "cc")
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cc",
-                "objcmd",
-                src_suffixes=[".c"],
-                target_suffixes=[platform.object_suffix],
-                language="c",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cc")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -227,20 +217,7 @@ class ClangCxxCompiler(BaseTool):
         }
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cxx",
-                "objcmd",
-                src_suffixes=[".cpp", ".cxx", ".cc", ".C"],
-                target_suffixes=[platform.object_suffix],
-                language="cxx",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cxx")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -269,24 +246,10 @@ class LlvmArchiver(BaseTool):
 
         # Prefer llvm-ar if available, otherwise fall back to ar
         ar_cmd = "llvm-ar" if shutil.which("llvm-ar") else "ar"
-        return {
-            "cmd": ar_cmd,
-            "flags": ["rcs"],
-            "libcmd": ["$ar.cmd", "$ar.flags", TargetPath(), SourcePath()],
-        }
+        return gnu_archiver_vars(ar_cmd)
 
     def builders(self) -> dict[str, Builder]:
-        platform = get_platform()
-        return {
-            "StaticLibrary": CommandBuilder(
-                "StaticLibrary",
-                "ar",
-                "libcmd",
-                src_suffixes=[platform.object_suffix],
-                target_suffixes=[platform.static_lib_suffix],
-                single_source=False,
-            ),
-        }
+        return gnu_archiver_builders()
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -13,6 +13,7 @@ from pcons.configure.platform import get_platform
 from pcons.core.builder import CommandBuilder, MultiOutputBuilder, OutputSpec
 from pcons.core.environment import Environment
 from pcons.core.subst import SourcePath, TargetPath
+from pcons.toolchains.gnu_common import gnu_compile_vars, gnu_link_vars
 from pcons.toolchains.unix import UnixToolchain
 from pcons.tools.tool import BaseTool
 from pcons.tools.toolchain import CXX_MODULE_INTERFACE_SUFFIXES
@@ -174,26 +175,7 @@ class ClangCCompiler(BaseTool):
         super().__init__("cc", language="c")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "clang",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cc.cmd",
-                "$cc.flags",
-                "${prefix(cc.iprefix, cc.includes)}",
-                "${prefix(cc.dprefix, cc.defines)}",
-                "$cc.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-        }
+        return gnu_compile_vars("clang", "cc")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()
@@ -235,26 +217,9 @@ class ClangCxxCompiler(BaseTool):
 
     def default_vars(self) -> dict[str, object]:
         return {
-            "cmd": "clang++",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
+            **gnu_compile_vars("clang++", "cxx"),
             "moddir": "cxx_modules",
             "modules": False,  # set True to enable C++20 module scanning
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cxx.cmd",
-                "$cxx.flags",
-                "${prefix(cxx.iprefix, cxx.includes)}",
-                "${prefix(cxx.dprefix, cxx.defines)}",
-                "$cxx.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
         }
 
     def builders(self) -> dict[str, Builder]:
@@ -356,44 +321,7 @@ class LlvmLinker(BaseTool):
         super().__init__("link")
 
     def default_vars(self) -> dict[str, object]:
-        platform = get_platform()
-        shared_flag = "-dynamiclib" if platform.is_macos else "-shared"
-        return {
-            "cmd": "clang",
-            "flags": [],
-            "lprefix": "-l",
-            "libs": [],
-            "Lprefix": "-L",
-            "libdirs": [],
-            # Framework support (macOS only, but always defined for portability)
-            "Fprefix": "-F",
-            "frameworkdirs": [],
-            "fprefix": "-framework",
-            "frameworks": [],
-            "progcmd": [
-                "$link.cmd",
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-            "sharedcmd": [
-                "$link.cmd",
-                shared_flag,
-                "$link.flags",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-                "${prefix(link.Lprefix, link.libdirs)}",
-                "${prefix(link.lprefix, link.libs)}",
-                "${prefix(link.Fprefix, link.frameworkdirs)}",
-                "${pairwise(link.fprefix, link.frameworks)}",
-            ],
-        }
+        return gnu_link_vars("clang")
 
     def builders(self) -> dict[str, Builder]:
         platform = get_platform()

--- a/pcons/toolchains/unix.py
+++ b/pcons/toolchains/unix.py
@@ -331,13 +331,7 @@ class UnixToolchain(BaseToolchain):
         defines.extend(extra_defines)
 
         # Apply to compilers
-        for tool_name in ("cc", "cxx"):
-            if env.has_tool(tool_name):
-                tool = getattr(env, tool_name)
-                if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                    tool.flags.extend(compile_flags)
-                if hasattr(tool, "defines") and isinstance(tool.defines, list):
-                    tool.defines.extend(defines)
+        self._add_compile_flags_and_defines(env, ("cc", "cxx"), compile_flags, defines)
 
         # Apply to linker
         if env.has_tool("link") and link_flags:

--- a/pcons/toolchains/unix.py
+++ b/pcons/toolchains/unix.py
@@ -256,15 +256,7 @@ class UnixToolchain(BaseToolchain):
 
         if platform.is_macos:
             # macOS uses -arch flag for universal binary builds
-            arch_flags = ["-arch", arch]
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(arch_flags)
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(arch_flags)
+            self._add_tool_flags(env, ("cc", "cxx", "link"), ["-arch", arch])
 
     def apply_preset(self, env: Environment, name: str) -> None:
         """Apply a named flag preset.
@@ -278,18 +270,8 @@ class UnixToolchain(BaseToolchain):
             logger.warning("Unknown preset '%s' for Unix toolchain", name)
             return
 
-        compile_flags = preset.get("compile_flags", [])
-        link_flags = preset.get("link_flags", [])
-
-        for tool_name in ("cc", "cxx"):
-            if env.has_tool(tool_name):
-                tool = getattr(env, tool_name)
-                if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                    tool.flags.extend(compile_flags)
-
-        if env.has_tool("link") and link_flags:
-            if isinstance(env.link.flags, list):
-                env.link.flags.extend(link_flags)
+        self._add_tool_flags(env, ("cc", "cxx"), preset.get("compile_flags", []))
+        self._add_tool_flags(env, ("link",), preset.get("link_flags", []))
 
     def apply_cross_preset(self, env: Environment, preset: Any) -> None:
         """Apply a cross-compilation preset.
@@ -304,12 +286,7 @@ class UnixToolchain(BaseToolchain):
         # Apply target triple (Clang/LLVM only — GCC uses different
         # toolchain binaries rather than --target flag)
         if hasattr(preset, "triple") and preset.triple:
-            target_flag = f"--target={preset.triple}"
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.append(target_flag)
+            self._add_tool_flags(env, ("cc", "cxx"), [f"--target={preset.triple}"])
 
         # Delegate to base for sysroot, extra flags, env_vars, arch
         super().apply_cross_preset(env, preset)

--- a/pcons/toolchains/wasi.py
+++ b/pcons/toolchains/wasi.py
@@ -21,18 +21,23 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, cast
 
 from pcons.core.builder import CommandBuilder
 from pcons.core.subst import SourcePath, TargetPath
-from pcons.toolchains.unix import UnixToolchain
+from pcons.toolchains.gnu_common import (
+    gnu_archiver_builders,
+    gnu_archiver_vars,
+    gnu_compile_builders,
+    gnu_compile_vars,
+)
+from pcons.toolchains.wasm_common import WasmToolchain
 from pcons.tools.tool import BaseTool
 
 if TYPE_CHECKING:
     from pcons.core.builder import Builder
     from pcons.core.environment import Environment
     from pcons.core.toolconfig import ToolConfig
-    from pcons.tools.toolchain import SourceHandler
 
 logger = logging.getLogger(__name__)
 
@@ -126,45 +131,15 @@ class WasiCCompiler(BaseTool):
         super().__init__("cc", language="c")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "clang",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cc.cmd",
-                "--target=wasm32-wasi",
-                "$cc.sysroot_flag",
-                "$cc.flags",
-                "${prefix(cc.iprefix, cc.includes)}",
-                "${prefix(cc.dprefix, cc.defines)}",
-                "$cc.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-            # Placeholder — set during configure
-            "sysroot_flag": "",
-        }
+        return gnu_compile_vars(
+            "clang",
+            "cc",
+            target_tokens=["--target=wasm32-wasi", "$cc.sysroot_flag"],
+            extra_vars={"sysroot_flag": ""},  # placeholder, set during configure
+        )
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cc",
-                "objcmd",
-                src_suffixes=[".c"],
-                target_suffixes=[".o"],
-                language="c",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cc", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -194,44 +169,15 @@ class WasiCxxCompiler(BaseTool):
         super().__init__("cxx", language="cxx")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "clang++",
-            "flags": [],
-            "iprefix": "-I",
-            "includes": [],
-            "dprefix": "-D",
-            "defines": [],
-            "depflags": ["-MD", "-MF", TargetPath(suffix=".d")],
-            "objcmd": [
-                "$cxx.cmd",
-                "--target=wasm32-wasi",
-                "$cxx.sysroot_flag",
-                "$cxx.flags",
-                "${prefix(cxx.iprefix, cxx.includes)}",
-                "${prefix(cxx.dprefix, cxx.defines)}",
-                "$cxx.depflags",
-                "-c",
-                "-o",
-                TargetPath(),
-                SourcePath(),
-            ],
-            "sysroot_flag": "",
-        }
+        return gnu_compile_vars(
+            "clang++",
+            "cxx",
+            target_tokens=["--target=wasm32-wasi", "$cxx.sysroot_flag"],
+            extra_vars={"sysroot_flag": ""},  # placeholder, set during configure
+        )
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "Object": CommandBuilder(
-                "Object",
-                "cxx",
-                "objcmd",
-                src_suffixes=[".cpp", ".cxx", ".cc", ".C"],
-                target_suffixes=[".o"],
-                language="cxx",
-                single_source=True,
-                depfile=TargetPath(suffix=".d"),
-                deps_style="gcc",
-            ),
-        }
+        return gnu_compile_builders("cxx", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -260,23 +206,10 @@ class WasiArchiver(BaseTool):
         super().__init__("ar")
 
     def default_vars(self) -> dict[str, object]:
-        return {
-            "cmd": "llvm-ar",
-            "flags": ["rcs"],
-            "libcmd": ["$ar.cmd", "$ar.flags", TargetPath(), SourcePath()],
-        }
+        return gnu_archiver_vars("llvm-ar")
 
     def builders(self) -> dict[str, Builder]:
-        return {
-            "StaticLibrary": CommandBuilder(
-                "StaticLibrary",
-                "ar",
-                "libcmd",
-                src_suffixes=[".o"],
-                target_suffixes=[".a"],
-                single_source=False,
-            ),
-        }
+        return gnu_archiver_builders(object_suffix=".o", static_lib_suffix=".a")
 
     def configure(self, config: object) -> ToolConfig | None:
         from pcons.configure.config import Configure
@@ -365,7 +298,7 @@ class WasiLinker(BaseTool):
 # =============================================================================
 
 
-class WasiToolchain(UnixToolchain):
+class WasiToolchain(WasmToolchain):
     """WASI toolchain for compiling C/C++ to WebAssembly.
 
     Uses wasi-sdk (a clang/LLVM distribution targeting wasm32-wasi).
@@ -378,52 +311,13 @@ class WasiToolchain(UnixToolchain):
 
     TOOL_NAMES = ("cc", "cxx", "ar", "link")
 
+    program_suffix = ".wasm"
+    platform_label = "WASI"
+
     def __init__(self) -> None:
         super().__init__("wasi")
         self._sdk_path: Path | None = None
         self._sysroot: Path | None = None
-
-    # -- Suffix / naming overrides ------------------------------------------
-
-    def get_output_prefix(self, target_type: str) -> str:
-        # WASI targets Unix-like wasm — always use "lib" prefix
-        # regardless of host platform (e.g., when cross-compiling from Windows).
-        if target_type in ("static_library", "shared_library"):
-            return "lib"
-        return ""
-
-    def get_output_suffix(self, target_type: str) -> str:
-        if target_type == "program":
-            return ".wasm"
-        if target_type == "shared_library":
-            raise NotImplementedError(
-                "WASI does not support shared libraries. "
-                "Use StaticLibrary instead, or target a native platform."
-            )
-        return ".a"  # static library
-
-    def get_compile_flags_for_target_type(self, target_type: str) -> list[str]:
-        # No -fPIC needed for WebAssembly
-        if target_type == "shared_library":
-            raise NotImplementedError("WASI does not support shared libraries.")
-        return []
-
-    # -- Source handler ------------------------------------------------------
-
-    def get_source_handler(self, suffix: str) -> SourceHandler | None:
-        """Handle C/C++ sources (no Objective-C or assembly for wasm)."""
-        from pcons.tools.toolchain import SourceHandler
-
-        depfile = TargetPath(suffix=".d")
-        # Check case-sensitive .C (C++ on Unix) before lowering
-        if suffix == ".C":
-            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
-        suffix_lower = suffix.lower()
-        if suffix_lower == ".c":
-            return SourceHandler("cc", "c", ".o", depfile, "gcc")
-        if suffix_lower in (".cpp", ".cxx", ".cc", ".c++"):
-            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
-        return None
 
     # -- Configuration -------------------------------------------------------
 
@@ -494,25 +388,6 @@ class WasiToolchain(UnixToolchain):
                     tool = getattr(env, tool_name)
                     if hasattr(tool, "sysroot_flag"):
                         tool.sysroot_flag = sysroot_flag
-
-    # -- Variant / arch overrides -------------------------------------------
-
-    def apply_target_arch(self, env: Environment, arch: str, **kwargs: Any) -> None:
-        # wasm32 is the only architecture; ignore arch requests
-        super(UnixToolchain, self).apply_target_arch(env, "wasm32", **kwargs)
-
-    def apply_cross_preset(self, env: Environment, preset: Any) -> None:
-        # Sysroot is already handled by setup(); just apply extra flags
-        if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(preset.extra_compile_flags)
-        if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(preset.extra_link_flags)
 
 
 # =============================================================================

--- a/pcons/toolchains/wasi.py
+++ b/pcons/toolchains/wasi.py
@@ -119,6 +119,12 @@ def _find_sysroot(sdk_path: Path) -> Path | None:
     return None
 
 
+def _wasi_hints() -> list[Path | str] | None:
+    """Search hints pointing at a wasi-sdk's bin directory, if one is found."""
+    sdk = find_wasi_sdk()
+    return [sdk / "bin"] if sdk else None
+
+
 # =============================================================================
 # Tools
 # =============================================================================
@@ -142,24 +148,10 @@ class WasiCCompiler(BaseTool):
         return gnu_compile_builders("cc", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
         # Prefer wasi-sdk's clang, fall back to system clang
-        sdk = find_wasi_sdk()
-        if sdk:
-            clang = config.find_program("clang", hints=[sdk / "bin"])
-        else:
-            clang = config.find_program("clang")
-        if clang is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cc", cmd=str(clang.path))
-        if clang.version:
-            tool_config.version = clang.version
-        return tool_config
+        return self._find_tool_config(
+            config, "clang", hints=_wasi_hints(), with_version=True
+        )
 
 
 class WasiCxxCompiler(BaseTool):
@@ -180,23 +172,9 @@ class WasiCxxCompiler(BaseTool):
         return gnu_compile_builders("cxx", object_suffix=".o")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        sdk = find_wasi_sdk()
-        if sdk:
-            clangxx = config.find_program("clang++", hints=[sdk / "bin"])
-        else:
-            clangxx = config.find_program("clang++")
-        if clangxx is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        tool_config = ToolConfig("cxx", cmd=str(clangxx.path))
-        if clangxx.version:
-            tool_config.version = clangxx.version
-        return tool_config
+        return self._find_tool_config(
+            config, "clang++", hints=_wasi_hints(), with_version=True
+        )
 
 
 class WasiArchiver(BaseTool):
@@ -212,22 +190,7 @@ class WasiArchiver(BaseTool):
         return gnu_archiver_builders(object_suffix=".o", static_lib_suffix=".a")
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        sdk = find_wasi_sdk()
-        if sdk:
-            ar = config.find_program("llvm-ar", hints=[sdk / "bin"])
-        else:
-            ar = config.find_program("llvm-ar")
-        if ar is None:
-            ar = config.find_program("ar")
-        if ar is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("ar", cmd=str(ar.path))
+        return self._find_tool_config(config, "llvm-ar", "ar", hints=_wasi_hints())
 
 
 class WasiLinker(BaseTool):
@@ -277,20 +240,7 @@ class WasiLinker(BaseTool):
         }
 
     def configure(self, config: object) -> ToolConfig | None:
-        from pcons.configure.config import Configure
-
-        if not isinstance(config, Configure):
-            return None
-        sdk = find_wasi_sdk()
-        if sdk:
-            clang = config.find_program("clang", hints=[sdk / "bin"])
-        else:
-            clang = config.find_program("clang")
-        if clang is None:
-            return None
-        from pcons.core.toolconfig import ToolConfig
-
-        return ToolConfig("link", cmd=str(clang.path))
+        return self._find_tool_config(config, "clang", hints=_wasi_hints())
 
 
 # =============================================================================

--- a/pcons/toolchains/wasm_common.py
+++ b/pcons/toolchains/wasm_common.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+"""Shared base for WebAssembly toolchains (Emscripten, WASI).
+
+Emscripten and WASI both drive a Unix-like clang/emcc compiler to produce wasm
+output, so they share suffix handling, source dispatch, and arch/preset logic.
+The pieces that differ (SDK discovery, the program suffix, the linker) stay in
+the concrete toolchains.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from pcons.core.subst import TargetPath
+from pcons.toolchains.unix import UnixToolchain
+
+if TYPE_CHECKING:
+    from pcons.core.environment import Environment
+    from pcons.tools.toolchain import SourceHandler
+
+
+class WasmToolchain(UnixToolchain):
+    """Base for wasm32 toolchains compiling C/C++ via a clang-like driver.
+
+    Subclasses set `TOOL_NAMES`, `program_suffix` (".js"/".wasm"), and
+    `platform_label` (used in the "no shared libraries" error messages), and
+    provide SDK discovery via __init__/_configure_tools/setup.
+
+    `TOOL_NAMES` stays on the concrete subclasses: the stub generator treats any
+    class carrying it as a real toolchain, so the abstract base must not.
+    """
+
+    program_suffix: str
+    platform_label: str
+
+    # -- Suffix / naming overrides ------------------------------------------
+
+    def get_output_prefix(self, target_type: str) -> str:
+        # wasm targets are Unix-like — always use the "lib" prefix regardless of
+        # host platform (e.g. when cross-compiling from Windows).
+        if target_type in ("static_library", "shared_library"):
+            return "lib"
+        return ""
+
+    def get_output_suffix(self, target_type: str) -> str:
+        if target_type == "program":
+            return self.program_suffix
+        if target_type == "shared_library":
+            raise NotImplementedError(
+                f"{self.platform_label} does not support shared libraries. "
+                "Use StaticLibrary instead, or target a native platform."
+            )
+        return ".a"  # static library
+
+    def get_compile_flags_for_target_type(self, target_type: str) -> list[str]:
+        # No -fPIC needed for WebAssembly
+        if target_type == "shared_library":
+            raise NotImplementedError(
+                f"{self.platform_label} does not support shared libraries."
+            )
+        return []
+
+    # -- Source handler ------------------------------------------------------
+
+    def get_source_handler(self, suffix: str) -> SourceHandler | None:
+        """Handle C/C++ sources (no Objective-C or assembly for wasm)."""
+        from pcons.tools.toolchain import SourceHandler
+
+        depfile = TargetPath(suffix=".d")
+        # Check case-sensitive .C (C++ on Unix) before lowering
+        if suffix == ".C":
+            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
+        suffix_lower = suffix.lower()
+        if suffix_lower == ".c":
+            return SourceHandler("cc", "c", ".o", depfile, "gcc")
+        if suffix_lower in (".cpp", ".cxx", ".cc", ".c++"):
+            return SourceHandler("cxx", "cxx", ".o", depfile, "gcc")
+        return None
+
+    # -- Variant / arch overrides -------------------------------------------
+
+    def apply_target_arch(self, env: Environment, arch: str, **kwargs: Any) -> None:
+        # wasm32 is the only architecture; ignore arch requests
+        super(UnixToolchain, self).apply_target_arch(env, "wasm32", **kwargs)
+
+    def apply_cross_preset(self, env: Environment, preset: Any) -> None:
+        # Sysroot (if any) is handled by setup(); just apply extra flags.
+        if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
+            for tool_name in ("cc", "cxx"):
+                if env.has_tool(tool_name):
+                    tool = getattr(env, tool_name)
+                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
+                        tool.flags.extend(preset.extra_compile_flags)
+        if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
+            if env.has_tool("link"):
+                if isinstance(env.link.flags, list):
+                    env.link.flags.extend(preset.extra_link_flags)

--- a/pcons/toolchains/wasm_common.py
+++ b/pcons/toolchains/wasm_common.py
@@ -86,12 +86,6 @@ class WasmToolchain(UnixToolchain):
     def apply_cross_preset(self, env: Environment, preset: Any) -> None:
         # Sysroot (if any) is handled by setup(); just apply extra flags.
         if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(preset.extra_compile_flags)
+            self._add_tool_flags(env, ("cc", "cxx"), preset.extra_compile_flags)
         if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(preset.extra_link_flags)
+            self._add_tool_flags(env, ("link",), preset.extra_link_flags)

--- a/pcons/tools/install.py
+++ b/pcons/tools/install.py
@@ -36,7 +36,9 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from pcons.core.builder import Builder
     from pcons.core.environment import Environment
+    from pcons.core.node import Node
     from pcons.core.project import Project
+    from pcons.util.source_location import SourceLocation
 
 
 def _stamp_name_for(path: Path) -> str:
@@ -97,6 +99,36 @@ def _deduplicate_target_name(project: Project, base_name: str) -> str:
             target_name,
         )
     return target_name
+
+
+def _apply_install_prefix(project: Project, dest: Path, no_prefix: bool) -> Path:
+    """Prepend PCONS_INSTALL_PREFIX to *dest* unless it is rooted or opted out."""
+    if no_prefix or _is_rooted(dest):
+        return dest
+    from pcons import get_var
+
+    prefix = get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist"))
+    return Path(prefix) / dest
+
+
+def _make_install_target(
+    target_name: str,
+    builder_name: str,
+    builder_data: dict[str, str],
+    sources: Sequence[Target | Node | Path | str],
+    *,
+    defined_at: SourceLocation,
+) -> Target:
+    """Create an interface Target carrying install builder metadata."""
+    install_target = Target(
+        target_name,
+        target_type="interface",
+        defined_at=defined_at,
+    )
+    install_target._builder_name = builder_name
+    install_target._builder_data = builder_data
+    install_target._pending_sources = list(sources)
+    return install_target
 
 
 def install_dir(env: Environment, target_type: str) -> str:
@@ -531,32 +563,19 @@ class InstallBuilder:
         Returns:
             A Target representing the install operation.
         """
-        from pcons import get_var
-
         dest_dir = Path(dest_dir)
         target_name = _deduplicate_target_name(
             project, name or f"install_{dest_dir.name}"
         )
+        dest_dir = _apply_install_prefix(project, dest_dir, no_prefix)
 
-        if not no_prefix and not _is_rooted(dest_dir):
-            dest_dir = (
-                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
-                / dest_dir
-            )
-
-        # Create the install target
-        install_target = Target(
+        return _make_install_target(
             target_name,
-            target_type="interface",
+            "Install",
+            {"dest_dir": str(dest_dir)},
+            list(sources),
             defined_at=get_caller_location(),
         )
-
-        # Set builder metadata for factory dispatch
-        install_target._builder_name = "Install"
-        install_target._builder_data = {"dest_dir": str(dest_dir)}
-        install_target._pending_sources = list(sources)
-
-        return install_target
 
 
 @builder("InstallAs", target_type="interface", factory_class=InstallNodeFactory)
@@ -591,8 +610,6 @@ class InstallAsBuilder:
         Raises:
             BuilderError: If source is a list (use Install() for multiple files).
         """
-        from pcons import get_var
-
         # Validate source is not a list - common user error
         if isinstance(source, (list, tuple)):
             from pcons.core.errors import BuilderError
@@ -605,26 +622,15 @@ class InstallAsBuilder:
 
         dest = Path(dest)
         target_name = _deduplicate_target_name(project, name or f"install_{dest.name}")
+        dest = _apply_install_prefix(project, dest, no_prefix)
 
-        if not no_prefix and not _is_rooted(dest):
-            dest = (
-                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
-                / dest
-            )
-
-        # Create the install target
-        install_target = Target(
+        return _make_install_target(
             target_name,
-            target_type="interface",
+            "InstallAs",
+            {"dest": str(dest)},
+            [source],
             defined_at=get_caller_location(),
         )
-
-        # Set builder metadata for factory dispatch
-        install_target._builder_name = "InstallAs"
-        install_target._builder_data = {"dest": str(dest)}
-        install_target._pending_sources = [source]
-
-        return install_target
 
 
 @builder("InstallDir", target_type="interface", factory_class=InstallNodeFactory)
@@ -656,29 +662,16 @@ class InstallDirBuilder:
         Returns:
             A Target representing the install operation.
         """
-        from pcons import get_var
-
         dest_dir = Path(dest_dir)
         target_name = _deduplicate_target_name(
             project, name or f"install_dir_{dest_dir.name}"
         )
+        dest_dir = _apply_install_prefix(project, dest_dir, no_prefix)
 
-        if not no_prefix and not _is_rooted(dest_dir):
-            dest_dir = (
-                Path(get_var("PCONS_INSTALL_PREFIX", str(project.root_dir / "dist")))
-                / dest_dir
-            )
-
-        # Create the install target
-        install_target = Target(
+        return _make_install_target(
             target_name,
-            target_type="interface",
+            "InstallDir",
+            {"dest_dir": str(dest_dir)},
+            [source],
             defined_at=get_caller_location(),
         )
-
-        # Set builder metadata for factory dispatch
-        install_target._builder_name = "InstallDir"
-        install_target._builder_data = {"dest_dir": str(dest_dir)}
-        install_target._pending_sources = [source]
-
-        return install_target

--- a/pcons/tools/tool.py
+++ b/pcons/tools/tool.py
@@ -102,6 +102,7 @@ class BaseTool(ABC):
         config: object,
         *programs: str,
         hints: list[Path | str] | None = None,
+        version_flag: str = "--version",
         with_version: bool = False,
     ) -> ToolConfig | None:
         """Locate the first available program and build this tool's ToolConfig.
@@ -113,6 +114,8 @@ class BaseTool(ABC):
             config: The Configure instance (anything else yields None).
             programs: Candidate executable names, tried in order.
             hints: Extra directories to search.
+            version_flag: Flag used to probe the version; pass "" for tools
+                that don't support --version (e.g. lib.exe, lld-link).
             with_version: Copy the detected program version onto the config.
         """
         from pcons.configure.config import Configure
@@ -121,7 +124,7 @@ class BaseTool(ABC):
             return None
         found = None
         for name in programs:
-            found = config.find_program(name, hints=hints)
+            found = config.find_program(name, hints=hints, version_flag=version_flag)
             if found is not None:
                 break
         if found is None:

--- a/pcons/tools/tool.py
+++ b/pcons/tools/tool.py
@@ -97,6 +97,43 @@ class BaseTool(ABC):
         """Default implementation returns None (tool not configured)."""
         return None
 
+    def _find_tool_config(
+        self,
+        config: object,
+        *programs: str,
+        hints: list[Path | str] | None = None,
+        with_version: bool = False,
+    ) -> ToolConfig | None:
+        """Locate the first available program and build this tool's ToolConfig.
+
+        Tries each name in *programs* in order. Returns None if *config* is not
+        a Configure or none of the candidates are found.
+
+        Args:
+            config: The Configure instance (anything else yields None).
+            programs: Candidate executable names, tried in order.
+            hints: Extra directories to search.
+            with_version: Copy the detected program version onto the config.
+        """
+        from pcons.configure.config import Configure
+
+        if not isinstance(config, Configure):
+            return None
+        found = None
+        for name in programs:
+            found = config.find_program(name, hints=hints)
+            if found is not None:
+                break
+        if found is None:
+            return None
+
+        from pcons.core.toolconfig import ToolConfig
+
+        tool_config = ToolConfig(self._name, cmd=str(found.path))
+        if with_version and found.version:
+            tool_config.version = found.version
+        return tool_config
+
     def setup(self, env: Environment) -> None:
         """Set up the tool namespace with default values."""
         # Create or get the tool's namespace

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -678,6 +678,25 @@ class BaseToolchain(ABC):
         # Store variant name on environment
         env.variant = variant
 
+    @staticmethod
+    def _add_tool_flags(
+        env: Environment, tool_names: tuple[str, ...], flags: list[str]
+    ) -> None:
+        """Extend each named tool's `flags` list with `flags`.
+
+        Skips tools that are absent or whose `flags` isn't a list. The
+        arch/preset/cross-preset hooks all push flags onto cc/cxx and/or link
+        this same way.
+        """
+        if not flags:
+            return
+        for tool_name in tool_names:
+            if not env.has_tool(tool_name):
+                continue
+            tool_flags = getattr(getattr(env, tool_name), "flags", None)
+            if isinstance(tool_flags, list):
+                tool_flags.extend(flags)
+
     def apply_target_arch(self, env: Environment, arch: str, **kwargs: Any) -> None:
         """Apply target architecture flags to the environment.
 
@@ -720,29 +739,17 @@ class BaseToolchain(ABC):
 
         # Apply sysroot to cc, cxx, link
         if hasattr(preset, "sysroot") and preset.sysroot:
-            sysroot_flag = f"--sysroot={preset.sysroot}"
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.append(sysroot_flag)
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.append(sysroot_flag)
+            self._add_tool_flags(
+                env, ("cc", "cxx", "link"), [f"--sysroot={preset.sysroot}"]
+            )
 
         # Apply extra compile flags
         if hasattr(preset, "extra_compile_flags") and preset.extra_compile_flags:
-            for tool_name in ("cc", "cxx"):
-                if env.has_tool(tool_name):
-                    tool = getattr(env, tool_name)
-                    if hasattr(tool, "flags") and isinstance(tool.flags, list):
-                        tool.flags.extend(preset.extra_compile_flags)
+            self._add_tool_flags(env, ("cc", "cxx"), preset.extra_compile_flags)
 
         # Apply extra link flags
         if hasattr(preset, "extra_link_flags") and preset.extra_link_flags:
-            if env.has_tool("link"):
-                if isinstance(env.link.flags, list):
-                    env.link.flags.extend(preset.extra_link_flags)
+            self._add_tool_flags(env, ("link",), preset.extra_link_flags)
 
         # Override CC/CXX commands from env_vars
         if hasattr(preset, "env_vars") and preset.env_vars:

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -697,6 +697,30 @@ class BaseToolchain(ABC):
             if isinstance(tool_flags, list):
                 tool_flags.extend(flags)
 
+    @staticmethod
+    def _add_compile_flags_and_defines(
+        env: Environment,
+        tool_names: tuple[str, ...],
+        flags: list[str],
+        defines: list[str],
+    ) -> None:
+        """Extend each named tool's `flags` and `defines` lists.
+
+        Skips tools that are absent or whose attribute isn't a list. Used by
+        the apply_variant hooks, which push compile flags and defines onto the
+        compiler tools the same way.
+        """
+        for tool_name in tool_names:
+            if not env.has_tool(tool_name):
+                continue
+            tool = getattr(env, tool_name)
+            tool_flags = getattr(tool, "flags", None)
+            if isinstance(tool_flags, list):
+                tool_flags.extend(flags)
+            tool_defines = getattr(tool, "defines", None)
+            if isinstance(tool_defines, list):
+                tool_defines.extend(defines)
+
     def apply_target_arch(self, env: Environment, arch: str, **kwargs: Any) -> None:
         """Apply target architecture flags to the environment.
 

--- a/tests/configure/test_checks.py
+++ b/tests/configure/test_checks.py
@@ -54,6 +54,43 @@ _cc_path, _is_msvc_style = _find_c_compiler()
 has_cc = _cc_path is not None
 
 
+class TestCachedOrCompiler:
+    """Cached and no-compiler paths of _cached_or_compiler (no real compiler)."""
+
+    def _make_checks(self, tmp_path, test_project):  # noqa: F811
+        config = Configure(build_dir=tmp_path)
+        env = Environment()
+        env.add_tool("cc")  # no cmd -> no compiler configured
+        return config, ToolChecks(config, env, "cc")
+
+    def test_check_header_cached(self, tmp_path, test_project):  # noqa: F811
+        config, checks = self._make_checks(tmp_path, test_project)
+        config.set(checks._cache_key("header", "stdio.h"), True)
+        result = checks.check_header("stdio.h")
+        assert result.cached is True
+        assert result.success is True
+
+    def test_check_type_cached(self, tmp_path, test_project):  # noqa: F811
+        config, checks = self._make_checks(tmp_path, test_project)
+        config.set(checks._cache_key("type", "size_t"), True)
+        result = checks.check_type("size_t")
+        assert result.cached is True
+        assert result.success is True
+
+    def test_check_function_cached(self, tmp_path, test_project):  # noqa: F811
+        config, checks = self._make_checks(tmp_path, test_project)
+        config.set(checks._cache_key("function", "printf"), False)
+        result = checks.check_function("printf")
+        assert result.cached is True
+        assert result.success is False
+
+    def test_no_compiler_returns_failure(self, tmp_path, test_project):  # noqa: F811
+        _config, checks = self._make_checks(tmp_path, test_project)
+        result = checks.check_header("uncached-header.h")
+        assert result.success is False
+        assert "No compiler configured" in result.output
+
+
 @pytest.mark.skipif(not has_cc, reason="No C compiler available")
 class TestToolChecksWithCompiler:
     """Tests that require a real compiler."""
@@ -141,6 +178,12 @@ class TestToolChecksWithCompiler:
         checks = ToolChecks(config, env, "cc")
         flag = "/W4" if _is_msvc_style else "-Wall"
         result = checks.check_header("stdio.h", extra_flags=[flag])
+        assert result.success is True
+
+    def test_check_function_exists(self, setup):
+        config, env = setup
+        checks = ToolChecks(config, env, "cc")
+        result = checks.check_function("printf", headers=["stdio.h"])
         assert result.success is True
 
     def test_check_type_exists(self, setup):

--- a/tests/generators/test_dot.py
+++ b/tests/generators/test_dot.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: MIT
+"""Tests for DotGenerator (GraphViz output)."""
+
+import sys
+from pathlib import Path
+
+from pcons.core.node import FileNode
+from pcons.core.project import Project
+from pcons.core.target import Target
+from pcons.generators.dot import DotGenerator
+from pcons.generators.generator import BaseGenerator
+
+
+class TestDotGeneratorBasic:
+    def test_generator_creation(self):
+        gen = DotGenerator()
+        assert gen.name == "dot"
+
+    def test_empty_project(self, tmp_path):
+        project = Project("empty", build_dir=tmp_path)
+        gen = DotGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        output = (tmp_path / "deps.dot").read_text()
+        assert 'digraph "empty"' in output
+        assert "rankdir=LR" in output
+
+    def test_object_and_output_nodes(self, tmp_path):
+        """Object nodes (ellipse) and output nodes are emitted."""
+        project = Project("app", build_dir=tmp_path)
+        target = Target("myapp", target_type="program")
+        src = FileNode(Path("src/main.c"))
+        obj = FileNode(Path("build/main.o"))
+        exe = FileNode(Path("build/myapp"))
+        obj.depends([src])
+        target.intermediate_nodes.append(obj)
+        target.output_nodes.append(exe)
+
+        gen = DotGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        output = (tmp_path / "deps.dot").read_text()
+        # Object node uses ellipse shape
+        assert "shape=ellipse" in output
+        assert "shape=box3d" in output  # program output
+        assert "src_main_c -> build_main_o" in output
+
+    def test_header_dependencies(self, tmp_path):
+        """include_headers parses .d files and emits header (note) nodes."""
+        project = Project("hdr", build_dir=tmp_path)
+        target = Target("app", target_type="program")
+        src = FileNode(tmp_path / "main.c")
+        obj = FileNode(tmp_path / "main.o")
+        exe = FileNode(tmp_path / "app")
+        obj.depends([src])
+        target.intermediate_nodes.append(obj)
+        target.output_nodes.append(exe)
+
+        depfile = tmp_path / "main.o.d"
+        depfile.write_text(
+            f"main.o: {tmp_path / 'main.c'} {tmp_path / 'foo.h'} /usr/include/stdio.h\n"
+        )
+
+        gen = DotGenerator(include_headers=True)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        output = (tmp_path / "deps.dot").read_text()
+        assert 'foo_h [label="foo.h" shape=note];' in output
+        assert "foo_h -> main_o" in output
+        # System headers (/usr, /Library, /System) are dropped on POSIX; the
+        # prefix filter is Unix-pathed, so skip the assertion on Windows.
+        if not sys.platform.startswith("win"):
+            assert "stdio" not in output
+
+    def test_include_headers_without_depfile(self, tmp_path):
+        """include_headers=True with no .d file present yields no header nodes."""
+        project = Project("nodep", build_dir=tmp_path)
+        target = Target("app", target_type="program")
+        obj = FileNode(tmp_path / "main.o")
+        obj.depends([FileNode(tmp_path / "main.c")])
+        target.intermediate_nodes.append(obj)
+        target.output_nodes.append(FileNode(tmp_path / "app"))
+
+        gen = DotGenerator(include_headers=True)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        output = (tmp_path / "deps.dot").read_text()
+        # Source edge present, but no header nodes were parsed (no .d file).
+        assert "main_c -> main_o" in output
+
+    def test_depfile_read_error_is_swallowed(self, tmp_path):
+        """A depfile that cannot be read (e.g. a directory) is ignored."""
+        project = Project("baddep", build_dir=tmp_path)
+        target = Target("app", target_type="program")
+        obj = FileNode(tmp_path / "main.o")
+        obj.depends([FileNode(tmp_path / "main.c")])
+        target.intermediate_nodes.append(obj)
+        target.output_nodes.append(FileNode(tmp_path / "app"))
+
+        # A directory at the depfile path exists() but read_text() raises OSError.
+        (tmp_path / "main.o.d").mkdir()
+
+        gen = DotGenerator(include_headers=True)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        # No crash; output produced.
+        assert (tmp_path / "deps.dot").exists()
+
+    def test_output_dir_override(self, tmp_path):
+        sub = tmp_path / "diagrams"
+        project = Project("p", build_dir=tmp_path)
+        gen = DotGenerator(output_dir=sub)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        assert (sub / "deps.dot").exists()

--- a/tests/generators/test_mermaid.py
+++ b/tests/generators/test_mermaid.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: MIT
 """Tests for MermaidGenerator."""
 
+import sys
 from pathlib import Path
 
 from pcons.core.node import FileNode
@@ -146,6 +147,47 @@ class TestMermaidGeneratorGraph:
         assert "build_myapp[[" in output
         # Interface: hexagon {{name}}
         assert "include_headers{{" in output
+
+
+class TestMermaidGeneratorHeaders:
+    """Tests for header-dependency parsing (include_headers=True)."""
+
+    def test_header_dependencies(self, tmp_path):
+        project = Project("hdr", build_dir=tmp_path)
+        target = Target("app", target_type="program")
+        src = FileNode(tmp_path / "main.c")
+        obj = FileNode(tmp_path / "main.o")
+        exe = FileNode(tmp_path / "app")
+        obj.depends([src])
+        target.intermediate_nodes.append(obj)
+        target.output_nodes.append(exe)
+
+        depfile = tmp_path / "main.o.d"
+        depfile.write_text(
+            f"main.o: {tmp_path / 'main.c'} {tmp_path / 'foo.h'} /usr/include/stdio.h\n"
+        )
+
+        gen = MermaidGenerator(include_headers=True)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        output = (tmp_path / "deps.mmd").read_text()
+        # Header node uses the asymmetric shape: id>label]
+        assert "foo_h>foo.h]" in output
+        assert "foo_h --> main_o" in output
+        # System headers (/usr, /Library, /System) are dropped on POSIX; the
+        # prefix filter is Unix-pathed, so skip the assertion on Windows.
+        if not sys.platform.startswith("win"):
+            assert "stdio" not in output
+
+    def test_output_dir_override(self, tmp_path):
+        sub = tmp_path / "diagrams"
+        project = Project("p", build_dir=tmp_path)
+        gen = MermaidGenerator(output_dir=sub)
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        assert (sub / "deps.mmd").exists()
 
 
 class TestMermaidGeneratorDirection:

--- a/tests/toolchains/test_clang_cl.py
+++ b/tests/toolchains/test_clang_cl.py
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.toolchains.clang_cl."""
 
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
 from pcons.toolchains.clang_cl import (
     ClangClCCompiler,
     ClangClCxxCompiler,
@@ -8,6 +13,39 @@ from pcons.toolchains.clang_cl import (
     ClangClLinker,
     ClangClToolchain,
 )
+
+
+class TestClangClConfigure:
+    """configure() is Windows-gated and otherwise delegates to _find_tool_config."""
+
+    _CLASSES = [ClangClCCompiler, ClangClCxxCompiler, ClangClLibrarian, ClangClLinker]
+
+    @pytest.mark.parametrize("cls", _CLASSES)
+    def test_returns_none_off_windows(self, cls, monkeypatch, tmp_path):
+        from pcons.configure.config import Configure
+        from pcons.toolchains import clang_cl
+
+        monkeypatch.setattr(
+            clang_cl, "get_platform", lambda: SimpleNamespace(is_windows=False)
+        )
+        config = Configure(build_dir=tmp_path)
+        assert cls().configure(config) is None
+
+    @pytest.mark.parametrize("cls", _CLASSES)
+    def test_finds_program_on_windows(self, cls, monkeypatch, tmp_path):
+        from pcons.configure.config import Configure, ProgramInfo
+        from pcons.toolchains import clang_cl
+
+        monkeypatch.setattr(
+            clang_cl, "get_platform", lambda: SimpleNamespace(is_windows=True)
+        )
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda *a, **k: ProgramInfo(path=Path("C:/llvm/tool.exe"))
+        )
+        cfg = cls().configure(config)
+        assert cfg is not None
+        assert cfg.cmd == str(Path("C:/llvm/tool.exe"))
 
 
 class TestClangClCCompiler:

--- a/tests/toolchains/test_cross_presets.py
+++ b/tests/toolchains/test_cross_presets.py
@@ -258,6 +258,81 @@ class TestCrossPresetApplication:
 
         assert "/MACHINE:ARM64" in env.link.flags
 
+    def _make_msvc_env(self) -> Environment:
+        env = Environment()
+        for name in ("cc", "cxx", "link", "lib"):
+            tool = env.add_tool(name)
+            tool.set("cmd", f"{name}.exe")
+            tool.set("flags", [])
+            tool.set("defines", [])
+        return env
+
+    def _concrete_msvc(self):
+        from pcons.toolchains._msvc_compat import MsvcCompatibleToolchain
+
+        class ConcreteMsvc(MsvcCompatibleToolchain):
+            def _configure_tools(self, config: object) -> bool:
+                return True
+
+        return ConcreteMsvc("test-msvc")
+
+    def test_msvc_apply_extra_flags(self, test_project):  # noqa: F811
+        """MsvcCompatibleToolchain applies extra compile/link flags."""
+        env = self._make_msvc_env()
+        toolchain = self._concrete_msvc()
+
+        preset = CrossPreset(
+            name="test",
+            arch="x64",
+            extra_compile_flags=("/DCUSTOM",),
+            extra_link_flags=("/LIBPATH:custom",),
+        )
+        toolchain.apply_cross_preset(env, preset)
+
+        assert "/DCUSTOM" in env.cc.flags
+        assert "/DCUSTOM" in env.cxx.flags
+        assert "/LIBPATH:custom" in env.link.flags
+
+    def test_msvc_apply_variant(self, test_project):  # noqa: F811
+        """MsvcCompatibleToolchain.apply_variant adds flags and defines."""
+        env = self._make_msvc_env()
+        toolchain = self._concrete_msvc()
+
+        toolchain.apply_variant(env, "debug")
+
+        assert "/Od" in env.cc.flags
+        assert "/Zi" in env.cxx.flags
+        assert "DEBUG" in env.cc.defines
+        assert "_DEBUG" in env.cxx.defines
+
+    def test_wasm_apply_cross_preset(self, test_project):  # noqa: F811
+        """WasmToolchain applies extra flags without sysroot handling."""
+        from pcons.toolchains.emscripten import EmscriptenToolchain
+
+        env = _make_unix_env()
+        toolchain = EmscriptenToolchain()
+
+        preset = CrossPreset(
+            name="test",
+            arch="wasm32",
+            extra_compile_flags=("-DWASM",),
+            extra_link_flags=("-sUSE_PTHREADS",),
+        )
+        toolchain.apply_cross_preset(env, preset)
+
+        assert "-DWASM" in env.cc.flags
+        assert "-DWASM" in env.cxx.flags
+        assert "-sUSE_PTHREADS" in env.link.flags
+
+    def test_wasm_apply_target_arch_forces_wasm32(self, test_project):  # noqa: F811
+        """WasmToolchain ignores the requested arch and uses wasm32."""
+        from pcons.toolchains.emscripten import EmscriptenToolchain
+
+        env = _make_unix_env()
+        toolchain = EmscriptenToolchain()
+        # Any requested arch is accepted but treated as wasm32 (no error).
+        toolchain.apply_target_arch(env, "x86_64")
+
     def test_env_apply_cross_preset_delegates(self, test_project):  # noqa: F811
         """Environment.apply_cross_preset() should delegate to toolchains."""
         from pcons.toolchains.llvm import LlvmToolchain

--- a/tests/toolchains/test_cxx_module_scanner.py
+++ b/tests/toolchains/test_cxx_module_scanner.py
@@ -22,6 +22,7 @@ from pcons.toolchains.cxx_module_scanner import (
     build_keyed_entries,
     build_module_map,
     map_module_providers,
+    merge_scan_compile_flags,
     module_file_for,
     run_scan_deps,
     run_scan_deps_msvc,
@@ -761,3 +762,32 @@ class TestBuildKeyedEntries:
             results, spec_to_obj, obj_key, {}, "cxx_modules", ".pcm"
         )
         assert entries == [("obj.lib1/consumer.cpp.o", [], [])]
+
+
+class TestMergeScanCompileFlags:
+    """Tests for merge_scan_compile_flags."""
+
+    def test_dedups_extra_and_context_flags(self) -> None:
+        from types import SimpleNamespace
+
+        ctx = SimpleNamespace(
+            flags=["-O2", "-std=c++23"],  # -std dup vs base, kept once
+            includes=["inc", "/abs/inc"],
+            defines=["FOO=1", "BAR"],
+        )
+        result = merge_scan_compile_flags(
+            ["-std=c++23"], ctx, extra_flags=("-fmodules", "-fmodules")
+        )
+        assert result == [
+            "-std=c++23",
+            "-fmodules",
+            "-O2",
+            "-Iinc",
+            "-I/abs/inc",
+            "-DFOO=1",
+            "-DBAR",
+        ]
+
+    def test_no_context(self) -> None:
+        result = merge_scan_compile_flags(["-std=c++20"], None, extra_flags=("-x",))
+        assert result == ["-std=c++20", "-x"]

--- a/tests/toolchains/test_emscripten.py
+++ b/tests/toolchains/test_emscripten.py
@@ -291,3 +291,44 @@ class TestEmscriptenRegistration:
         entry = toolchain_registry.get("emcc")
         assert entry is not None
         assert entry.toolchain_class is EmscriptenToolchain
+
+
+class TestEmsdkHints:
+    """Tests for _emsdk_hints search-hint helper."""
+
+    def test_none_when_no_emsdk(self, monkeypatch):
+        from pcons.toolchains import emscripten
+
+        monkeypatch.setattr(emscripten, "find_emsdk", lambda: None)
+        assert emscripten._emsdk_hints() is None
+
+    def test_returns_emcc_dir_when_found(self, monkeypatch, tmp_path):
+        from pcons.toolchains import emscripten
+
+        emcc_dir = tmp_path / "upstream" / "emscripten"
+        monkeypatch.setattr(emscripten, "find_emsdk", lambda: tmp_path)
+        monkeypatch.setattr(emscripten, "_find_emcc_dir", lambda _p: emcc_dir)
+        assert emscripten._emsdk_hints() == [emcc_dir]
+
+    def test_none_when_emcc_dir_missing(self, monkeypatch, tmp_path):
+        from pcons.toolchains import emscripten
+
+        monkeypatch.setattr(emscripten, "find_emsdk", lambda: tmp_path)
+        monkeypatch.setattr(emscripten, "_find_emcc_dir", lambda _p: None)
+        assert emscripten._emsdk_hints() is None
+
+
+class TestEmccConfigureMissing:
+    """configure() returns None when the program is not found."""
+
+    @pytest.mark.parametrize(
+        "cls", [EmccCCompiler, EmccCxxCompiler, EmccArchiver, EmccLinker]
+    )
+    def test_configure_returns_none(self, cls, monkeypatch, tmp_path):
+        from pcons.configure.config import Configure
+        from pcons.toolchains import emscripten
+
+        monkeypatch.setattr(emscripten, "_emsdk_hints", lambda: None)
+        config = Configure(build_dir=tmp_path)
+        config.find_program = lambda *a, **k: None  # type: ignore[method-assign]
+        assert cls().configure(config) is None

--- a/tests/toolchains/test_gcc.py
+++ b/tests/toolchains/test_gcc.py
@@ -157,6 +157,34 @@ class TestGccLinker:
         assert "SharedLibrary" in builders
 
 
+class TestGccConfigure:
+    """Each tool's configure() delegates to _find_tool_config."""
+
+    @pytest.mark.parametrize(
+        "cls", [GccCCompiler, GccCxxCompiler, GccArchiver, GccLinker]
+    )
+    def test_configure_finds_program(self, cls, tmp_path):
+        from pcons.configure.config import Configure, ProgramInfo
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda *a, **k: ProgramInfo(path=Path("/usr/bin/tool"), version="1.0")
+        )
+        cfg = cls().configure(config)
+        assert cfg is not None
+        assert cfg.cmd == str(Path("/usr/bin/tool"))
+
+    @pytest.mark.parametrize(
+        "cls", [GccCCompiler, GccCxxCompiler, GccArchiver, GccLinker]
+    )
+    def test_configure_returns_none_when_missing(self, cls, tmp_path):
+        from pcons.configure.config import Configure
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = lambda *a, **k: None  # type: ignore[method-assign]
+        assert cls().configure(config) is None
+
+
 class TestGccToolchain:
     def test_creation(self):
         tc = GccToolchain()

--- a/tests/toolchains/test_gfortran.py
+++ b/tests/toolchains/test_gfortran.py
@@ -301,3 +301,32 @@ def test_find_fortran_toolchain_returns_toolchain() -> None:
     with patch("shutil.which", return_value="/usr/bin/gfortran"):
         tc = find_fortran_toolchain()
         assert isinstance(tc, GfortranToolchain)
+
+
+class TestGfortranConfigure:
+    """GfortranCompiler/Linker configure() delegates to _find_tool_config."""
+
+    @pytest.mark.parametrize("cls", [GfortranCompiler, GfortranLinker])
+    def test_configure_finds_program(self, cls, tmp_path):
+        from pcons.configure.config import Configure, ProgramInfo
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda *a, **k: ProgramInfo(path=Path("/usr/bin/gfortran"), version="14")
+        )
+        cfg = cls().configure(config)
+        assert cfg is not None
+        assert cfg.cmd == str(Path("/usr/bin/gfortran"))
+
+    @pytest.mark.parametrize("cls", [GfortranCompiler, GfortranLinker])
+    def test_configure_returns_none_when_missing(self, cls, tmp_path):
+        from pcons.configure.config import Configure
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = lambda *a, **k: None  # type: ignore[method-assign]
+        assert cls().configure(config) is None
+
+    def test_linker_builders(self):
+        """GfortranLinker.builders exposes the GNU link builders."""
+        builders = GfortranLinker().builders()
+        assert "Program" in builders

--- a/tests/toolchains/test_llvm.py
+++ b/tests/toolchains/test_llvm.py
@@ -581,3 +581,33 @@ class TestLibcxxModulesManifest:
         )
         modules = _parse_libcxx_manifest(manifest)
         assert list(modules.keys()) == ["std"]
+
+
+class TestLlvmConfigure:
+    """Each tool's configure() delegates to _find_tool_config."""
+
+    @pytest.mark.parametrize(
+        "cls", [ClangCCompiler, ClangCxxCompiler, LlvmArchiver, LlvmLinker]
+    )
+    def test_configure_finds_program(self, cls, tmp_path):
+        from pathlib import Path
+
+        from pcons.configure.config import Configure, ProgramInfo
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda *a, **k: ProgramInfo(path=Path("/usr/bin/tool"), version="1.0")
+        )
+        cfg = cls().configure(config)
+        assert cfg is not None
+        assert cfg.cmd == str(Path("/usr/bin/tool"))
+
+    @pytest.mark.parametrize(
+        "cls", [ClangCCompiler, ClangCxxCompiler, LlvmArchiver, LlvmLinker]
+    )
+    def test_configure_returns_none_when_missing(self, cls, tmp_path):
+        from pcons.configure.config import Configure
+
+        config = Configure(build_dir=tmp_path)
+        config.find_program = lambda *a, **k: None  # type: ignore[method-assign]
+        assert cls().configure(config) is None

--- a/tests/toolchains/test_wasi.py
+++ b/tests/toolchains/test_wasi.py
@@ -257,3 +257,35 @@ class TestWasiRegistration:
         entry = toolchain_registry.get("wasi-sdk")
         assert entry is not None
         assert entry.toolchain_class is WasiToolchain
+
+
+class TestWasiHints:
+    """Tests for _wasi_hints search-hint helper."""
+
+    def test_none_when_no_sdk(self, monkeypatch):
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: None)
+        assert wasi._wasi_hints() is None
+
+    def test_returns_bin_when_found(self, monkeypatch, tmp_path):
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: tmp_path)
+        assert wasi._wasi_hints() == [tmp_path / "bin"]
+
+
+class TestWasiConfigureMissing:
+    """configure() returns None when the program is not found."""
+
+    @pytest.mark.parametrize(
+        "cls", [WasiCCompiler, WasiCxxCompiler, WasiArchiver, WasiLinker]
+    )
+    def test_configure_returns_none(self, cls, monkeypatch, tmp_path):
+        from pcons.configure.config import Configure
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "_wasi_hints", lambda: None)
+        config = Configure(build_dir=tmp_path)
+        config.find_program = lambda *a, **k: None  # type: ignore[method-assign]
+        assert cls().configure(config) is None

--- a/tests/tools/test_tool.py
+++ b/tests/tools/test_tool.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: MIT
 """Tests for pcons.tools.tool."""
 
+from pathlib import Path
+
+from pcons.configure.config import Configure, ProgramInfo
 from pcons.core.builder import Builder, CommandBuilder
 from pcons.core.environment import Environment
 from pcons.tools.tool import BaseTool, BuilderMethod, Tool
@@ -73,6 +76,59 @@ class TestBaseTool:
         # Builder should be callable from tool config
         assert hasattr(env.mock, "Compile")
         assert isinstance(env.mock.Compile, BuilderMethod)
+
+
+class TestFindToolConfig:
+    """Tests for BaseTool._find_tool_config (the shared configure helper)."""
+
+    def test_non_configure_returns_none(self):
+        tool = MockTool()
+        assert tool._find_tool_config(object(), "gcc") is None
+
+    def test_program_found(self, tmp_path):
+        tool = MockTool()
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda name, hints=None, version_flag="--version": ProgramInfo(
+                path=Path("/usr/bin/gcc")
+            )
+        )
+        cfg = tool._find_tool_config(config, "gcc")
+        assert cfg is not None
+        assert cfg.cmd == str(Path("/usr/bin/gcc"))
+
+    def test_with_version(self, tmp_path):
+        tool = MockTool()
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda name, hints=None, version_flag="--version": ProgramInfo(
+                path=Path("/usr/bin/gcc"), version="14.2.1"
+            )
+        )
+        cfg = tool._find_tool_config(config, "gcc", with_version=True)
+        assert cfg is not None
+        assert cfg.version == "14.2.1"
+
+    def test_not_found_returns_none(self, tmp_path):
+        tool = MockTool()
+        config = Configure(build_dir=tmp_path)
+        config.find_program = (  # type: ignore[method-assign]
+            lambda name, hints=None, version_flag="--version": None
+        )
+        assert tool._find_tool_config(config, "nope") is None
+
+    def test_falls_through_to_second_candidate(self, tmp_path):
+        tool = MockTool()
+        config = Configure(build_dir=tmp_path)
+        found = {"first": None, "second": ProgramInfo(path=Path("/usr/bin/second"))}
+
+        def fake_find(name, hints=None, version_flag="--version"):
+            return found[name]
+
+        config.find_program = fake_find  # type: ignore[method-assign]
+        cfg = tool._find_tool_config(config, "first", "second")
+        assert cfg is not None
+        assert cfg.cmd == str(Path("/usr/bin/second"))
 
 
 class TestBuilderMethod:


### PR DESCRIPTION
### Summary :memo:
Deduplicate the toolchains, generators, and configure layers by extracting shared bases, factories, and helpers, then cover every extracted helper with unit tests. Net -653 lines across `pcons/` (1007 added, 1660 removed) at 100% diff coverage of the change.

### Details
Drove `pcons/`-module duplication from 4.09% down to 0.72% (69 clones to 18) by pulling repeated logic into shared bases and helpers, one focused commit per clone. No behavior change - the extractions are byte-identical refactors verified by the existing suite. The remaining 0.72% is non-extractable residue: shared import blocks, generated stub signatures, and override-method/dataclass field lists.

1. GNU-style toolchains: shared the GCC/LLVM/gfortran object, archiver, and linker builders plus default vars into `gnu_common.py`, and routed every `configure()` through a single `BaseTool._find_tool_config` helper (GCC, LLVM, gfortran, Emscripten, WASI, clang-cl).
2. WebAssembly toolchains: extracted a `WasmToolchain` base for the suffix, source-dispatch, and variant/arch logic shared by Emscripten and WASI; SDK discovery and the linker stay in the concrete toolchains.
3. Graph generators: extracted a `GraphGenerator` base owning the traversal, label resolution, and depfile parsing, so DOT and Mermaid only provide per-node and per-edge text.
4. Configure checks: shared the cache/compiler preamble across the `check_*` methods via `ToolChecks._cached_or_compiler`.
5. Toolchain hooks: shared the flag-application and flags+defines apply loops across the preset and `apply_variant` hooks; shared install-target construction and the lazy Python-info cache for the Cython tools; shared a flag-merge helper in `CompileLinkContext` and dropped the redundant MSVC build-context overrides.
6. Tests: added unit coverage for all extracted helpers (`_find_tool_config`, `_cached_or_compiler`, `merge_scan_compile_flags`, the graph header-depfile paths, the preset/variant hooks, and every `configure()` including the Windows-gated clang-cl paths and the emsdk/wasi search hints), bringing diff coverage from 81% to 100%.

### Checks
- [ ] Closed #798
- [x] Tested Changes
- [ ] Stakeholder Approval
