### PR TITLE
Claude Fable 5 code review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ project.generate()
 ```
 
 ```bash
-uvx pcons # generate ninja.build and run it, producing build/myapp (or build/myapp.exe)
+uvx pcons # generate build.ninja and run it, producing build/myapp (or build/myapp.exe)
 ```
 
 ## Installation
@@ -118,7 +118,7 @@ make fmt
 
 # Or use uv directly
 uv run ruff check pcons/
-uv run mypy pcons/
+uvx ty check pcons/ examples/
 ```
 
 ## This Project is AI-Assisted

--- a/docs/plan-archive-builders.md
+++ b/docs/plan-archive-builders.md
@@ -53,7 +53,7 @@ project.Install("packages/", [docs_tar, release_zip])
 
 project.Default(docs_tar, release_zip)
 project.resolve()
-NinjaGenerator().generate(project, "build")
+Generator().generate(project)
 ```
 
 ## Implementation Approach

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,7 +94,7 @@ hello.add_sources(["hello.cpp"])
 project.Default(hello)
 
 # Resolve dependencies and generate build files
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 **3. Generate and build**:
@@ -256,7 +256,7 @@ Your script must call a generator at the end:
 project.resolve()
 
 # REQUIRED: Generate build files (Ninja is the default generator, but Makefile and Xcode generators are also included)
-Generator().generate(project, build_dir)
+Generator().generate(project)
 ```
 
 The `pcons` CLI executes your script but does NOT automatically call resolve/generate - your script controls when and how this happens. This gives you flexibility for conditional generation or multiple generators.
@@ -525,7 +525,7 @@ hello.private.compile_flags.extend(["-Wall", "-Wextra"])
 
 # Generate
 project.Default(hello)
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 **Build and run:**
@@ -615,7 +615,7 @@ calculator.private.compile_flags.extend(["-Wall", "-Wextra"])
 
 # Generate
 project.Default(calculator)
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 ### Static Library
@@ -664,7 +664,7 @@ app.add_sources([src_dir / "main.c"])
 app.private.link_libs.append(libmath)  # Gets libmath's public includes automatically!
 
 project.Default(app)
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 Key points:
@@ -717,7 +717,7 @@ app.add_sources([src_dir / "main.c"])
 app.private.link_libs.append(libplugin)
 
 project.Default(app, libplugin)
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 ### Project with Subdirectories
@@ -806,7 +806,7 @@ app = project.Program("myapp", env)
 app.add_sources(["main.c"])
 
 project.Default(app)
-Generator().generate(project, build_dir)
+Generator().generate(project)
 
 print(f"Variant: {variant}")
 print(f"Build dir: {build_dir}")
@@ -1022,7 +1022,7 @@ hello = project.Program("hello_fmt", env)
 hello.add_sources([project_dir / "src" / "main.cpp"])
 
 project.Default(hello)
-Generator().generate(project, build_dir)
+Generator().generate(project)
 ```
 
 #### sync_profile() Reference
@@ -1658,7 +1658,7 @@ Generate a traditional Makefile instead of Ninja build files:
 from pcons.generators.makefile import MakefileGenerator
 
 # Generate Makefile
-MakefileGenerator().generate(project, build_dir)
+MakefileGenerator().generate(project)
 # Creates build/Makefile
 ```
 
@@ -1678,7 +1678,7 @@ Generate dependency graphs:
 from pcons.generators.mermaid import MermaidGenerator
 
 # Generate Mermaid diagram
-MermaidGenerator().generate(project, build_dir)
+MermaidGenerator().generate(project)
 # Creates build/deps.mmd
 ```
 
@@ -2167,7 +2167,7 @@ msix = windows.create_msix(
 | `description` | Package description |
 | `processor_architecture` | `"x64"`, `"x86"`, or `"arm64"` (default: `"x64"`) |
 | `sign_cert` | Path to `.pfx` certificate for signing |
-| `sign_password` | Certificate password |
+| `sign_password_env` | Name of an environment variable holding the certificate password (not the password itself, so it's never baked into `build.ninja`) |
 
 #### Complete Platform-Conditional Example
 
@@ -2457,7 +2457,7 @@ lib_universal = create_universal_binary(
 )
 
 project.Default(lib_universal)
-Generator().generate(project, "build")
+Generator().generate(project)
 ```
 
 The `create_universal_binary()` function:

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -2960,7 +2960,6 @@ This is especially useful when porting CMake projects to pcons, since the templa
 | `config.define(name, value=1)` | Define a preprocessor symbol |
 | `config.undefine(name)` | Mark a symbol as undefined |
 | `config.check_sizeof(type)` | Get the size of a type and define `SIZEOF_*` |
-| `config.check_header(name)` | Check if a header exists |
 | `config.write_config_header(path)` | Generate a config.h file |
 | `ToolChecks(config, env, tool)` | Create feature checker for a tool |
 | `checks.check_flag(flag)` | Check if compiler accepts a flag |

--- a/examples/05_multi_library/test.toml
+++ b/examples/05_multi_library/test.toml
@@ -53,7 +53,7 @@ commands_windows = [
     { run = "type build\\compile_commands.json", expect_stdout = "math_utils.c" },
     { run = "type build\\compile_commands.json", expect_stdout = "physics.c" },
     { run = "type build\\compile_commands.json", expect_stdout = "main.c" },
-    { run = "type build\\compile_commands.json", expect_stdout = "-I" },
+    { run = "type build\\compile_commands.json", expect_stdout = "/I" },
 
     # Verify deps.mmd has the dependency graph (Windows uses different library names)
     { run = "type build\\deps.mmd", expect_stdout = "flowchart" },

--- a/examples/07_conan_example/test.toml
+++ b/examples/07_conan_example/test.toml
@@ -3,11 +3,12 @@
 
 [test]
 description = "Example showing how to use Conan packages with pcons"
+expected_outputs = ["build/hello_fmt"]
 
-[test.commands]
-generate = "uvx pcons generate"
-build = "ninja -C build"
-run = "./build/hello_fmt"
+[verify]
+commands = [
+    { run = "./build/hello_fmt", expect_stdout = "Hello from fmt" },
+]
 
 [skip]
 # Skip on Windows - MSVC/Conan integration requires VS Developer environment

--- a/examples/13_subdirs/test.toml
+++ b/examples/13_subdirs/test.toml
@@ -1,13 +1,14 @@
 # Test configuration for subdirs example
 
 [test]
+description = "Nested subdirectories with add_subdirectory()"
 # Build the complete project (no build_targets means build all defaults)
 
-[test.expected_output]
-# Check that all expected files are built
-# The object files are in obj.<target_name>/ directories
-files = [
-    "obj.foo/src/foo.c.o",
-    "obj.subdirs_demo/src/main.c.o",
-    "subdirs_demo",
+# Check that all expected files are built. Object files live under
+# obj.<target_name>/ directories, nested inside each subdir's own build
+# subdirectory (build/<subdir>/obj.<target_name>/...).
+expected_outputs = [
+    "build/libfoo/obj.foo/libfoo/src/foo.c.o",
+    "build/app/obj.app/app/src/main.c.o",
+    "build/app/app",
 ]

--- a/examples/32_latex/test.toml
+++ b/examples/32_latex/test.toml
@@ -2,9 +2,7 @@
 
 [test]
 description = "LaTeX PDF compilation via latexmk"
-
-[test.verify]
-files = ["build/main.pdf"]
+expected_outputs = ["build/main.pdf"]
 
 [skip]
 require_commands = ["latexmk"]

--- a/examples/README.md
+++ b/examples/README.md
@@ -52,15 +52,27 @@ Examples are run as part of the test suite:
 # Run all example tests
 uv run pytest tests/test_examples.py -v
 
-# Run a specific example
-uv run pytest tests/test_examples.py -v -k "concat"
+# Run a specific example (matches against its directory name)
+uv run pytest tests/test_examples.py -v -k "01_hello_c"
 ```
 
 ## Adding New Examples
 
-1. Create a new directory under `tests/examples/`
+1. Create a new directory under `examples/`, named `NN_short_description` (see
+   "Numbering" below for picking `NN`)
 2. Add source files and a `pcons-build.py`
 3. Add a `test.toml` describing expected outputs
 4. Run the tests to verify it works
 
 Examples should be simple and focused - each demonstrating one concept or use case.
+
+### Numbering
+
+Directories are prefixed with a two-digit number (`01_hello_c`, `02_multi_file`,
+...) that roughly reflects the order examples were introduced, not a strict
+ordering pcons relies on. A few prefixes were reused by mistake as examples
+were added independently (`30_cxx_partitions`/`30_restat`,
+`31_cxx_modules_optin`/`31_pkg_config`, `32_cxx_import_std`/`32_latex`). This is
+harmless — tests key off the full directory name, not the numeric prefix — so
+these are left as-is rather than renumbered. When adding a new example, just
+pick the next unused number after the highest one currently in `examples/`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,9 @@ theme:
 nav:
   - Home: index.md
   - User Guide: user-guide.md
+  - Presets: presets.md
   - Porting from CMake: porting-from-cmake.md
+  - Porting from Make: porting-from-make.md
   - Changelog: changelog.md
   - Architecture: architecture.md
   - Contributing: contributing.md

--- a/pcons/cli.py
+++ b/pcons/cli.py
@@ -916,10 +916,14 @@ def load_user_modules(args: argparse.Namespace) -> None:
     modules.load_modules(extra_paths)
 
 
-def find_command_in_argv(argv: list[str]) -> str | None:
-    """Find a valid command in argv, skipping options and their values.
+def _find_command_index(argv: list[str]) -> int | None:
+    """Find the index of the subcommand token in argv, or None.
 
-    Returns the command name if found, None otherwise.
+    Skips options and their values so an option value that happens to
+    equal a command name (e.g. ``--build-dir test``) is not mistaken for
+    the subcommand. Shared by :func:`find_command_in_argv` and the
+    ``pcons test`` dispatch in :func:`main`, so both agree on *where*
+    the command lives, not just its name.
     """
     valid_commands = {"info", "init", "generate", "build", "clean", "test"}
     # Options that take a value
@@ -957,9 +961,18 @@ def find_command_in_argv(argv: list[str]) -> str | None:
         else:
             # First positional argument
             if arg in valid_commands:
-                return arg
+                return i
             return None
     return None
+
+
+def find_command_in_argv(argv: list[str]) -> str | None:
+    """Find a valid command in argv, skipping options and their values.
+
+    Returns the command name if found, None otherwise.
+    """
+    idx = _find_command_index(argv)
+    return argv[idx] if idx is not None else None
 
 
 def add_build_args(parser: argparse.ArgumentParser) -> None:
@@ -1220,8 +1233,13 @@ def main() -> int:
     if command == "test":
         from pcons.test_runner import main as test_main
 
-        idx = sys.argv.index("test")
-        return test_main(sys.argv[idx + 1 :])
+        # Locate the subcommand positionally (same rules as
+        # find_command_in_argv) rather than scanning raw argv for the
+        # literal string "test", which could match an option's value
+        # (e.g. `pcons build --target test`).
+        idx = _find_command_index(sys.argv[1:])
+        assert idx is not None  # command == "test" guarantees a match
+        return test_main(sys.argv[idx + 2 :])
 
     # Special case: if --help or -h is present without a command,
     # use the full parser so help shows available commands

--- a/pcons/configure/checks.py
+++ b/pcons/configure/checks.py
@@ -181,16 +181,38 @@ class ToolChecks:
         self._config.set(cache_key, result.success)
         return result
 
+    def _is_msvc_style(self) -> bool:
+        """Whether the configured compiler uses MSVC-style command lines.
+
+        MSVC and clang-cl (in its cl.exe-compatible mode) both take
+        slash-flags (/c, /Fo, /Fe, /E, /WX, ...) instead of the Unix-style
+        flags (-c, -o, -l, -E, -Werror, ...) used by GCC/Clang.
+        """
+        toolchain = getattr(self._env, "_toolchain", None)
+        tc_name = getattr(toolchain, "name", "") if toolchain else ""
+        if tc_name:
+            return tc_name in ("msvc", "clang-cl")
+        # No toolchain object attached to the environment (e.g. a bare
+        # Environment with cc.cmd set directly) -- fall back to sniffing the
+        # compiler executable's name.
+        compiler = self._get_compiler() or ""
+        return Path(compiler).stem.lower() in ("cl", "clang-cl")
+
     def _get_werror_flag(self) -> str:
         """Return the appropriate treat-warnings-as-errors flag.
 
         MSVC and clang-cl use /WX; GCC and Clang use -Werror.
         """
-        toolchain = getattr(self._env, "_toolchain", None)
-        tc_name = getattr(toolchain, "name", "") if toolchain else ""
-        if tc_name in ("msvc", "clang-cl"):
-            return "/WX"
-        return "-Werror"
+        return "/WX" if self._is_msvc_style() else "-Werror"
+
+    def _lib_flag(self, lib: str) -> str:
+        """Return the command-line argument to link against a library.
+
+        MSVC/clang-cl take a bare "name.lib" argument; GCC/Clang take "-lname".
+        """
+        if self._is_msvc_style():
+            return lib if lib.lower().endswith(".lib") else f"{lib}.lib"
+        return f"-l{lib}"
 
     def check_flag(self, flag: str) -> CheckResult:
         """Check if the compiler accepts a flag.
@@ -314,7 +336,13 @@ class ToolChecks:
             self._tool_name,
             self._caller_location(),
         )
-        cache_key = self._cache_key("type", type_name)
+        # Include headers in the cache key: the same type name can exist or
+        # not depending on which headers are included (e.g. a typedef only
+        # visible via a specific header).
+        cache_parts = [type_name]
+        if headers:
+            cache_parts.extend(sorted(headers))
+        cache_key = self._cache_key("type", *cache_parts)
         outcome = self._cached_or_compiler(cache_key)
         if isinstance(outcome, CheckResult):
             return outcome
@@ -354,7 +382,11 @@ class ToolChecks:
             self._tool_name,
             self._caller_location(),
         )
-        cache_key = self._cache_key("sizeof", type_name)
+        # Include headers in the cache key, same rationale as check_type().
+        cache_parts = [type_name]
+        if headers:
+            cache_parts.extend(sorted(headers))
+        cache_key = self._cache_key("sizeof", *cache_parts)
         cached = self._config.get(cache_key)
         if cached is not None:
             trace("configure", "  cached: %s", cached)
@@ -425,8 +457,10 @@ PCONS_UNDEFINED
 #endif
 """
         cdir = self._make_check_dir()
-        result = self._try_preprocess(compiler, source, check_dir=cdir)
-        self._cleanup_check_dir(*cdir)
+        try:
+            result = self._try_preprocess(compiler, source, check_dir=cdir)
+        finally:
+            self._cleanup_check_dir(*cdir)
         if not result.success:
             self._config.set(cache_key, "__UNDEFINED__")
             return None
@@ -471,7 +505,15 @@ PCONS_UNDEFINED
             self._tool_name,
             self._caller_location(),
         )
-        cache_key = self._cache_key("function", function)
+        # Include headers/libs in the cache key: they change what the probe
+        # actually compiles/links against, so a different combo must not
+        # collide with (or hit) another combo's cached result.
+        cache_parts = [function]
+        if headers:
+            cache_parts.extend(sorted(headers))
+        if libs:
+            cache_parts.extend(sorted(libs))
+        cache_key = self._cache_key("function", *cache_parts)
         outcome = self._cached_or_compiler(cache_key)
         if isinstance(outcome, CheckResult):
             return outcome
@@ -492,7 +534,7 @@ int main(void) {{
 """
         extra_flags: list[str] = []
         if libs:
-            extra_flags.extend(f"-l{lib}" for lib in libs)
+            extra_flags.extend(self._lib_flag(lib) for lib in libs)
 
         cdir = self._make_check_dir()
         try:
@@ -567,16 +609,25 @@ int main(void) {{
 
         try:
             src_path = dir_path / f"check{suffix}"
-            out_path = dir_path / "check.out"
-
             src_path.write_text(source)
 
-            cmd = [compiler]
-            if not link:
-                cmd.append("-c")
-            cmd.extend(["-o", str(out_path), str(src_path)])
-            if extra_flags:
-                cmd.extend(extra_flags)
+            if self._is_msvc_style():
+                out_path = dir_path / ("check.exe" if link else "check.obj")
+                cmd = [compiler, "/nologo"]
+                if extra_flags:
+                    cmd.extend(extra_flags)
+                if not link:
+                    cmd.append("/c")
+                cmd.append(f"/Fe{out_path}" if link else f"/Fo{out_path}")
+                cmd.append(str(src_path))
+            else:
+                out_path = dir_path / "check.out"
+                cmd = [compiler]
+                if not link:
+                    cmd.append("-c")
+                cmd.extend(["-o", str(out_path), str(src_path)])
+                if extra_flags:
+                    cmd.extend(extra_flags)
 
             trace("configure", "  cmd: %s", " ".join(cmd))
 
@@ -629,7 +680,10 @@ int main(void) {{
             src_path = dir_path / f"check{suffix}"
             src_path.write_text(source)
 
-            cmd = [compiler, "-E", str(src_path)]
+            if self._is_msvc_style():
+                cmd = [compiler, "/nologo", "/E", str(src_path)]
+            else:
+                cmd = [compiler, "-E", str(src_path)]
             trace("configure", "  cmd: %s", " ".join(cmd))
 
             try:

--- a/pcons/configure/config.py
+++ b/pcons/configure/config.py
@@ -84,6 +84,11 @@ class Configure:
         self._cache: dict[str, Any] = {}
         self._toolchains: dict[str, Toolchain] = {}
         self._programs: dict[str, ProgramInfo] = {}
+        # Derived output state for the config header. Rebuilt fresh from the
+        # define()/undefine()/check_*() calls made *this run* — never loaded
+        # from or persisted to the cache, so a removed define() call actually
+        # stops emitting once the build script no longer calls it.
+        self._defines: dict[str, str | int | None] = {}
 
         # Try to load existing cache
         self._load_cache()
@@ -167,19 +172,13 @@ class Configure:
         """
         trace("configure", "Finding program: %s", name)
 
-        # Check cache first
         cache_key = f"program:{name}"
-        if cache_key in self._cache:
-            cached = self._cache[cache_key]
-            path = Path(cached["path"])
-            if path.exists():
-                trace("configure", "  Found in cache: %s", path)
-                return ProgramInfo(path=path, version=cached.get("version"))
 
-        # Search for the program
+        # Explicit hints are the caller's most specific instruction, so they
+        # take priority over both the cache and PATH. This lets a caller
+        # override a stale/cached result (e.g. a different compiler install)
+        # by passing hints=[...].
         found_path: Path | None = None
-
-        # Check hints first
         if hints:
             for hint in hints:
                 hint_path = Path(hint)
@@ -193,6 +192,14 @@ class Configure:
                 if candidate.is_file() and os.access(candidate, os.X_OK):
                     found_path = candidate
                     break
+
+        # No hint match: fall back to the cache.
+        if found_path is None and cache_key in self._cache:
+            cached = self._cache[cache_key]
+            path = Path(cached["path"])
+            if path.exists():
+                trace("configure", "  Found in cache: %s", path)
+                return ProgramInfo(path=path, version=cached.get("version"))
 
         # Search PATH
         if found_path is None:
@@ -293,50 +300,19 @@ class Configure:
         """
         self._toolchains[toolchain.name] = toolchain
 
-    def check_compile(
-        self,
-        source: str,
-        *,
-        lang: str = "c",
-        flags: list[str] | None = None,
-    ) -> bool:
-        """Check if source code compiles.
-
-        Args:
-            source: Source code to compile.
-            lang: Language ('c' or 'cxx').
-            flags: Additional compiler flags.
-
-        Returns:
-            True if compilation succeeds.
-        """
-        # This is a placeholder - real implementation needs a compiler
-        # Will be implemented when toolchains are available
-        return False
-
-    def check_link(
-        self,
-        source: str,
-        *,
-        lang: str = "c",
-        flags: list[str] | None = None,
-        libs: list[str] | None = None,
-    ) -> bool:
-        """Check if source code compiles and links.
-
-        Args:
-            source: Source code to compile.
-            lang: Language ('c' or 'cxx').
-            flags: Additional compiler flags.
-            libs: Libraries to link.
-
-        Returns:
-            True if compilation and linking succeed.
-        """
-        # Placeholder - needs compiler/linker
-        return False
-
     # Feature check methods that track results for config header generation
+    #
+    # Note: there is no Configure.check_header()/check_symbol()/check_compile()
+    # here. Compiling a test program requires a real compiler, which means an
+    # Environment and a specific tool (e.g. "cc"/"cxx") — state that Configure
+    # itself does not have. Use ToolChecks (pcons.configure.checks) to run the
+    # actual compile probes, then record the outcome with define()/undefine():
+    #
+    #     checks = ToolChecks(config, env, "cc")
+    #     if checks.check_header("stdint.h").success:
+    #         config.define("HAVE_STDINT_H")
+    #     else:
+    #         config.undefine("HAVE_STDINT_H")
 
     def define(self, name: str, value: str | int | bool = 1) -> None:
         """Define a preprocessor macro for the config header.
@@ -353,11 +329,10 @@ class Configure:
             config.define("VERSION_MINOR", 2)
             config.define("HAVE_CUSTOM_FEATURE")
         """
-        defines = self._cache.setdefault("_defines", {})
         if isinstance(value, bool):
-            defines[name] = 1 if value else None  # None means #undef
+            self._defines[name] = 1 if value else None  # None means #undef
         else:
-            defines[name] = value
+            self._defines[name] = value
 
     def undefine(self, name: str) -> None:
         """Mark a macro as undefined for the config header.
@@ -367,56 +342,7 @@ class Configure:
         Args:
             name: Macro name.
         """
-        defines = self._cache.setdefault("_defines", {})
-        defines[name] = None
-
-    def check_header(
-        self,
-        header: str,
-        *,
-        define_name: str | None = None,
-        lang: str = "c",
-    ) -> bool:
-        """Check if a header file exists and can be included.
-
-        If found, defines HAVE_<HEADER>_H (with dots and slashes replaced).
-
-        Args:
-            header: Header file name (e.g., "stdint.h", "sys/types.h").
-            define_name: Override for the define name.
-            lang: Language ('c' or 'cxx').
-
-        Returns:
-            True if header is available.
-
-        Example:
-            if config.check_header("stdint.h"):
-                # HAVE_STDINT_H is defined
-                pass
-        """
-        # Cache key for this check
-        cache_key = f"header:{header}"
-        if cache_key in self._cache:
-            result = bool(self._cache[cache_key])
-        else:
-            # Try to compile a simple include
-            source = f"#include <{header}>\nint main(void) {{ return 0; }}\n"
-            result = self.check_compile(source, lang=lang)
-            self._cache[cache_key] = result
-
-        # Generate define name
-        if define_name is None:
-            # HAVE_STDINT_H, HAVE_SYS_TYPES_H, etc.
-            safe_name = header.upper().replace(".", "_").replace("/", "_")
-            define_name = f"HAVE_{safe_name}"
-
-        # Record the result
-        if result:
-            self.define(define_name)
-        else:
-            self.undefine(define_name)
-
-        return result
+        self._defines[name] = None
 
     def check_sizeof(
         self,
@@ -486,62 +412,6 @@ class Configure:
 
         return size_map.get(type_name.lower())
 
-    def check_symbol(
-        self,
-        symbol: str,
-        *,
-        header: str | None = None,
-        define_name: str | None = None,
-        lang: str = "c",
-    ) -> bool:
-        """Check if a symbol (function, variable, macro) exists.
-
-        Defines HAVE_<SYMBOL> if the symbol exists.
-
-        Args:
-            symbol: Symbol name (e.g., "pthread_create", "M_PI").
-            header: Header file that declares the symbol.
-            define_name: Override for the define name.
-            lang: Language ('c' or 'cxx').
-
-        Returns:
-            True if symbol exists.
-
-        Example:
-            if config.check_symbol("pthread_create", header="pthread.h"):
-                # HAVE_PTHREAD_CREATE is defined
-                pass
-        """
-        cache_key = f"symbol:{symbol}"
-        if cache_key in self._cache:
-            result = bool(self._cache[cache_key])
-        else:
-            # Build test source
-            include = f"#include <{header}>\n" if header else ""
-            # Try different approaches to detect the symbol
-            # First try using it as a function pointer (works for functions)
-            source = f"""{include}
-int main(void) {{
-    void (*fp)(void) = (void (*)(void)){symbol};
-    (void)fp;
-    return 0;
-}}
-"""
-            result = self.check_compile(source, lang=lang)
-            self._cache[cache_key] = result
-
-        # Generate define name
-        if define_name is None:
-            safe_name = symbol.upper()
-            define_name = f"HAVE_{safe_name}"
-
-        if result:
-            self.define(define_name)
-        else:
-            self.undefine(define_name)
-
-        return result
-
     def write_config_header(
         self,
         path: Path | str,
@@ -560,7 +430,9 @@ int main(void) {{
             include_platform: Include platform detection macros.
 
         Example:
-            config.check_header("stdint.h")
+            checks = ToolChecks(config, env, "cc")
+            if checks.check_header("stdint.h").success:
+                config.define("HAVE_STDINT_H")
             config.check_sizeof("int")
             config.define("VERSION", "1.0.0")
             config.write_config_header("config.h")
@@ -609,7 +481,7 @@ int main(void) {{
             lines.append("")
 
         # Collect defines by category
-        defines = self._cache.get("_defines", {})
+        defines = self._defines
 
         # Separate into categories
         have_defs = {k: v for k, v in defines.items() if k.startswith("HAVE_")}
@@ -657,9 +529,14 @@ int main(void) {{
         lines.append(f"#endif /* {guard} */")
         lines.append("")
 
-        # Write the file
+        # Write-if-changed: avoid bumping the file's mtime (and triggering a
+        # full rebuild of everything that includes it) when the content is
+        # unchanged from the previous run.
+        content = "\n".join(lines)
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text("\n".join(lines))
+        if path.exists() and path.read_text() == content:
+            return
+        path.write_text(content)
 
     def __repr__(self) -> str:
         return (

--- a/pcons/contrib/bundle.py
+++ b/pcons/contrib/bundle.py
@@ -15,6 +15,7 @@ These are building blocks that domain-specific modules can use:
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -54,6 +55,11 @@ def generate_info_plist(
         >>> plist = generate_info_plist("MyPlugin", "1.0.0", bundle_type="BNDL")
         >>> (bundle_dir / "Contents" / "Info.plist").write_text(plist)
     """
+    # Deferred import: importing _helpers at module scope triggers a runpy
+    # "found in sys.modules after import of package" RuntimeWarning when a
+    # build script is run via `python -m`.
+    from pcons.contrib.installers._helpers import _xml_escape
+
     if identifier is None:
         # Sanitize name for bundle identifier
         safe_name = name.replace(" ", "").replace("-", "")
@@ -70,29 +76,29 @@ def generate_info_plist(
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>
-    <string>{executable}</string>
+    <string>{_xml_escape(executable)}</string>
     <key>CFBundleIdentifier</key>
-    <string>{identifier}</string>
+    <string>{_xml_escape(identifier)}</string>
     <key>CFBundleInfoDictionaryVersion</key>
     <string>6.0</string>
     <key>CFBundleName</key>
-    <string>{name}</string>
+    <string>{_xml_escape(name)}</string>
     <key>CFBundlePackageType</key>
-    <string>{bundle_type}</string>
+    <string>{_xml_escape(bundle_type)}</string>
     <key>CFBundleShortVersionString</key>
-    <string>{version}</string>
+    <string>{_xml_escape(version)}</string>
     <key>CFBundleSignature</key>
-    <string>{signature}</string>
+    <string>{_xml_escape(signature)}</string>
     <key>CFBundleVersion</key>
-    <string>{version}</string>
+    <string>{_xml_escape(version)}</string>
     <key>LSMinimumSystemVersion</key>
-    <string>{min_os_version}</string>
+    <string>{_xml_escape(min_os_version)}</string>
 """
 
     if extra_keys:
         for key, value in extra_keys.items():
-            plist += f"    <key>{key}</key>\n"
-            plist += f"    <string>{value}</string>\n"
+            plist += f"    <key>{_xml_escape(key)}</key>\n"
+            plist += f"    <string>{_xml_escape(value)}</string>\n"
 
     plist += """\
 </dict>
@@ -103,7 +109,7 @@ def generate_info_plist(
 
 def create_macos_bundle(
     project: Project,
-    env: Environment,  # noqa: ARG001 - kept for API consistency
+    env: Environment,
     plugin: Target,
     *,
     bundle_dir: Path | str,
@@ -155,11 +161,23 @@ def create_macos_bundle(
     # Install Info.plist
     if info_plist is not None:
         if isinstance(info_plist, str):
-            # Write plist content to file, then install
-            # Note: This creates a source node; the actual file should exist
-            # In practice, the user should write the plist file themselves
-            # or use env.Command to generate it
-            pass
+            # Generate the plist content into a build-dir file, then install
+            # it into the bundle's Contents directory, mirroring the Path
+            # branch below.
+            plist_path = Path(".bundle_staging") / bundle_path.name / "Info.plist"
+            python_cmd = sys.executable.replace("\\", "/")
+            plist_target = env.Command(
+                target=plist_path,
+                source=None,
+                command=[
+                    python_cmd,
+                    "-c",
+                    f"import pathlib; pathlib.Path({str(plist_path)!r})"
+                    f".write_text({info_plist!r}, encoding='utf-8')",
+                ],
+                name=f"info_plist_{bundle_path.stem}",
+            )
+            project.Install(contents_dir, [plist_target])
         elif isinstance(info_plist, Path):
             project.Install(contents_dir, [info_plist])
 

--- a/pcons/contrib/installers/_helpers.py
+++ b/pcons/contrib/installers/_helpers.py
@@ -13,8 +13,10 @@ for proper ninja integration, or called directly from Python.
 from __future__ import annotations
 
 import argparse
+import os
 import plistlib
 import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -284,6 +286,50 @@ def _xml_escape(text: str) -> str:
     )
 
 
+def sign_msix(
+    input_path: Path,
+    output_path: Path,
+    *,
+    signtool: str,
+    cert: Path,
+    password_env: str | None = None,
+) -> None:
+    """Copy an MSIX package and sign the copy with SignTool.
+
+    SignTool signs a file in place rather than producing a new file, so this
+    copies ``input_path`` to ``output_path`` first and signs that copy. The
+    original ``input_path`` is left untouched as an unsigned artifact.
+
+    Args:
+        input_path: Path to the unsigned .msix package.
+        output_path: Path to write the signed .msix package to.
+        signtool: Path to SignTool.exe.
+        cert: Path to the .pfx signing certificate.
+        password_env: Name of an environment variable holding the
+            certificate password. The password itself is never passed
+            through the build description or written to the build file;
+            it is read from the process environment when this runs.
+
+    Raises:
+        InstallerError: If password_env is given but the named environment
+            variable is not set.
+    """
+    shutil.copy(input_path, output_path)
+
+    sign_args = [signtool, "sign", "/fd", "SHA256", "/f", str(cert)]
+    if password_env:
+        password = os.environ.get(password_env)
+        if not password:
+            raise InstallerError(
+                f"Environment variable '{password_env}' is not set; "
+                "cannot sign MSIX package without the certificate password."
+            )
+        sign_args.extend(["/p", password])
+    sign_args.append(str(output_path))
+
+    subprocess.run(sign_args, check=True)
+
+
 def generate_msix_assets(output_dir: Path) -> None:
     """Generate placeholder PNG assets for MSIX packaging.
 
@@ -390,6 +436,19 @@ def main() -> int:
         "--output-dir", "-o", required=True, help="Output directory"
     )
 
+    # sign_msix command
+    sign_parser = subparsers.add_parser(
+        "sign_msix", help="Copy an MSIX package and sign the copy with SignTool"
+    )
+    sign_parser.add_argument("--input", required=True, help="Unsigned .msix path")
+    sign_parser.add_argument("--output", required=True, help="Signed .msix output path")
+    sign_parser.add_argument("--signtool", required=True, help="Path to SignTool.exe")
+    sign_parser.add_argument("--cert", required=True, help="Path to .pfx certificate")
+    sign_parser.add_argument(
+        "--password-env",
+        help="Environment variable holding the certificate password",
+    )
+
     args = parser.parse_args()
 
     if args.command == "gen_plist":
@@ -424,6 +483,14 @@ def main() -> int:
         )
     elif args.command == "gen_msix_assets":
         generate_msix_assets(Path(args.output_dir))
+    elif args.command == "sign_msix":
+        sign_msix(
+            Path(args.input),
+            Path(args.output),
+            signtool=args.signtool,
+            cert=Path(args.cert),
+            password_env=args.password_env,
+        )
 
     return 0
 

--- a/pcons/contrib/installers/macos.py
+++ b/pcons/contrib/installers/macos.py
@@ -83,30 +83,21 @@ def _validate_staging_path(project: Project, staging_prefix: str) -> None:
     for target in project.targets:
         for node in target.output_nodes:
             node_path = node.path
-            try:
-                # Check if node path would be under or conflict with staging
-                node_path.relative_to(staging_path)
+            if node_path.is_relative_to(staging_path):
                 raise ValueError(
                     f"Installer staging path '{staging_path}' conflicts with "
                     f"target '{target.name}' output: {node_path}. "
                     f"Rename the target's output or use a different build directory."
                 )
-            except ValueError:
-                # Not under staging path - this is expected
-                pass
 
     # Check for conflicts with existing nodes in project
     for node_path in project._nodes:
-        try:
-            node_path.relative_to(staging_path)
+        if node_path.is_relative_to(staging_path):
             raise ValueError(
                 f"Installer staging path '{staging_path}' conflicts with "
                 f"existing build node: {node_path}. "
                 f"This may indicate a naming conflict in your build configuration."
             )
-        except ValueError:
-            # Not under staging path - this is expected
-            pass
 
 
 def create_component_pkg(

--- a/pcons/contrib/installers/windows.py
+++ b/pcons/contrib/installers/windows.py
@@ -89,7 +89,7 @@ def create_msix(
     description: str | None = None,
     processor_architecture: str = "x64",
     sign_cert: Path | None = None,
-    sign_password: str | None = None,
+    sign_password_env: str | None = None,
 ) -> Target:
     """Create a Windows MSIX package using MakeAppx.exe.
 
@@ -112,7 +112,11 @@ def create_msix(
         description: Package description.
         processor_architecture: Target architecture ("x64", "x86", "arm64").
         sign_cert: Path to .pfx certificate for signing.
-        sign_password: Password for the certificate.
+        sign_password_env: Name of an environment variable holding the
+            certificate password. The password itself is never embedded in
+            the generated build file; it is read from the environment when
+            the signing step actually runs. Leave unset for certificates
+            that don't require a password.
 
     Returns:
         Target representing the .msix file.
@@ -238,20 +242,30 @@ def create_msix(
                 "Install Windows SDK for code signing support",
             )
 
+        # SignTool signs its target in place rather than producing a new
+        # file. Route through the _helpers CLI (like the manifest/assets
+        # steps above) so the declared ninja target is the file that's
+        # actually written: a copy of the unsigned .msix is made and that
+        # copy is signed, leaving the unsigned package intact.
+        signed_output = output.with_suffix(".signed.msix")
         sign_cmd = [
+            python_cmd,
+            "-m",
+            "pcons.contrib.installers._helpers",
+            "sign_msix",
+            "--input",
+            str(output),
+            "--output",
+            str(signed_output),
+            "--signtool",
             signtool,
-            "sign",
-            "/fd",
-            "SHA256",
-            "/f",
+            "--cert",
             str(sign_cert),
+            *(["--password-env", sign_password_env] if sign_password_env else []),
         ]
-        if sign_password:
-            sign_cmd.extend(["/p", sign_password])
-        sign_cmd.append(str(output))
 
         signed_target = env.Command(
-            target=output.with_suffix(".signed.msix"),
+            target=signed_output,
             source=[msix_target],
             command=sign_cmd,
             name=f"sign_{name}",

--- a/pcons/contrib/windows/msvcup.py
+++ b/pcons/contrib/windows/msvcup.py
@@ -17,6 +17,7 @@ See https://github.com/marler8997/msvcup for more information.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 import os
 import subprocess
@@ -28,6 +29,28 @@ from pathlib import Path
 from pcons.configure.platform import get_platform
 
 logger = logging.getLogger(__name__)
+
+# SHA-256 checksums for the pinned msvcup release archives, keyed by
+# (msvcup_version, host_arch). These are the checksums GitHub computes
+# automatically for each uploaded release asset -- not something msvcup
+# itself publishes -- but they let us pin the exact bytes we expect for a
+# given release and refuse to run anything else (e.g. a MITM'd or
+# compromised download).
+#
+# To update when bumping the default `msvcup_version`, fetch the digest
+# for each windows zip asset, e.g.:
+#   gh release view <tag> --repo marler8997/msvcup --json assets \
+#     --jq '.assets[] | select(.name | endswith("windows.zip")) | "\(.name) \(.digest)"'
+# or, without `gh`:
+#   curl -sL <asset-url> | sha256sum
+_RELEASE_SHA256: dict[tuple[str, str], str] = {
+    ("v2026_02_07", "x86_64"): (
+        "fdc1743a766ee96ebb912b3cd657f4cc2bc773a125887f4a05242230d0554124"
+    ),
+    ("v2026_02_07", "aarch64"): (
+        "53192e26737f450c8b97ab949069fb96cc017e90230aa7c11e7dc2e47127b90c"
+    ),
+}
 
 
 class MsvcUp:
@@ -155,6 +178,7 @@ class MsvcUp:
 
         logger.info("Downloading msvcup %s for %s...", self._msvcup_version, host_arch)
         urllib.request.urlretrieve(zip_url, zip_path)  # noqa: S310
+        self._verify_checksum(zip_path, host_arch)
 
         msvcup_exe.parent.mkdir(parents=True, exist_ok=True)
         with zipfile.ZipFile(zip_path) as zf:
@@ -170,6 +194,42 @@ class MsvcUp:
 
         logger.info("Installed msvcup to %s", msvcup_exe)
         return msvcup_exe
+
+    def _verify_checksum(self, zip_path: Path, host_arch: str) -> None:
+        """Verify a downloaded archive against its pinned SHA-256 checksum.
+
+        Fails closed: if no checksum is pinned for this version/arch, or the
+        computed digest doesn't match, the downloaded file is deleted and a
+        ``RuntimeError`` is raised rather than extracting and executing an
+        unverified binary.
+        """
+        expected = _RELEASE_SHA256.get((self._msvcup_version, host_arch))
+        if expected is None:
+            zip_path.unlink(missing_ok=True)
+            msg = (
+                f"No pinned SHA-256 checksum for msvcup {self._msvcup_version} "
+                f"({host_arch}); refusing to run an unverified download. "
+                "Add an entry to _RELEASE_SHA256 in msvcup.py -- see the "
+                "comment above that dict for how to get the hash."
+            )
+            raise RuntimeError(msg)
+
+        digest = hashlib.sha256()
+        with open(zip_path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                digest.update(chunk)
+        actual = digest.hexdigest()
+
+        if actual != expected:
+            zip_path.unlink(missing_ok=True)
+            msg = (
+                f"msvcup download checksum mismatch for {self._msvcup_version} "
+                f"({host_arch}): expected {expected}, got {actual}. The "
+                "downloaded file has been deleted. This may indicate a "
+                "corrupted download or a tampered/compromised source -- "
+                "refusing to execute it."
+            )
+            raise RuntimeError(msg)
 
     # -- Install + autoenv ----------------------------------------------------
 

--- a/pcons/core/_project_builder_stubs.py
+++ b/pcons/core/_project_builder_stubs.py
@@ -175,7 +175,7 @@ if TYPE_CHECKING:
             description: str | None = None,
             processor_architecture: str = 'x64',
             sign_cert: Path | None = None,
-            sign_password: str | None = None,
+            sign_password_env: str | None = None,
         ) -> Target:
             """Create a Windows MSIX package [win32 only]"""
             ...

--- a/pcons/core/graph.py
+++ b/pcons/core/graph.py
@@ -34,18 +34,20 @@ def topological_sort_targets(targets: list[Target]) -> list[Target]:
     if not targets:
         return []
 
-    # Build adjacency list and in-degree count
+    # Build adjacency list and in-degree count. Keyed on qualified_name
+    # (project::target) rather than the bare name, since two targets in
+    # different (sub)projects may legitimately share a short name.
     # target -> set of targets that depend on it
-    dependents: dict[str, set[str]] = {t.name: set() for t in targets}
+    dependents: dict[str, set[str]] = {t.qualified_name: set() for t in targets}
     # target -> number of dependencies not yet processed
-    in_degree: dict[str, int] = {t.name: 0 for t in targets}
-    target_map: dict[str, Target] = {t.name: t for t in targets}
+    in_degree: dict[str, int] = {t.qualified_name: 0 for t in targets}
+    target_map: dict[str, Target] = {t.qualified_name: t for t in targets}
 
     for target in targets:
         for dep in target.dependencies:
-            if dep.name in dependents:
-                dependents[dep.name].add(target.name)
-                in_degree[target.name] += 1
+            if dep.qualified_name in dependents:
+                dependents[dep.qualified_name].add(target.qualified_name)
+                in_degree[target.qualified_name] += 1
 
     # Start with targets that have no dependencies
     queue = deque(name for name, count in in_degree.items() if count == 0)
@@ -82,11 +84,23 @@ def detect_cycles_in_targets(targets: list[Target]) -> list[list[str]]:
         Empty list if no cycles.
     """
     cycles: list[list[str]] = []
-    target_map: dict[str, Target] = {t.name: t for t in targets}
+    # Keyed on qualified_name (project::target): two targets in different
+    # (sub)projects may legitimately share a short name.
+    target_map: dict[str, Target] = {t.qualified_name: t for t in targets}
 
     # Colors: 0=white (unvisited), 1=gray (in progress), 2=black (done)
-    colors: dict[str, int] = {t.name: 0 for t in targets}
+    colors: dict[str, int] = {t.qualified_name: 0 for t in targets}
     path: list[str] = []
+
+    def target_deps(target: Target) -> list[Target]:
+        # Include implicit target deps from target.depends(other_target):
+        # they are real must-resolve-before edges (see Resolver._resolve_target)
+        # even though they don't propagate into .dependencies.
+        return [
+            *target.dependencies,
+            *target._implicit_target_deps,
+            *target._implicit_target_deps_output_only,
+        ]
 
     def dfs(name: str) -> None:
         colors[name] = 1  # Gray - in progress
@@ -94,23 +108,24 @@ def detect_cycles_in_targets(targets: list[Target]) -> list[list[str]]:
 
         target = target_map.get(name)
         if target:
-            for dep in target.dependencies:
-                if dep.name not in colors:
+            for dep in target_deps(target):
+                dep_name = dep.qualified_name
+                if dep_name not in colors:
                     # External dependency, skip
                     continue
-                if colors[dep.name] == 1:
+                if colors[dep_name] == 1:
                     # Found a back edge - there's a cycle
-                    cycle_start = path.index(dep.name)
-                    cycles.append(path[cycle_start:] + [dep.name])
-                elif colors[dep.name] == 0:
-                    dfs(dep.name)
+                    cycle_start = path.index(dep_name)
+                    cycles.append(path[cycle_start:] + [dep_name])
+                elif colors[dep_name] == 0:
+                    dfs(dep_name)
 
         path.pop()
         colors[name] = 2  # Black - done
 
     for target in targets:
-        if colors[target.name] == 0:
-            dfs(target.name)
+        if colors[target.qualified_name] == 0:
+            dfs(target.qualified_name)
 
     return cycles
 
@@ -178,9 +193,9 @@ def collect_all_nodes(targets: list[Target]) -> set[Node]:
     visited_targets: set[str] = set()
 
     def collect_from_target(target: Target) -> None:
-        if target.name in visited_targets:
+        if target.qualified_name in visited_targets:
             return
-        visited_targets.add(target.name)
+        visited_targets.add(target.qualified_name)
 
         # Add this target's nodes and sources
         result.update(target.nodes)
@@ -211,9 +226,9 @@ def collect_build_order(target: Target) -> list[Target]:
     visited: set[str] = set()
 
     def collect(t: Target) -> None:
-        if t.name in visited:
+        if t.qualified_name in visited:
             return
-        visited.add(t.name)
+        visited.add(t.qualified_name)
 
         # Collect dependencies first
         for dep in t.dependencies:

--- a/pcons/core/project.py
+++ b/pcons/core/project.py
@@ -523,17 +523,91 @@ class Project(_ProjectBuilders):
         These are built when 'ninja' is run with no arguments.
 
         Args:
-            *targets: Targets, nodes, or alias names to build by default.
+            *targets: Targets, output Nodes, or alias/target names to build
+                by default. A Node must already be a registered output of
+                some target (e.g. from ``env.Command()``); it is resolved to
+                that owning target, since defaults are ultimately consumed
+                as targets by the generators.
+
+        Raises:
+            ValueError: If a Node isn't the output of any registered target,
+                or an alias resolves to no target-backed output.
+            KeyError: If a string name matches neither an alias nor a target.
         """
         for t in targets:
-            if isinstance(t, Target):
-                if t not in self._default_targets:
-                    self._default_targets.append(t)
-            elif isinstance(t, str):
-                # Look up by name
-                target = self.get_target(t)
-                if target and target not in self._default_targets:
-                    self._default_targets.append(target)
+            match t:
+                case Target():
+                    self._add_default_target(t)
+                case Node():
+                    target = self._find_target_for_node(t)
+                    if target is None:
+                        raise ValueError(
+                            f"Default(): {t!r} is not an output of any "
+                            f"target registered in project '{self.name}', "
+                            "so it can't be used as a default build target. "
+                            "Pass the owning Target instead, or call "
+                            "Default() with the node after its target has "
+                            "produced its outputs (e.g. after resolve())."
+                        )
+                    self._add_default_target(target)
+                case str():
+                    for target in self._resolve_default_name(t):
+                        self._add_default_target(target)
+                case _:
+                    raise TypeError(
+                        f"Default() arguments must be Target, Node, or str; "
+                        f"got {type(t)!r}"
+                    )
+
+    def _add_default_target(self, target: Target) -> None:
+        """Register `target` as a default build target, deduping by identity."""
+        if target not in self._default_targets:
+            self._default_targets.append(target)
+
+    def _find_target_for_node(self, node: Node) -> Target | None:
+        """Find the target (in this project or its children) that produced `node`.
+
+        Searches intermediate/output nodes, so this only succeeds for nodes
+        that already exist -- e.g. outputs of eagerly-built targets such as
+        ``env.Command()``. Compile/link target outputs aren't populated
+        until ``resolve()`` runs. Returns None if no target produced `node`.
+        """
+        for target in self.targets:
+            if node in target.output_nodes or node in target.intermediate_nodes:
+                return target
+        return None
+
+    def _resolve_default_name(self, name: str) -> list[Target]:
+        """Resolve a Default() string argument to one or more targets.
+
+        Tries `name` as an alias first (an alias may wrap several targets),
+        then as a plain target name.
+        """
+        alias = self._aliases.get(name)
+        if alias is not None:
+            resolved: list[Target] = list(alias._target_refs)
+            for node in alias._nodes:
+                target = self._find_target_for_node(node)
+                if target is not None and target not in resolved:
+                    resolved.append(target)
+            if not resolved:
+                raise ValueError(
+                    f"Default(): alias '{name}' does not resolve to any "
+                    "target-backed build output, so it can't be used as a "
+                    "default build target."
+                )
+            return resolved
+
+        target = self.get_target(name, raise_if_missing=False)
+        if target is not None:
+            return [target]
+
+        raise KeyError(
+            f"Default(): '{name}' is not a known alias or target in "
+            f"project '{self.name}'. Tried aliases "
+            f"{sorted(self._aliases)!r} and targets "
+            f"{sorted(t.name for t in self.targets)!r}."
+        )
 
     @property
     def default_targets(self) -> list[Target]:

--- a/pcons/core/resolver.py
+++ b/pcons/core/resolver.py
@@ -51,6 +51,7 @@ from typing import TYPE_CHECKING, Any
 
 from pcons.core.builder_registry import BuilderRegistry
 from pcons.core.debug import is_enabled, trace, trace_value
+from pcons.core.errors import DependencyCycleError
 from pcons.core.graph import topological_sort_targets
 from pcons.core.node import FileNode, Node
 from pcons.core.subst import TargetPath
@@ -186,6 +187,15 @@ class Resolver:
         # Register Command factory (env.Command doesn't use builder registry)
         self._builder_factories["Command"] = CommandNodeFactory(project)
 
+        # Stack of qualified_names currently being resolved. _resolve_target()
+        # recurses eagerly into target.depends() targets (_implicit_target_deps),
+        # which aren't reflected in the topological-order graph (that only
+        # covers .dependencies), so a depends()-only cycle isn't caught by
+        # _targets_in_build_order()'s cycle detection. This stack lets that
+        # recursion detect re-entrancy and raise a clean DependencyCycleError
+        # instead of recursing until RecursionError.
+        self._resolving: list[str] = []
+
     def resolve(self) -> None:
         """Resolve all targets in build order.
 
@@ -256,49 +266,65 @@ class Resolver:
         if target._resolved:
             return
 
+        qualified_name = target.qualified_name
+        if qualified_name in self._resolving:
+            # A depends()-only cycle: this target is already being resolved
+            # further up the call stack (reached via _implicit_target_deps
+            # recursion below), so raise instead of recursing forever.
+            cycle_start = self._resolving.index(qualified_name)
+            raise DependencyCycleError([*self._resolving[cycle_start:], qualified_name])
+
         trace("resolve", "Resolving target: %s", target.name)
 
-        env = target._env
+        self._resolving.append(qualified_name)
+        try:
+            env = target._env
 
-        # Dispatch to registered factory via _builder_name
-        builder_name = target._builder_name
-        if builder_name is not None and builder_name in self._builder_factories:
-            factory = self._builder_factories[builder_name]
-            factory.resolve(target, env)
-        elif env is None:
-            trace("resolve", "  Skipping target without env")
-        else:
-            logger.debug(
-                "Target '%s' has no factory registered for builder '%s'",
-                target.name,
-                builder_name,
-            )
+            # Dispatch to registered factory via _builder_name
+            builder_name = target._builder_name
+            if builder_name is not None and builder_name in self._builder_factories:
+                factory = self._builder_factories[builder_name]
+                factory.resolve(target, env)
+            elif env is None:
+                trace("resolve", "  Skipping target without env")
+            else:
+                logger.debug(
+                    "Target '%s' has no factory registered for builder '%s'",
+                    target.name,
+                    builder_name,
+                )
 
-        if target.output_nodes:
-            trace("resolve", "  Output: %s", [str(n.path) for n in target.output_nodes])
+            if target.output_nodes:
+                trace(
+                    "resolve",
+                    "  Output: %s",
+                    [str(n.path) for n in target.output_nodes],
+                )
 
-        # Apply any extra implicit deps added via target.depends()
-        if target._extra_implicit_deps:
-            target._apply_extra_implicit_deps()
+            # Apply any extra implicit deps added via target.depends()
+            if target._extra_implicit_deps:
+                target._apply_extra_implicit_deps()
 
-        # Apply implicit target dependencies from target.depends(other_target).
-        # Propagated deps: outputs become implicit deps on all build nodes
-        # (intermediate + output). Output-only deps: only on output nodes.
-        for dep_target in target._implicit_target_deps:
-            if not dep_target._resolved:
-                self._resolve_target(dep_target)
-            for node in target.intermediate_nodes + target.output_nodes:
-                for dep_node in dep_target.output_nodes:
-                    if dep_node not in node.implicit_deps:
-                        node.implicit_deps.append(dep_node)
+            # Apply implicit target dependencies from target.depends(other_target).
+            # Propagated deps: outputs become implicit deps on all build nodes
+            # (intermediate + output). Output-only deps: only on output nodes.
+            for dep_target in target._implicit_target_deps:
+                if not dep_target._resolved:
+                    self._resolve_target(dep_target)
+                for node in target.intermediate_nodes + target.output_nodes:
+                    for dep_node in dep_target.output_nodes:
+                        if dep_node not in node.implicit_deps:
+                            node.implicit_deps.append(dep_node)
 
-        for dep_target in target._implicit_target_deps_output_only:
-            if not dep_target._resolved:
-                self._resolve_target(dep_target)
-            for node in target.output_nodes:
-                for dep_node in dep_target.output_nodes:
-                    if dep_node not in node.implicit_deps:
-                        node.implicit_deps.append(dep_node)
+            for dep_target in target._implicit_target_deps_output_only:
+                if not dep_target._resolved:
+                    self._resolve_target(dep_target)
+                for node in target.output_nodes:
+                    for dep_node in dep_target.output_nodes:
+                        if dep_node not in node.implicit_deps:
+                            node.implicit_deps.append(dep_node)
+        finally:
+            self._resolving.pop()
 
         target._resolved = True
 

--- a/pcons/core/subst.py
+++ b/pcons/core/subst.py
@@ -326,6 +326,44 @@ _TOKEN_PATTERN = re.compile(
 _ARG_SPLIT = re.compile(r",\s*")
 
 
+def _split_template_string(template: str) -> list[str]:
+    """Split a string command template on whitespace into tokens.
+
+    Like str.split(), but treats a ``${...}`` span as a single unbreakable
+    token even if it contains whitespace. This keeps function-call syntax
+    such as ``${join(sep, items)}`` intact when the argument list has a
+    space after the comma, instead of tearing it apart before it can be
+    recognized as a function call.
+    """
+    tokens: list[str] = []
+    current: list[str] = []
+    depth = 0
+    i = 0
+    n = len(template)
+    while i < n:
+        ch = template[i]
+        if ch == "$" and i + 1 < n and template[i + 1] == "{":
+            depth += 1
+            current.append("${")
+            i += 2
+            continue
+        if ch == "}" and depth > 0:
+            depth -= 1
+            current.append("}")
+            i += 1
+            continue
+        if ch.isspace() and depth == 0:
+            if current:
+                tokens.append("".join(current))
+                current = []
+        else:
+            current.append(ch)
+        i += 1
+    if current:
+        tokens.append("".join(current))
+    return tokens
+
+
 # =============================================================================
 # Core substitution
 # =============================================================================
@@ -374,7 +412,11 @@ def _subst_command(
     SourcePath and TargetPath marker objects in the template are preserved
     as-is, allowing generators to convert them to appropriate syntax.
     """
-    tokens = template.split() if isinstance(template, str) else list(template)
+    tokens = (
+        _split_template_string(template)
+        if isinstance(template, str)
+        else list(template)
+    )
 
     result: list[CommandToken] = []
     for token in tokens:
@@ -431,7 +473,9 @@ def _expand_token(
                 else:
                     sv = str(v)
                     if "$" in sv:
-                        exp = _expand_token(sv, namespace, expanding, location)
+                        exp = _expand_token(
+                            sv, namespace, expanding | {var_name}, location
+                        )
                         if isinstance(exp, list):
                             var_result.extend(cast(list[CommandToken], exp))
                         else:
@@ -551,6 +595,7 @@ def _call_function(
         prefix = str(_resolve_arg(args[0], namespace, expanding, location))
         items = _resolve_arg(args[1], namespace, expanding, location)
         items = items if isinstance(items, list) else [items]
+        items = _expand_items(items, namespace, expanding, location)
         result: list[CommandToken] = []
         for item in items:
             if isinstance(item, ProjectPath):
@@ -569,6 +614,7 @@ def _call_function(
         items = _resolve_arg(args[0], namespace, expanding, location)
         suffix = str(_resolve_arg(args[1], namespace, expanding, location))
         items = items if isinstance(items, list) else [items]
+        items = _expand_items(items, namespace, expanding, location)
         suffix_result: list[CommandToken] = [str(item) + suffix for item in items]
         return suffix_result
 
@@ -581,6 +627,7 @@ def _call_function(
         items = _resolve_arg(args[1], namespace, expanding, location)
         suffix = str(_resolve_arg(args[2], namespace, expanding, location))
         items = items if isinstance(items, list) else [items]
+        items = _expand_items(items, namespace, expanding, location)
         wrap_result: list[CommandToken] = [
             prefix + str(item) + suffix for item in items
         ]
@@ -594,6 +641,7 @@ def _call_function(
         sep = str(_resolve_arg(args[0], namespace, expanding, location))
         items = _resolve_arg(args[1], namespace, expanding, location)
         items = items if isinstance(items, list) else [items]
+        items = _expand_items(items, namespace, expanding, location)
         join_result: list[CommandToken] = [sep.join(str(item) for item in items)]
         return join_result
 
@@ -607,6 +655,7 @@ def _call_function(
         prefix = str(_resolve_arg(args[0], namespace, expanding, location))
         items = _resolve_arg(args[1], namespace, expanding, location)
         items = items if isinstance(items, list) else [items]
+        items = _expand_items(items, namespace, expanding, location)
         pairwise_result: list[CommandToken] = []
         for item in items:
             pairwise_result.append(prefix)
@@ -615,6 +664,39 @@ def _call_function(
 
     else:
         raise SubstitutionError(f"Unknown function: {func_name}", location)
+
+
+def _expand_list_item(
+    item: Any,
+    namespace: Namespace,
+    expanding: set[str],
+    location: SourceLocation | None,
+) -> list[Any]:
+    """Recursively expand $var references embedded in a resolved list item.
+
+    Mirrors the expansion applied to whole-token list variables in
+    _expand_token(), so that list items which are themselves variable
+    references (e.g. a list value of ["$other", "literal"]) get expanded
+    rather than leaking a literal "$other" into the command. Non-string
+    items (marker objects like ProjectPath/PathToken) pass through unchanged.
+    """
+    if isinstance(item, str) and "$" in item:
+        expanded = _expand_token(item, namespace, expanding, location)
+        return expanded if isinstance(expanded, list) else [expanded]
+    return [item]
+
+
+def _expand_items(
+    items: list[Any],
+    namespace: Namespace,
+    expanding: set[str],
+    location: SourceLocation | None,
+) -> list[Any]:
+    """Expand $var references in each element of a resolved argument list."""
+    result: list[Any] = []
+    for item in items:
+        result.extend(_expand_list_item(item, namespace, expanding, location))
+    return result
 
 
 def _resolve_arg(
@@ -721,7 +803,11 @@ def _quote_for_shell(s: str, shell: str) -> str:
         # Strategy:
         # - Ninja variables ($in, $out, $topdir, etc.) → don't quote (ninja expands them)
         # - Shell operators (>, |, &&) → don't quote
-        # - Path-like arguments with spaces (pcons-expanded) → quote with double quotes
+        # - Tokens containing shell metacharacters (spaces, but also things like
+        #   backticks, ;, |, &, (, ), <, >, *, ? - which may come from
+        #   attacker-influenced input such as globbed filenames or flags pulled
+        #   from a dependency's Conan/pkg-config metadata) → quote with double
+        #   quotes so the shell can't interpret them
         # - Simple flags (--type, -c) → don't quote
         import re
 
@@ -749,6 +835,18 @@ def _quote_for_shell(s: str, shell: str) -> str:
         if re.match(r"^\$[a-zA-Z_][a-zA-Z0-9_.]*$", s):
             return s
 
+        # Any shell metacharacter (not just whitespace) means the shell could
+        # interpret this token specially: backticks/`$(...)` (command
+        # substitution), `;`/`|`/`&` (command separators), `()`/`<>` etc.
+        # Decide on quoting - and escape backslash/quote/backtick for the
+        # quoted form - using the token's original content, before the $
+        # escaping below inserts backslashes of its own.
+        needs_quote = any(c in s for c in " \t\n\"'\\$`!*?[](){}|&;<>")
+        if needs_quote:
+            # Escape backslash, double quote, and backtick so the token
+            # survives intact inside a double-quoted shell string.
+            s = s.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+
         # Escape literal $ signs that are NOT ninja variable references.
         # Ninja commands are passed to the shell, so $ must survive both layers:
         #   \$$ in ninja file → ninja expands $$ to $ → shell sees \$ → literal $
@@ -761,16 +859,7 @@ def _quote_for_shell(s: str, shell: str) -> str:
             s,
         )
 
-        # Path-like arguments with spaces need quoting (for paths pcons expanded)
-        # Use double quotes for cross-platform compatibility
-        has_spaces = " " in s or "\t" in s
-        if has_spaces:
-            # Escape embedded double quotes
-            escaped = s.replace('"', '\\"')
-            return f'"{escaped}"'
-
-        # Everything else (flags, paths without spaces) - pass through
-        return s
+        return f'"{s}"' if needs_quote else s
 
     if shell == "bash":
         needs_quote = any(c in s for c in " \t\n\"'\\$`!*?[](){}|&;<>")

--- a/pcons/core/subst.py
+++ b/pcons/core/subst.py
@@ -843,9 +843,21 @@ def _quote_for_shell(s: str, shell: str) -> str:
         # escaping below inserts backslashes of its own.
         needs_quote = any(c in s for c in " \t\n\"'\\$`!*?[](){}|&;<>")
         if needs_quote:
-            # Escape backslash, double quote, and backtick so the token
-            # survives intact inside a double-quoted shell string.
-            s = s.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
+            if platform.system() == "Windows":
+                # Ninja runs cmd.exe on Windows. Backslash is not an escape
+                # character there, and backtick / $(...) are not command
+                # substitution, so wrapping in double quotes already
+                # neutralizes cmd's metacharacters (& | < > ^). Only embedded
+                # double quotes need escaping (\" for CommandLineToArgvW).
+                # Escaping backslashes here would corrupt payloads that rely on
+                # them, e.g. `python -c` string escapes or Windows paths.
+                s = s.replace('"', '\\"')
+            else:
+                # Ninja runs /bin/sh. Escape backslash, double quote, and
+                # backtick so the token survives intact inside a double-quoted
+                # shell string and can't break out or trigger command
+                # substitution.
+                s = s.replace("\\", "\\\\").replace('"', '\\"').replace("`", "\\`")
 
         # Escape literal $ signs that are NOT ninja variable references.
         # Ninja commands are passed to the shell, so $ must survive both layers:

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -884,9 +884,9 @@ class Target:
     def _collect_from_deps(self, result: UsageRequirements, visited: set[str]) -> None:
         """Recursively collect public requirements from dependencies."""
         for dep in self.transitive_dependencies():
-            if dep.name in visited:
+            if dep.qualified_name in visited:
                 continue
-            visited.add(dep.name)
+            visited.add(dep.qualified_name)
 
             # Merge this dependency's public requirements
             result.merge(dep.public)
@@ -903,11 +903,11 @@ class Target:
             Set of language names (e.g., {'c', 'cxx'}).
         """
         languages = set(self.required_languages)
-        visited: set[str] = {self.name}
+        visited: set[str] = {self.qualified_name}
 
         for dep in self.dependencies:
-            if dep.name not in visited:
-                visited.add(dep.name)
+            if dep.qualified_name not in visited:
+                visited.add(dep.qualified_name)
                 languages.update(dep.get_all_languages())
 
         return languages
@@ -944,8 +944,8 @@ class Target:
 
         def _collect(target: Target, *, include_private: bool) -> None:
             for dep in direct_deps(target, include_private=include_private):
-                if dep.name not in visited:
-                    visited.add(dep.name)
+                if dep.qualified_name not in visited:
+                    visited.add(dep.qualified_name)
                     # A static library's private link deps are not baked into the
                     # archive, so they must follow through to the link line. Shared
                     # libraries and other targets resolve their own private deps.

--- a/pcons/generators/compile_commands.py
+++ b/pcons/generators/compile_commands.py
@@ -217,6 +217,72 @@ class CompileCommandsGenerator(BaseGenerator):
     ) -> str:
         """Format the command for a source file.
 
+        Prefers the real, fully-expanded command tokens the resolver already
+        computed in ``build_info["command"]`` — the same tokens the Ninja and
+        Makefile generators build the actual invocation from — so the emitted
+        command matches the real toolchain call (e.g. MSVC's ``/c /Fo<out>``
+        rather than a hardcoded GCC ``-c -o <out>``). Falls back to
+        hand-assembling GCC-style flags from the context only when
+        ``build_info`` lacks pre-expanded tokens, which happens for
+        hand-built ``_build_info`` in unit tests that skip
+        ``project.resolve()`` (the resolver is what populates ``"command"``).
+        """
+        command_tokens = build_info.get("command") if build_info else None
+        if isinstance(command_tokens, list):
+            from pcons.core.subst import to_shell_command
+
+            expanded = self._expand_command_tokens(
+                command_tokens, source, output, project
+            )
+            return to_shell_command(expanded, shell="bash")
+
+        return self._format_command_fallback(
+            tool_name, command_var, source, output, build_info
+        )
+
+    def _expand_command_tokens(
+        self,
+        tokens: list[Any],
+        source: FileNode,
+        output: FileNode,
+        project: Project,
+    ) -> list[str]:
+        """Expand SourcePath/TargetPath markers and PathToken paths to literals.
+
+        Unlike Ninja/Make, compile_commands.json entries run with
+        ``directory`` set to the project root, so project-relative
+        ``PathToken`` paths are used unchanged. ``"build"``-typed paths
+        (relative to build_dir) get the build_dir prepended since the
+        working directory here isn't the build dir the way ninja/make use.
+        """
+        from pcons.core.subst import PathToken, SourcePath, TargetPath
+
+        result: list[str] = []
+        for token in tokens:
+            if isinstance(token, SourcePath):
+                result.append(f"{token.prefix}{source.path}{token.suffix}")
+            elif isinstance(token, TargetPath):
+                result.append(f"{token.prefix}{output.path}{token.suffix}")
+            elif isinstance(token, PathToken):
+                if token.path_type == "build":
+                    path = str(Path(project.build_dir) / token.path)
+                    result.append(f"{token.prefix}{path}{token.suffix}")
+                else:
+                    result.append(token.relativize(lambda p: p))
+            else:
+                result.append(str(token))
+        return result
+
+    def _format_command_fallback(
+        self,
+        tool_name: str,
+        command_var: str,
+        source: FileNode,
+        output: FileNode,
+        build_info: dict[str, object] | None = None,
+    ) -> str:
+        """Hand-assemble a command when build_info has no pre-expanded tokens.
+
         Includes effective flags from build_info context if available.
         The command is formatted as a shell command string with proper quoting.
         """

--- a/pcons/generators/makefile.py
+++ b/pcons/generators/makefile.py
@@ -8,6 +8,7 @@ Requires GNU Make 3.80+ for order-only prerequisites.
 from __future__ import annotations
 
 import re
+import shlex
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO, cast
@@ -284,7 +285,7 @@ class MakefileGenerator(BaseGenerator):
         # Write the command
         command = self._get_command(node, target, project, sources)
         if command:
-            f.write(f"\t{command}\n")
+            f.write(f"\t{self._escape_dollar_for_recipe(command)}\n")
 
         f.write("\n")
 
@@ -462,40 +463,19 @@ class MakefileGenerator(BaseGenerator):
         # Chain commands with &&
         return command + " && " + " && ".join(substituted_cmds)
 
-    def _quote_tokens_for_make(self, tokens: list[str]) -> str:
-        """Quote and join tokens for use in Makefile shell commands.
+    def _escape_dollar_for_recipe(self, text: str) -> str:
+        """Escape literal ``$`` as ``$$`` in a Makefile recipe line.
 
-        Handles:
-        - Shell quoting for tokens with spaces or special characters
-        - Escaping $ as $$ for Make
+        Recipe text here is a fully-expanded shell command whose tokens are
+        already quoted for bash (e.g. via :func:`~pcons.core.subst.to_shell_command`).
+        Make performs its own ``$``-expansion pass over the raw recipe text
+        *before* handing it to the shell, and that pass doesn't know or care
+        about shell quotes. So a shell-protected token like the rpath idiom
+        ``'-Wl,-rpath,$ORIGIN/../lib'`` still has its ``$O`` consumed by Make
+        as a reference to (usually undefined) variable ``O`` unless the ``$``
+        is doubled here.
         """
-        if not tokens:
-            return ""
-
-        quoted = []
-        for token in tokens:
-            # Escape $ as $$ for Make (must be done first)
-            escaped = token.replace("$", "$$")
-            # Shell quote if needed (spaces, special chars)
-            if self._needs_shell_quote(escaped):
-                # Use single quotes, but handle existing single quotes
-                if "'" not in escaped:
-                    escaped = f"'{escaped}'"
-                else:
-                    # Escape for double quotes
-                    escaped = escaped.replace("\\", "\\\\")
-                    escaped = escaped.replace('"', '\\"')
-                    escaped = escaped.replace("`", "\\`")
-                    escaped = f'"{escaped}"'
-            quoted.append(escaped)
-        return " ".join(quoted)
-
-    def _needs_shell_quote(self, s: str) -> bool:
-        """Check if a string needs shell quoting."""
-        if not s:
-            return True
-        # Characters that trigger quoting
-        return any(c in s for c in " \t\n\"'\\`!*?[](){}|&;<>")
+        return self.ESCAPE_DOLLAR.sub("$$", text)
 
     def _substitute_make_vars(
         self,
@@ -612,8 +592,12 @@ class MakefileGenerator(BaseGenerator):
         f.write("# Tests\n")
         f.write(f"test-build: {' '.join(program_outputs)}\n")
         # Embed sys.executable so the runner is found in whatever venv
-        # pcons was invoked from. The path is escaped for shell.
-        python_exe = sys.executable.replace("\\", "/")
+        # pcons was invoked from. Quote it for the shell (in case the
+        # interpreter path has spaces) and escape $ for Make (which
+        # otherwise treats $ in the raw recipe text as a variable
+        # reference before the shell ever sees the line).
+        python_exe = shlex.quote(sys.executable.replace("\\", "/"))
+        python_exe = self._escape_dollar_for_recipe(python_exe)
         f.write("test: test-build\n")
         f.write(
             f"\t{python_exe} -m pcons.test_runner --manifest=tests.json --no-color\n"

--- a/pcons/generators/ninja.py
+++ b/pcons/generators/ninja.py
@@ -289,6 +289,12 @@ class NinjaGenerator(BaseGenerator):
 
             if deps_style == "msvc":
                 f.write("  deps = msvc\n")
+                # Ninja's default msvc_deps_prefix is the English
+                # "Note: including file: " that cl.exe emits. On a
+                # localized (e.g. German/Japanese) cl.exe this default
+                # silently matches nothing and header deps are dropped, so
+                # pin it explicitly rather than relying on ninja's default.
+                f.write("  msvc_deps_prefix = Note: including file: \n")
             elif deps_style == "gcc":
                 if depfile:
                     # depfile is a PathToken - use suffix to create $out.d pattern
@@ -702,7 +708,15 @@ class NinjaGenerator(BaseGenerator):
         # run pcons itself so the runner is guaranteed to find the
         # `pcons` package, even when the user's `python` on PATH is a
         # different interpreter.
-        python_exe = self._escape_path(sys.executable)
+        # Quote for the shell (not just ninja's $-escaping) so an
+        # interpreter path containing spaces survives as a single argument:
+        # _escape_path's "$ " for spaces is unescaped by ninja to a bare
+        # space, which the shell then splits on.
+        from pcons.core.subst import to_shell_command
+
+        python_exe = to_shell_command(
+            [sys.executable.replace("\\", "/")], shell="ninja"
+        )
         f.write("rule pcons_test\n")
         f.write(
             f"  command = {python_exe} -m pcons.test_runner "

--- a/pcons/modules.py
+++ b/pcons/modules.py
@@ -140,7 +140,21 @@ def load_modules(extra_paths: list[Path | str] | None = None) -> dict[str, Modul
                 logger.debug("Loaded module: %s from %s", name, module_file)
 
             except (ImportError, ModuleNotFoundError, SyntaxError) as e:
-                logger.warning("Failed to load module %s: %s", name, e)
+                logger.warning(
+                    "Failed to load module %s from %s: %s", name, module_file, e
+                )
+            except Exception as e:
+                # A module is an optional add-on: any error raised while
+                # importing it or running its register() must not be fatal
+                # to the rest of pcons (KeyboardInterrupt/SystemExit still
+                # propagate since they are not Exception subclasses).
+                logger.warning(
+                    "Skipping module %s from %s: %s: %s",
+                    name,
+                    module_file,
+                    type(e).__name__,
+                    e,
+                )
 
     return dict(_loaded_modules)
 

--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 import shlex
 import shutil
 import subprocess
@@ -132,13 +133,13 @@ class ConanFinder(BaseFinder):
         """
         # 1. Explicit command from constructor
         if self._conan_cmd:
-            return [self._conan_cmd]
+            return shlex.split(self._conan_cmd)
 
         # 2-3. Environment variables
         for env_var in ("PCONS_CONAN", "CONAN"):
             env_val = os.environ.get(env_var)
             if env_val:
-                return [env_val]
+                return shlex.split(env_val)
 
         # 4. Check if conan is in PATH
         if shutil.which("conan"):
@@ -190,12 +191,16 @@ class ConanFinder(BaseFinder):
         )
 
     def _detect_compiler_settings(
-        self, toolchain: Toolchain | None = None
+        self,
+        toolchain: Toolchain | None = None,
+        build_type: str = "Release",
     ) -> dict[str, str]:
         """Detect compiler settings for Conan profile.
 
         Args:
             toolchain: Optional toolchain to get settings from.
+            build_type: Build type, used to derive compiler.runtime_type
+                for MSVC (mandatory in Conan 2 profiles).
 
         Returns:
             Dict of Conan settings.
@@ -218,32 +223,37 @@ class ConanFinder(BaseFinder):
         elif self._platform.arch in ("x86", "i686", "i386"):
             settings["arch"] = "x86"
 
-        # Compiler settings from toolchain
+        # Compiler settings from toolchain. No real Toolchain exposes a
+        # `.version` attribute (only test doubles do), so the version is
+        # always detected by running the toolchain's actual compiler
+        # command below — never a bare "gcc"/"clang" looked up on PATH,
+        # which could silently be a different compiler than the one
+        # [buildenv] CC/CXX configures for the build itself.
+        compiler_cmd: str | None = None
         if toolchain is not None:
             compiler_name = toolchain.name.lower()
+            compiler_cmd = self._get_toolchain_compiler_cmd(
+                toolchain, "cc"
+            ) or self._get_toolchain_compiler_cmd(toolchain, "cxx")
             if "gcc" in compiler_name:
                 settings["compiler"] = "gcc"
-                if hasattr(toolchain, "version") and toolchain.version:
-                    # Extract major version
-                    version_str = str(toolchain.version)
-                    major = version_str.split(".")[0]
-                    settings["compiler.version"] = major
                 settings["compiler.libcxx"] = "libstdc++11"
             elif "clang" in compiler_name or "llvm" in compiler_name:
                 if self._platform.is_macos:
                     settings["compiler"] = "apple-clang"
-                else:
-                    settings["compiler"] = "clang"
-                if hasattr(toolchain, "version") and toolchain.version:
-                    version_str = str(toolchain.version)
-                    major = version_str.split(".")[0]
-                    settings["compiler.version"] = major
-                if self._platform.is_macos:
                     settings["compiler.libcxx"] = "libc++"
                 else:
+                    settings["compiler"] = "clang"
                     settings["compiler.libcxx"] = "libstdc++11"
             elif "msvc" in compiler_name:
                 settings["compiler"] = "msvc"
+                # Conan 2 requires compiler.runtime (and runtime_type) for
+                # msvc. pcons links the dynamic CRT (/MD, /MDd); the debug
+                # vs. release runtime follows the build type.
+                settings["compiler.runtime"] = "dynamic"
+                settings["compiler.runtime_type"] = (
+                    "Debug" if build_type == "Debug" else "Release"
+                )
         else:
             # Default to system compiler detection
             if self._platform.is_macos:
@@ -253,9 +263,8 @@ class ConanFinder(BaseFinder):
                 settings["compiler"] = "gcc"
                 settings["compiler.libcxx"] = "libstdc++11"
 
-        # Auto-detect compiler version if not set
-        if "compiler.version" not in settings and "compiler" in settings:
-            version = self._detect_compiler_version(settings.get("compiler", ""))
+        if "compiler" in settings:
+            version = self._detect_compiler_version(settings["compiler"], compiler_cmd)
             if version:
                 settings["compiler.version"] = version
 
@@ -283,8 +292,6 @@ class ConanFinder(BaseFinder):
         if not flags:
             return None
 
-        import re
-
         for flag in flags:
             flag_str = str(flag)
             # GCC/Clang: -std=c++17, -std=c++20, -std=c++2a, -std=gnu++23
@@ -306,19 +313,25 @@ class ConanFinder(BaseFinder):
                 return aliases.get(std, std)
         return None
 
-    def _detect_compiler_version(self, compiler: str) -> str | None:
+    def _detect_compiler_version(
+        self, compiler: str, compiler_cmd: str | None = None
+    ) -> str | None:
         """Auto-detect compiler version by running the compiler.
 
         Args:
             compiler: Compiler name (gcc, clang, apple-clang, msvc).
-
-        Returns:
-            Major version string, or None if detection fails.
+            compiler_cmd: The actual command to invoke, e.g. from
+                ``_get_toolchain_compiler_cmd`` — this must match what
+                [buildenv] CC/CXX use, so profile detection doesn't run a
+                bare "gcc"/"clang" off PATH while the build itself uses a
+                different, toolchain-selected compiler. Falls back to the
+                bare compiler name when no toolchain is available.
         """
+        cmd = compiler_cmd or compiler
         try:
             if compiler in ("apple-clang", "clang"):
                 result = subprocess.run(
-                    ["clang", "--version"],
+                    [cmd, "--version"],
                     capture_output=True,
                     text=True,
                 )
@@ -332,22 +345,51 @@ class ConanFinder(BaseFinder):
                                     return parts[i + 1].split(".")[0]
             elif compiler == "gcc":
                 result = subprocess.run(
-                    ["gcc", "--version"],
+                    [cmd, "--version"],
                     capture_output=True,
                     text=True,
                 )
                 if result.returncode == 0:
                     # Parse "gcc (Ubuntu X.Y.Z-...) X.Y.Z" or similar
                     line = result.stdout.split("\n")[0]
-                    # Find version number pattern
-                    import re
-
                     match = re.search(r"(\d+)\.\d+\.\d+", line)
                     if match:
                         return match.group(1)
+            elif compiler == "msvc":
+                # cl.exe prints its version banner to stderr and exits
+                # non-zero when run with no arguments; e.g.:
+                # "Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33130 for x64"
+                result = subprocess.run(
+                    [cmd],
+                    capture_output=True,
+                    text=True,
+                )
+                match = re.search(r"Version (\d+\.\d+)", result.stderr)
+                if match:
+                    return self._msvc_conan_version(match.group(1))
         except (OSError, subprocess.SubprocessError):
             pass
         return None
+
+    @staticmethod
+    def _msvc_conan_version(cl_version: str) -> str | None:
+        """Map a raw cl.exe version (e.g. "19.38") to Conan's msvc
+        ``compiler.version`` scheme.
+
+        Conan buckets msvc by product line rather than exact toolset:
+        17.x -> "170" (VS 2012), 18.x -> "180" (VS 2013), and 19.x splits
+        by the minor version's leading digit: 19.0x -> "190" (VS 2015),
+        19.1x -> "191" (VS 2017), 19.2x -> "192" (VS 2019), 19.3x -> "193"
+        and 19.4x -> "194" (VS 2022 and its later updates).
+        """
+        major_str, _, minor_str = cl_version.partition(".")
+        if not major_str.isdigit():
+            return None
+        major = int(major_str)
+        if major != 19:
+            return f"{major}0"
+        minor = int(minor_str) if minor_str.isdigit() else 0
+        return f"19{minor // 10}"
 
     def set_profile_setting(self, key: str, value: str) -> None:
         """Set a custom profile setting.
@@ -397,7 +439,7 @@ class ConanFinder(BaseFinder):
         lines.append("[settings]")
 
         # Get base settings from toolchain
-        settings = self._detect_compiler_settings(toolchain)
+        settings = self._detect_compiler_settings(toolchain, build_type)
         settings["build_type"] = build_type
 
         # Set compiler.cppstd — explicit parameter wins, then infer from env
@@ -538,9 +580,14 @@ class ConanFinder(BaseFinder):
         if conanfile is not None:
             self.conanfile = Path(conanfile)
 
-        # Check if we need to run conan install
+        # Check if we need to run conan install. A stale cache key file
+        # whose .pc files were deleted out from under it (output folder
+        # wiped, cache key left behind) must not be treated as valid —
+        # fall through to a real install instead of silently returning {}.
         if not force and self._is_cache_valid():
-            return self._parse_pkgconfig_files()
+            packages = self._parse_pkgconfig_files()
+            if packages:
+                return packages
 
         # Ensure profile exists
         if not self.profile_path.exists():
@@ -554,7 +601,7 @@ class ConanFinder(BaseFinder):
         cmd: list[str] = [
             *self.conan_cmd,
             "install",
-            str(self.conanfile.parent if self.conanfile.is_file() else self.conanfile),
+            str(self.conanfile),
             f"--profile:host={self.profile_path}",
             f"--profile:build={self.profile_path}",
             "-g",
@@ -782,7 +829,16 @@ class ConanFinder(BaseFinder):
                 old_result = result
                 for var_name, var_value in variables.items():
                     result = result.replace(f"${{{var_name}}}", var_value)
-                    result = result.replace(f"${var_name}", var_value)
+                    # Unbraced $name form: a plain replace() would also
+                    # rewrite the head of a longer name that happens to
+                    # share this prefix (e.g. "$prefix" inside
+                    # "$prefix_bin"), corrupting it. Require that the
+                    # match not be followed by another identifier char.
+                    result = re.sub(
+                        r"\$" + re.escape(var_name) + r"(?![A-Za-z0-9_])",
+                        lambda m, v=var_value: v,
+                        result,
+                    )
                 if result == old_result:
                     break  # No more substitutions possible
             return result

--- a/pcons/test_runner.py
+++ b/pcons/test_runner.py
@@ -575,6 +575,10 @@ def run_all(
       - With ``stop_on_fail``, after the first failure no new tests are
         launched and remaining ones are emitted as ``SKIP``.
 
+    ``jobs <= 0`` follows ninja's ``-j0`` convention of "unlimited": every
+    ready test may launch at once (capped, in practice, at one worker per
+    test — there's no point in a bigger pool than that).
+
     The returned list preserves manifest order so report output is stable
     regardless of how tests interleave at runtime.
     """
@@ -582,9 +586,16 @@ def run_all(
     deps_of = {t["name"]: list(t.get("depends_on") or ()) for t in tests}
     _validate_deps(tests)
 
+    # Normalize once, and use this value for both the pool size and the
+    # launch gate below — using the raw (possibly non-positive) `jobs`
+    # for the gate while sizing the pool off `max(1, jobs)` meant `-j0`
+    # (or a negative value) made `len(running) >= jobs` always true, so
+    # no non-serial test was ever submitted.
+    effective_jobs = jobs if jobs > 0 else max(len(tests), 1)
+
     results: dict[str, TestResult] = {}
     pending: set[str] = set(by_name)
-    pool = concurrent.futures.ThreadPoolExecutor(max_workers=max(1, jobs))
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=effective_jobs)
     running: dict[concurrent.futures.Future, str] = {}
     serial_in_flight = False
     stopped = False
@@ -641,7 +652,7 @@ def run_all(
                 return
             if serial_in_flight:
                 continue
-            if len(running) >= jobs:
+            if len(running) >= effective_jobs:
                 break
             pending.discard(name)
             on_start(test)
@@ -740,6 +751,18 @@ def print_summary(
 
 # ----- Output: JUnit XML ----------------------------------------------------
 
+# XML 1.0 forbids most C0 control characters in text content (tab, LF, CR
+# are the only ones allowed below 0x20). Captured stdout/stderr from a
+# test process can contain anything — e.g. a test that crashes mid binary
+# write — so it must be scrubbed before being embedded, or ET.write()
+# produces a file that no XML parser will accept.
+_XML_ILLEGAL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f]")
+
+
+def _sanitize_xml_text(text: str) -> str:
+    """Strip control characters that are illegal in XML 1.0 text/attributes."""
+    return _XML_ILLEGAL_CHARS_RE.sub("", text)
+
 
 def write_junit(path: Path, project_name: str, results: list[TestResult]) -> None:
     """Write a single-suite JUnit XML report.
@@ -775,13 +798,20 @@ def write_junit(path: Path, project_name: str, results: list[TestResult]) -> Non
             time=f"{r.duration:.3f}",
         )
         if r.status == FAIL:
-            f = ET.SubElement(case, "failure", message=r.message or "test failed")
-            f.text = r.stderr or r.stdout or ""
+            f = ET.SubElement(
+                case, "failure", message=_sanitize_xml_text(r.message or "test failed")
+            )
+            f.text = _sanitize_xml_text(r.stderr or r.stdout or "")
         elif r.status in (TIMEOUT, ERROR):
-            e = ET.SubElement(case, "error", type=r.status, message=r.message or "")
-            e.text = r.stderr or r.stdout or ""
+            e = ET.SubElement(
+                case,
+                "error",
+                type=r.status,
+                message=_sanitize_xml_text(r.message or ""),
+            )
+            e.text = _sanitize_xml_text(r.stderr or r.stdout or "")
         elif r.status == SKIP:
-            ET.SubElement(case, "skipped", message=r.message or "")
+            ET.SubElement(case, "skipped", message=_sanitize_xml_text(r.message or ""))
 
     tree = ET.ElementTree(root)
     ET.indent(tree, space="  ")
@@ -896,11 +926,48 @@ def main(argv: list[str] | None = None) -> int:
     # The "build_dir" entry in the manifest is informational only.
     build_dir = manifest_path.parent.resolve()
 
+    # Labels survive discovery expansion unchanged (each discovered case
+    # inherits its parent's labels), so -L/-LE can be applied up front,
+    # against the pre-discovery entries. This lets a whole discover-enabled
+    # binary be skipped by label without ever invoking its "list test
+    # cases" flag. Name regexes (-R/-E) can't be applied yet: a discover
+    # entry's own name isn't one of the case names it will expand into, so
+    # those filters are re-applied below, once expansion has run.
+    label_filtered = filter_tests(
+        tests,
+        include_labels=args.L,
+        exclude_labels=args.LE,
+        include_regex=None,
+        exclude_regex=None,
+    )
+    label_filtered = expand_filter_with_deps(label_filtered, tests)
+
+    if args.list:
+        # --list only needs names, so there's no reason to actually run
+        # discovery binaries just to enumerate their cases; list the
+        # manifest-level entries instead (annotating discover entries,
+        # since their real case names are only known once run).
+        listed = filter_tests(
+            label_filtered,
+            include_labels=[],
+            exclude_labels=[],
+            include_regex=args.R,
+            exclude_regex=args.E,
+        )
+        print(f"Test project: {project_name} ({len(listed)} tests)")
+        for t in listed:
+            labels = ",".join(t.get("labels", []) or [])
+            label_str = f" [{labels}]" if labels else ""
+            discover_str = f" (discover: {t['discover']})" if t.get("discover") else ""
+            print(f"  {t['name']}{label_str}{discover_str}")
+        return 0
+
     # Discover test cases inside binaries that asked for it. This rewrites
-    # the manifest's test list in place: a "discover" entry is replaced by
-    # N entries, one per case found by running the binary's listing flag.
-    # Done before filtering so that label/regex filters apply per-case.
-    tests, _expansion_map = expand_discovered_tests(tests, build_dir)
+    # the test list in place: a "discover" entry is replaced by N entries,
+    # one per case found by running the binary's listing flag. Only the
+    # label-filtered survivors reach this point, so an excluded binary's
+    # cases are never enumerated.
+    tests, _expansion_map = expand_discovered_tests(label_filtered, build_dir)
 
     filtered = filter_tests(
         tests,
@@ -912,14 +979,6 @@ def main(argv: list[str] | None = None) -> int:
     # Auto-include any deps that the filter would otherwise drop, so that
     # `pcons test -L api` still pulls in a `setup_server` fixture.
     filtered = expand_filter_with_deps(filtered, tests)
-
-    if args.list:
-        print(f"Test project: {project_name} ({len(filtered)} tests)")
-        for t in filtered:
-            labels = ",".join(t.get("labels", []) or [])
-            label_str = f" [{labels}]" if labels else ""
-            print(f"  {t['name']}{label_str}")
-        return 0
 
     if not filtered:
         print(f"Test project: {project_name}: no tests matched.")

--- a/pcons/toolchains/build_context.py
+++ b/pcons/toolchains/build_context.py
@@ -90,17 +90,33 @@ class CompileLinkContext:
 
     def _merge_with_base_flags(
         self, tool_name: str | None, flags: list[str | PathToken]
-    ) -> list[object]:
+    ) -> list[str | PathToken]:
         """Prepend env.<tool>.flags to `flags`, dropping duplicates.
 
         Keeps env-level flags (e.g. -std=c++20, -fsanitize=address) ahead of
-        the target-specific flags from usage requirements.
+        the target-specific flags from usage requirements. Uses the same
+        flag-pair-aware merge as usage requirements so separated-argument
+        flags (-isystem, -framework, -include, -arch, -Xlinker, ...) aren't
+        split by naive per-token deduplication.
         """
-        base_flags: list[object] = []
+        from pcons.core.flags import (
+            get_separated_arg_flags_from_toolchains,
+            merge_flags,
+        )
+
+        base_flags: list[str | PathToken] = []
         if tool_name and self._env and self._env.has_tool(tool_name):
             tool_cfg = getattr(self._env, tool_name, None)
             base_flags = list(getattr(tool_cfg, "flags", None) or [])
-        return base_flags + [f for f in flags if f not in base_flags]
+
+        separated_arg_flags = (
+            get_separated_arg_flags_from_toolchains(self._env.toolchains)
+            if self._env is not None
+            else None
+        )
+        result: list[str | PathToken] = list(base_flags)
+        merge_flags(result, flags, separated_arg_flags)
+        return result
 
     def _compile_overrides(self) -> dict[str, object]:
         """Return compile-time overrides: includes, defines, flags."""
@@ -166,9 +182,13 @@ class CompileLinkContext:
             mode: Which overrides to return: "compile" or "link".
             tool_name: The tool name (e.g., "cc", "cxx") for flag merging
                 in compile mode.
-            language: The link language (e.g., "c", "cxx"). If "cxx" and env
-                has a "cxx" tool, the linker_cmd will be set to env.cxx.cmd
-                to ensure proper C++ runtime linkage.
+            language: The link language (e.g., "c", "cxx"). If "cxx",
+                "objcxx", or "cuda" and env has a "cxx" tool, the linker_cmd
+                will be set to env.cxx.cmd to ensure proper C++ runtime
+                linkage. Objective-C++ (.mm) is compiled with the cxx tool
+                (see unix.py's get_source_handler) and CUDA is designed to
+                link via the host C++ toolchain, so both need the C++ driver
+                just like plain C++.
             env: The build environment, used to look up the C++ compiler
                 command when linking C++ code.
             target: The target being built. When provided along with
@@ -187,7 +207,11 @@ class CompileLinkContext:
         # cl.exe as a linker driver breaks flags like /OUT:. We only override
         # when link.cmd == cc.cmd (i.e., the linker is the C compiler driver).
         linker_cmd = None
-        if language == "cxx" and env is not None and env.has_tool("cxx"):
+        if (
+            language in ("cxx", "objcxx", "cuda")
+            and env is not None
+            and env.has_tool("cxx")
+        ):
             cxx_cmd = getattr(env.cxx, "cmd", None)
             # Only override when the link tool is using the C compiler as its cmd
             # (GCC/Clang pattern). Skip when the link tool has its own separate

--- a/pcons/toolchains/cuda.py
+++ b/pcons/toolchains/cuda.py
@@ -119,14 +119,6 @@ class CudaToolchain(BaseToolchain):
         defines = list(spec[1]) + list(kwargs.get("extra_defines", []))
         return [ToolContribution("cuda", flags=tuple(flags), defines=tuple(defines))]
 
-    def _linker_for_language(self, language: str) -> str:
-        """CUDA linking is typically handled by the host C++ compiler."""
-        # nvcc can link, but usually we delegate to the C++ toolchain
-        if language == "cuda":
-            # Return cuda so the resolver knows to use nvcc if needed
-            return "cuda"
-        return super()._linker_for_language(language)
-
 
 def find_cuda_toolchain() -> CudaToolchain | None:
     """Find CUDA installation and create toolchain.

--- a/pcons/toolchains/cuda.py
+++ b/pcons/toolchains/cuda.py
@@ -29,6 +29,7 @@ import logging
 import shutil
 from typing import TYPE_CHECKING, Any
 
+from pcons.configure.platform import get_platform
 from pcons.core.preset import ToolContribution
 from pcons.core.subst import TargetPath
 from pcons.tools.cuda import CudaCompiler
@@ -73,12 +74,22 @@ class CudaToolchain(BaseToolchain):
         suffix_lower = suffix.lower()
         if suffix_lower == ".cu":
             # Use TargetPath for depfile - resolved to PathToken during resolution
-            return SourceHandler("cuda", "cuda", ".o", TargetPath(suffix=".d"), "gcc")
+            return SourceHandler(
+                "cuda",
+                "cuda",
+                self.get_object_suffix(),
+                TargetPath(suffix=".d"),
+                "gcc",
+            )
         return None
 
     def get_object_suffix(self) -> str:
-        """CUDA produces standard object files."""
-        return ".o"
+        """CUDA object suffix matches the host platform (.obj on Windows, .o elsewhere).
+
+        nvcc is paired with a host C/C++ toolchain (MSVC on Windows, GCC/Clang
+        elsewhere), so its objects must match that toolchain's convention.
+        """
+        return get_platform().object_suffix
 
     def _configure_tools(self, config: object) -> bool:
         from pcons.configure.config import Configure

--- a/pcons/toolchains/emscripten.py
+++ b/pcons/toolchains/emscripten.py
@@ -20,7 +20,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from pcons.core.builder import MultiOutputBuilder, OutputSpec
 from pcons.core.subst import SourcePath, TargetPath
@@ -337,8 +337,8 @@ def find_emscripten_toolchain() -> EmscriptenToolchain:
     from pcons.tools.toolchain import toolchain_registry
 
     toolchain = toolchain_registry.find_available("wasm", ["emscripten", "emcc"])
-    if toolchain is not None:
-        return cast(EmscriptenToolchain, toolchain)
+    if isinstance(toolchain, EmscriptenToolchain):
+        return toolchain
 
     raise RuntimeError(
         "Emscripten not found. Install it from https://emscripten.org/docs/getting_started/ "
@@ -357,6 +357,7 @@ toolchain_registry.register(
     EmscriptenToolchain,
     aliases=["emscripten", "emcc"],
     check_command="emcc",
+    is_available=is_emcc_available,
     tool_classes=[EmccCCompiler, EmccCxxCompiler, EmccArchiver, EmccLinker],
     category="wasm",
     platforms=["linux", "darwin"],

--- a/pcons/toolchains/gfortran.py
+++ b/pcons/toolchains/gfortran.py
@@ -215,12 +215,6 @@ class GfortranToolchain(UnixToolchain):
         # Fall back to C/C++ handlers from UnixToolchain
         return super().get_source_handler(suffix)
 
-    def _linker_for_language(self, language: str) -> str:
-        """For Fortran, use the 'link' tool (which is gfortran)."""
-        if language == "fortran":
-            return "link"
-        return super()._linker_for_language(language)
-
     def get_runtime_libs(
         self, linker_language: str, object_languages: set[str]
     ) -> list[str]:

--- a/pcons/toolchains/llvm.py
+++ b/pcons/toolchains/llvm.py
@@ -346,6 +346,9 @@ class LlvmToolchain(UnixToolchain):
 
     TOOL_NAMES = ("cc", "cxx", "ar", "link", "metal")
 
+    # Clang understands --target=<triple> for cross-compilation.
+    IS_CLANG_DRIVER = True
+
     def __init__(self) -> None:
         super().__init__("llvm")
 

--- a/pcons/toolchains/msvc.py
+++ b/pcons/toolchains/msvc.py
@@ -62,6 +62,57 @@ def _find_msvc_install() -> Path | None:
     return None
 
 
+def _version_sort_key(name: str) -> tuple[int, ...] | None:
+    """Parse a dot-separated version directory name into an int tuple.
+
+    Handles both MSVC tool versions (``14.38.33130``) and Windows SDK
+    versions (``10.0.22621.0``). Returns None if any component isn't a
+    plain non-negative integer, so callers can skip garbage directory
+    names instead of crashing.
+    """
+    parts = name.split(".")
+    if not parts:
+        return None
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def _sorted_version_dirs(parent: Path) -> list[Path]:
+    """List subdirectories of `parent` sorted newest-version-first.
+
+    Directory names are compared numerically component-by-component
+    (e.g. "14.10" > "14.9"), unlike plain lexicographic sort. Entries
+    that aren't dirs or don't parse as a version are skipped.
+    """
+    keyed = []
+    for entry in parent.iterdir():
+        if not entry.is_dir():
+            continue
+        key = _version_sort_key(entry.name)
+        if key is None:
+            continue
+        keyed.append((key, entry))
+    keyed.sort(key=lambda pair: pair[0], reverse=True)
+    return [entry for _, entry in keyed]
+
+
+def _host_arch_dirs() -> tuple[str, str]:
+    """Return the (host, target) bin-dir names for the running host.
+
+    Matches MSVC's `bin/Host<ARCH>/<arch>/` layout (e.g. `Hostx64/x64`),
+    used both to locate the host-native toolset and as a same-arch
+    fallback bin directory when no dev shell has been activated.
+    """
+    import platform as _platform
+
+    machine = _platform.machine().lower()
+    if machine in ("arm64", "aarch64"):
+        return "HostARM64", "arm64"
+    return "Hostx64", "x64"
+
+
 def _find_msvc_modules_dir() -> Path | None:
     """Find the MSVC C++ standard library modules directory.
 
@@ -83,7 +134,7 @@ def _find_msvc_modules_dir() -> Path | None:
     vc_tools = vs_path / "VC" / "Tools" / "MSVC"
     if not vc_tools.exists():
         return None
-    for version_dir in sorted(vc_tools.iterdir(), reverse=True):
+    for version_dir in _sorted_version_dirs(vc_tools):
         modules = version_dir / "modules"
         if (modules / "std.ixx").exists():
             return modules
@@ -168,8 +219,6 @@ def _find_msvc_bin_dir() -> Path | None:
     Returns the path to the host-appropriate bin directory containing
     cl.exe, link.exe, lib.exe, etc., or None if not found.
     """
-    import platform as _platform
-
     vs_path = _find_msvc_install()
     if vs_path is None:
         return None
@@ -177,14 +226,8 @@ def _find_msvc_bin_dir() -> Path | None:
     if not vc_tools.exists():
         return None
     # Use the latest installed version
-    machine = _platform.machine().lower()
-    if machine in ("arm64", "aarch64"):
-        host = "HostARM64"
-        target = "arm64"
-    else:
-        host = "Hostx64"
-        target = "x64"
-    for version_dir in sorted(vc_tools.iterdir(), reverse=True):
+    host, target = _host_arch_dirs()
+    for version_dir in _sorted_version_dirs(vc_tools):
         bin_dir = version_dir / "bin" / host / target
         if (bin_dir / "cl.exe").exists():
             return bin_dir
@@ -243,17 +286,13 @@ class MsvcCompiler(BaseTool):
 
         cl = config.find_program("cl.exe", version_flag="")
         if cl is None:
-            vs_path = _find_msvc_install()
-            if vs_path:
-                vc_tools = vs_path / "VC" / "Tools" / "MSVC"
-                if vc_tools.exists():
-                    for version_dir in sorted(vc_tools.iterdir(), reverse=True):
-                        cl_path = version_dir / "bin" / "Hostx64" / "x64" / "cl.exe"
-                        if cl_path.exists():
-                            from pcons.configure.config import ProgramInfo
+            bin_dir = _find_msvc_bin_dir()
+            if bin_dir is not None:
+                cl_path = bin_dir / "cl.exe"
+                if cl_path.exists():
+                    from pcons.configure.config import ProgramInfo
 
-                            cl = ProgramInfo(path=cl_path)
-                            break
+                    cl = ProgramInfo(path=cl_path)
 
         if cl is None:
             return None
@@ -394,8 +433,8 @@ class MsvcResourceCompiler(BaseTool):
             sdk_path = Path(program_files_x86) / "Windows Kits" / "10" / "bin"
             if sdk_path.exists():
                 # Find the latest SDK version
-                for version_dir in sorted(sdk_path.iterdir(), reverse=True):
-                    if version_dir.is_dir() and version_dir.name.startswith("10."):
+                for version_dir in _sorted_version_dirs(sdk_path):
+                    if version_dir.name.startswith("10."):
                         # Check architecture-specific paths
                         for arch in ["x64", "arm64", "x86"]:
                             rc_path = version_dir / arch / "rc.exe"
@@ -473,18 +512,15 @@ class MsvcAssembler(BaseTool):
         if ml is None:
             ml = config.find_program("ml.exe", version_flag="")
         if ml is None:
-            # Try to find in Visual Studio installation
-            vs_path = _find_msvc_install()
-            if vs_path:
-                vc_tools = vs_path / "VC" / "Tools" / "MSVC"
-                if vc_tools.exists():
-                    for version_dir in sorted(vc_tools.iterdir(), reverse=True):
-                        ml_path = version_dir / "bin" / "Hostx64" / "x64" / "ml64.exe"
-                        if ml_path.exists():
-                            from pcons.configure.config import ProgramInfo
+            # Try to find in Visual Studio installation (host-aware, like
+            # _find_msvc_bin_dir: ARM64 hosts get HostARM64/arm64, not x64).
+            bin_dir = _find_msvc_bin_dir()
+            if bin_dir is not None:
+                ml_path = bin_dir / "ml64.exe"
+                if ml_path.exists():
+                    from pcons.configure.config import ProgramInfo
 
-                            ml = ProgramInfo(path=ml_path)
-                            break
+                    ml = ProgramInfo(path=ml_path)
 
         if ml is None:
             return None

--- a/pcons/toolchains/unix.py
+++ b/pcons/toolchains/unix.py
@@ -13,7 +13,7 @@ toolchains including:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from pcons.configure.platform import get_platform
 from pcons.core.preset import ToolContribution
@@ -42,6 +42,12 @@ class UnixToolchain(BaseToolchain):
     - Override _configure_tools() to configure toolchain-specific tools
     - Override get_source_handler() if they handle additional file types
     """
+
+    # Whether cc/cxx are Clang-family drivers that understand
+    # ``--target=<triple>``. GCC (and GCC-based toolchains like gfortran)
+    # reject --target=; it's a Clang/clang-cl flag. LlvmToolchain overrides
+    # this to True.
+    IS_CLANG_DRIVER: ClassVar[bool] = False
 
     # Named feature presets for common development workflows (see docs/presets.md).
     # Keep them small and orthogonal: `warnings` enables warnings; `werror`
@@ -266,13 +272,14 @@ class UnixToolchain(BaseToolchain):
     def _target_contributions(self, cross: Any) -> list[ToolContribution]:
         """Base contributions plus --target triple (Clang only) and --sysroot.
 
-        GCC uses different toolchain binaries rather than a --target flag, but
-        --target is harmless for the cross-preset descriptors we support.
+        GCC uses different toolchain binaries rather than a --target flag, and
+        rejects --target= outright, so it's only emitted for Clang-family
+        drivers (see IS_CLANG_DRIVER).
         """
         contribs = super()._target_contributions(cross)
         contribs.extend(self._sysroot_contributions(cross))
         triple = getattr(cross, "triple", None)
-        if triple:
+        if triple and self.IS_CLANG_DRIVER:
             contribs.append(ToolContribution("cc", flags=(f"--target={triple}",)))
             contribs.append(ToolContribution("cxx", flags=(f"--target={triple}",)))
         return contribs

--- a/pcons/toolchains/wasi.py
+++ b/pcons/toolchains/wasi.py
@@ -21,7 +21,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from pcons.core.builder import CommandBuilder
 from pcons.core.subst import SourcePath, TargetPath
@@ -123,6 +123,15 @@ def _wasi_hints() -> list[Path | str] | None:
     """Search hints pointing at a wasi-sdk's bin directory, if one is found."""
     sdk = find_wasi_sdk()
     return [sdk / "bin"] if sdk else None
+
+
+def is_wasi_sdk_available() -> bool:
+    """Check whether a real wasi-sdk installation is available.
+
+    A bare ``clang`` on PATH is not sufficient — WASI requires wasi-sdk's
+    sysroot and wasm32-wasi-aware clang, not just any system compiler.
+    """
+    return find_wasi_sdk() is not None
 
 
 # =============================================================================
@@ -357,8 +366,8 @@ def find_wasi_toolchain() -> WasiToolchain:
     from pcons.tools.toolchain import toolchain_registry
 
     toolchain = toolchain_registry.find_available("wasm", ["wasi"])
-    if toolchain is not None:
-        return cast(WasiToolchain, toolchain)
+    if isinstance(toolchain, WasiToolchain):
+        return toolchain
 
     raise RuntimeError(
         "wasi-sdk not found. Install it from https://github.com/WebAssembly/wasi-sdk "
@@ -377,6 +386,7 @@ toolchain_registry.register(
     WasiToolchain,
     aliases=["wasi", "wasi-sdk"],
     check_command="clang",
+    is_available=is_wasi_sdk_available,
     tool_classes=[WasiCCompiler, WasiCxxCompiler, WasiArchiver, WasiLinker],
     category="wasm",
     platforms=["linux", "darwin"],

--- a/pcons/tools/toolchain.py
+++ b/pcons/tools/toolchain.py
@@ -892,50 +892,6 @@ class BaseToolchain(ABC):
         flag = f"--sysroot={sysroot}"
         return [ToolContribution(t, flags=(flag,)) for t in ("cc", "cxx", "link")]
 
-    def get_linker_for_languages(self, languages: set[str]) -> str:
-        """Determine which tool should link based on languages used.
-
-        Args:
-            languages: Set of language names (e.g., {'c', 'cxx'}).
-
-        Returns:
-            Tool name to use for linking.
-        """
-        if not languages:
-            return "link"
-
-        # Find the highest priority language
-        priority = self.language_priority
-        max_priority = -1
-        max_lang = "c"
-
-        for lang in languages:
-            p = priority.get(lang, 0)
-            if p > max_priority:
-                max_priority = p
-                max_lang = lang
-
-        # Map language to linker tool
-        # (subclasses may override this mapping)
-        return self._linker_for_language(max_lang)
-
-    # Default mapping from language to linker tool name.
-    # Override in subclasses if the mapping is different.
-    _LANGUAGE_TO_LINKER: dict[str, str] = {
-        "c": "cc",
-        "cxx": "cxx",
-        "objcxx": "cxx",
-        "fortran": "fortran",
-        "cuda": "cuda",
-    }
-
-    def _linker_for_language(self, language: str) -> str:
-        """Get the linker tool name for a language.
-
-        Override in subclasses if the mapping is different.
-        """
-        return self._LANGUAGE_TO_LINKER.get(language, "link")
-
     def get_runtime_libs(
         self, linker_language: str, object_languages: set[str]
     ) -> list[str]:

--- a/pcons/util/commands.py
+++ b/pcons/util/commands.py
@@ -40,6 +40,16 @@ def concat(sources: list[str], dest: str) -> None:
                 out.write(f.read())
 
 
+def _escape_depfile_path(path: str) -> str:
+    """Escape spaces in a path for ninja depfile output.
+
+    Ninja depfiles use unescaped whitespace to separate dependencies, so any
+    space in a path must be backslash-escaped (mirrors the escaping done in
+    pcons/util/latex_deps.py).
+    """
+    return path.replace(" ", "\\ ")
+
+
 def copytree(
     src: str, dest: str, depfile: str | None = None, stamp: str | None = None
 ) -> None:
@@ -79,7 +89,10 @@ def copytree(
         # Write ninja depfile format: stamp_file: deps
         # Use the stamp file (or dest) as the "target" for dependency purposes
         target_str = (stamp or str(dest_path)).replace("\\", "/")
-        deps_str = " \\\n  ".join(source_files)
+        # Escape spaces so ninja doesn't treat them as dependency separators
+        # (mirrors the escaping in pcons/util/latex_deps.py).
+        escaped_files = [_escape_depfile_path(f) for f in source_files]
+        deps_str = " \\\n  ".join(escaped_files)
         with open(depfile_path, "w") as f:
             f.write(f"{target_str}: \\\n  {deps_str}\n")
 

--- a/tests/configure/test_checks.py
+++ b/tests/configure/test_checks.py
@@ -90,6 +90,58 @@ class TestCachedOrCompiler:
         assert result.success is False
         assert "No compiler configured" in result.output
 
+    def test_check_function_cache_key_varies_with_headers_and_libs(
+        self, tmp_path, test_project
+    ):  # noqa: F811
+        """headers/libs must be part of the cache key, not just the function name.
+
+        Regression test: check_function() used to cache purely on the
+        function name, so check_function("SSL_new", headers=[...], libs=[...])
+        and a bare check_function("SSL_new") would collide.
+        """
+        config, checks = self._make_checks(tmp_path, test_project)
+        key_with_headers_libs = checks._cache_key(
+            "function", "SSL_new", "openssl/ssl.h", "ssl"
+        )
+        config.set(key_with_headers_libs, True)
+
+        # A different (bare) combo must not hit that cache entry.
+        result_bare = checks.check_function("SSL_new")
+        assert result_bare.cached is False
+
+        # The exact same headers/libs combo does hit the cache.
+        result_match = checks.check_function(
+            "SSL_new", headers=["openssl/ssl.h"], libs=["ssl"]
+        )
+        assert result_match.cached is True
+        assert result_match.success is True
+
+    def test_check_type_cache_key_varies_with_headers(self, tmp_path, test_project):  # noqa: F811
+        config, checks = self._make_checks(tmp_path, test_project)
+        key_with_header = checks._cache_key("type", "my_type_t", "mylib.h")
+        config.set(key_with_header, True)
+
+        result_bare = checks.check_type("my_type_t")
+        assert result_bare.cached is False
+
+        result_match = checks.check_type("my_type_t", headers=["mylib.h"])
+        assert result_match.cached is True
+        assert result_match.success is True
+
+    def test_check_type_size_cache_key_varies_with_headers(
+        self, tmp_path, test_project
+    ):  # noqa: F811
+        config, checks = self._make_checks(tmp_path, test_project)
+        key_with_header = checks._cache_key("sizeof", "my_type_t", "mylib.h")
+        config.set(key_with_header, 8)
+
+        # Bare call misses the seeded entry; with no compiler configured it
+        # falls through to None rather than returning the seeded value.
+        assert checks.check_type_size("my_type_t") is None
+
+        # Exact same headers combo hits the cache.
+        assert checks.check_type_size("my_type_t", headers=["mylib.h"]) == 8
+
 
 @pytest.mark.skipif(not has_cc, reason="No C compiler available")
 class TestToolChecksWithCompiler:
@@ -291,3 +343,104 @@ class TestToolChecksWithoutCompiler:
         assert "gcc" in key
         assert "flag" in key
         assert "-Wall" in key
+
+
+class TestMsvcStyleDispatch:
+    """Toolchain-aware compile/link/preprocess flag rendering (no real MSVC needed).
+
+    Regression tests for ToolChecks hardcoding GCC/Clang-only flags
+    (-c, -o, -l, -E), which made every check fail under MSVC/clang-cl.
+    """
+
+    def _checks_with_compiler(self, tmp_path, test_project, compiler_cmd):  # noqa: F811
+        config = Configure(build_dir=tmp_path)
+        env = Environment()
+        env.add_tool("cc")
+        env.cc.cmd = compiler_cmd
+        return ToolChecks(config, env, "cc")
+
+    def test_is_msvc_style_detects_cl_and_clang_cl(self, tmp_path, test_project):  # noqa: F811
+        assert self._checks_with_compiler(
+            tmp_path, test_project, "cl.exe"
+        )._is_msvc_style()
+        assert self._checks_with_compiler(
+            tmp_path, test_project, "clang-cl"
+        )._is_msvc_style()
+        assert not self._checks_with_compiler(
+            tmp_path, test_project, "gcc"
+        )._is_msvc_style()
+
+    def test_lib_flag_msvc_vs_unix(self, tmp_path, test_project):  # noqa: F811
+        msvc_checks = self._checks_with_compiler(tmp_path, test_project, "cl.exe")
+        assert msvc_checks._lib_flag("ssl") == "ssl.lib"
+        assert msvc_checks._lib_flag("ssl.lib") == "ssl.lib"
+
+        gcc_checks = self._checks_with_compiler(tmp_path, test_project, "gcc")
+        assert gcc_checks._lib_flag("ssl") == "-lssl"
+
+    @staticmethod
+    def _fake_run(captured):
+        class _Result:
+            returncode = 0
+            stdout = ""
+            stderr = ""
+
+        def run(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return _Result()
+
+        return run
+
+    def test_try_compile_uses_msvc_flags(self, tmp_path, test_project, monkeypatch):  # noqa: F811
+        checks = self._checks_with_compiler(tmp_path, test_project, "cl.exe")
+        captured: dict[str, list[str]] = {}
+        monkeypatch.setattr(
+            "pcons.configure.checks.subprocess.run", self._fake_run(captured)
+        )
+
+        checks.try_compile("int main(void) { return 0; }\n")
+
+        cmd = captured["cmd"]
+        assert "/c" in cmd
+        assert any(arg.startswith("/Fo") for arg in cmd)
+        assert "-c" not in cmd
+        assert not any(arg == "-o" for arg in cmd)
+
+    def test_try_preprocess_uses_msvc_flag(self, tmp_path, test_project, monkeypatch):  # noqa: F811
+        checks = self._checks_with_compiler(tmp_path, test_project, "cl.exe")
+        captured: dict[str, list[str]] = {}
+        monkeypatch.setattr(
+            "pcons.configure.checks.subprocess.run", self._fake_run(captured)
+        )
+
+        checks.check_define("SOME_MACRO")
+
+        cmd = captured["cmd"]
+        assert "/E" in cmd
+        assert "-E" not in cmd
+
+    def test_try_compile_link_uses_fe(self, tmp_path, test_project, monkeypatch):  # noqa: F811
+        checks = self._checks_with_compiler(tmp_path, test_project, "cl.exe")
+        captured: dict[str, list[str]] = {}
+        monkeypatch.setattr(
+            "pcons.configure.checks.subprocess.run", self._fake_run(captured)
+        )
+
+        checks.try_compile("int main(void) { return 0; }\n", link=True)
+
+        cmd = captured["cmd"]
+        assert any(arg.startswith("/Fe") for arg in cmd)
+        assert "/c" not in cmd
+
+    def test_unix_style_unaffected(self, tmp_path, test_project, monkeypatch):  # noqa: F811
+        checks = self._checks_with_compiler(tmp_path, test_project, "gcc")
+        captured: dict[str, list[str]] = {}
+        monkeypatch.setattr(
+            "pcons.configure.checks.subprocess.run", self._fake_run(captured)
+        )
+
+        checks.try_compile("int main(void) { return 0; }\n")
+
+        cmd = captured["cmd"]
+        assert "-c" in cmd
+        assert "-o" in cmd

--- a/tests/configure/test_config.py
+++ b/tests/configure/test_config.py
@@ -129,6 +129,58 @@ class TestConfigureFindProgram:
             cached = config.get(cache_key)
             assert cached is not None
 
+    def _make_fake_exe(self, dir_path, name="fake_program"):
+        import sys
+
+        dir_path.mkdir(parents=True, exist_ok=True)
+        if sys.platform == "win32":
+            exe = dir_path / f"{name}.exe"
+            exe.write_text("@echo fake")
+        else:
+            exe = dir_path / name
+            exe.write_text("#!/bin/sh\necho fake")
+            exe.chmod(0o755)
+        return exe
+
+    def test_find_program_hint_overrides_cache(self, tmp_path):
+        """An explicit hint must win over a previously cached result.
+
+        Regression test: find_program() used to check the cache before
+        considering hints, so a hint pointing at a different location than
+        the cached one was silently ignored.
+        """
+        dir_a = tmp_path / "a"
+        dir_b = tmp_path / "b"
+        exe_a = self._make_fake_exe(dir_a)
+        exe_b = self._make_fake_exe(dir_b)
+
+        config = Configure(build_dir=tmp_path / "build")
+
+        # First run: caches the "a" copy.
+        first = config.find_program("fake_program", hints=[dir_a])
+        assert first is not None
+        assert first.path == exe_a
+
+        # Later run with a different explicit hint must find the "b" copy,
+        # not the stale cached "a" path.
+        second = config.find_program("fake_program", hints=[dir_b])
+        assert second is not None
+        assert second.path == exe_b
+
+    def test_find_program_no_hint_still_uses_cache(self, tmp_path):
+        """Without a hint, a cached result is still returned (no regression)."""
+        dir_a = tmp_path / "a"
+        exe_a = self._make_fake_exe(dir_a)
+
+        config = Configure(build_dir=tmp_path / "build")
+        first = config.find_program("fake_program", hints=[dir_a])
+        assert first is not None
+
+        # No hints this time: should come from cache, not PATH.
+        second = config.find_program("fake_program")
+        assert second is not None
+        assert second.path == exe_a
+
 
 class TestProgramInfo:
     def test_creation(self):

--- a/tests/configure/test_config_header.py
+++ b/tests/configure/test_config_header.py
@@ -16,7 +16,7 @@ class TestDefine:
         config = Configure(build_dir=tmp_path)
         config.define("MY_FEATURE")
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert defines.get("MY_FEATURE") == 1
 
     def test_define_with_value(self, tmp_path: Path) -> None:
@@ -25,7 +25,7 @@ class TestDefine:
         config.define("VERSION_MAJOR", 2)
         config.define("VERSION_MINOR", 5)
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert defines.get("VERSION_MAJOR") == 2
         assert defines.get("VERSION_MINOR") == 5
 
@@ -34,7 +34,7 @@ class TestDefine:
         config = Configure(build_dir=tmp_path)
         config.define("VERSION_STRING", "1.2.3")
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert defines.get("VERSION_STRING") == "1.2.3"
 
     def test_undefine(self, tmp_path: Path) -> None:
@@ -42,9 +42,45 @@ class TestDefine:
         config = Configure(build_dir=tmp_path)
         config.undefine("MISSING_FEATURE")
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert "MISSING_FEATURE" in defines
         assert defines.get("MISSING_FEATURE") is None
+
+    def test_defines_not_persisted_across_runs(self, tmp_path: Path) -> None:
+        """A define() removed from the build script must stop appearing.
+
+        Regression test: _defines used to be stored inside the persisted
+        cache dict, so once written, "#define USE_FOO 1" would survive
+        forever even after the build script stopped calling define("USE_FOO"),
+        because _load_cache() merged the whole cache (including _defines)
+        back in on the next run.
+        """
+        header_path = tmp_path / "config.h"
+
+        # First "run": build script calls define("USE_FOO") and saves the cache.
+        config1 = Configure(build_dir=tmp_path)
+        config1.define("USE_FOO")
+        config1.write_config_header(header_path)
+        config1.save()
+        assert "#define USE_FOO 1" in header_path.read_text()
+
+        # Second "run": loads the same persisted cache, but the build script
+        # no longer calls define("USE_FOO").
+        config2 = Configure(build_dir=tmp_path)
+        assert config2.get("USE_FOO") is None  # sanity: not in real check cache
+        config2.write_config_header(header_path)
+
+        content = header_path.read_text()
+        assert "USE_FOO" not in content
+
+    def test_check_result_cache_survives_reconfigure(self, tmp_path: Path) -> None:
+        """Unlike _defines, genuine cached check results ARE meant to persist."""
+        config1 = Configure(build_dir=tmp_path)
+        config1.set("some_check_key", True)
+        config1.save()
+
+        config2 = Configure(build_dir=tmp_path)
+        assert config2.get("some_check_key") is True
 
 
 class TestCheckSizeof:
@@ -58,7 +94,7 @@ class TestCheckSizeof:
         assert size is not None
         assert size == 4  # int is typically 4 bytes
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert defines.get("SIZEOF_INT") == 4
 
     def test_sizeof_pointer(self, tmp_path: Path) -> None:
@@ -70,7 +106,7 @@ class TestCheckSizeof:
         # Should be 8 on 64-bit, 4 on 32-bit
         assert size in (4, 8)
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert "SIZEOF_VOIDP" in defines
 
     def test_sizeof_custom_define_name(self, tmp_path: Path) -> None:
@@ -78,7 +114,7 @@ class TestCheckSizeof:
         config = Configure(build_dir=tmp_path)
         config.check_sizeof("long", define_name="MY_LONG_SIZE")
 
-        defines = config._cache.get("_defines", {})
+        defines = config._defines
         assert "MY_LONG_SIZE" in defines
 
     def test_sizeof_unknown_type(self, tmp_path: Path) -> None:
@@ -87,45 +123,6 @@ class TestCheckSizeof:
         size = config.check_sizeof("unknown_type_xyz", default=0)
 
         assert size == 0
-
-
-class TestCheckHeader:
-    """Tests for check_header method."""
-
-    def test_check_header_records_define(self, tmp_path: Path) -> None:
-        """Test that check_header records a define."""
-        config = Configure(build_dir=tmp_path)
-
-        # Since check_compile is not fully implemented,
-        # this will return False, but the define should be recorded
-        config.check_header("stdio.h")
-
-        defines = config._cache.get("_defines", {})
-        # Should have either defined or undefined HAVE_STDIO_H
-        assert "HAVE_STDIO_H" in defines
-
-    def test_check_header_custom_define(self, tmp_path: Path) -> None:
-        """Test check_header with custom define name."""
-        config = Configure(build_dir=tmp_path)
-        config.check_header("myheader.h", define_name="HAS_MY_HEADER")
-
-        defines = config._cache.get("_defines", {})
-        assert "HAS_MY_HEADER" in defines
-
-
-class TestCheckSymbol:
-    """Tests for check_symbol method."""
-
-    def test_check_symbol_records_define(self, tmp_path: Path) -> None:
-        """Test that check_symbol records a define."""
-        config = Configure(build_dir=tmp_path)
-
-        # Since check_compile is not implemented, this will fail
-        # but the define should still be recorded
-        config.check_symbol("printf", header="stdio.h")
-
-        defines = config._cache.get("_defines", {})
-        assert "HAVE_PRINTF" in defines
 
 
 class TestWriteConfigHeader:
@@ -234,3 +231,42 @@ class TestWriteConfigHeader:
             if line.startswith("#define ") and "CONFIG_H" not in line:
                 parts = line.split()
                 assert len(parts) >= 2  # #define NAME [value]
+
+    def test_write_is_skipped_when_content_unchanged(self, tmp_path: Path) -> None:
+        """Rewriting identical content must not touch the file at all.
+
+        Regression test: write_config_header() used to write unconditionally,
+        bumping the header's mtime (and forcing a full rebuild of everything
+        that includes it) on every run even when nothing changed.
+        """
+        header_path = tmp_path / "config.h"
+
+        config1 = Configure(build_dir=tmp_path)
+        config1.define("FOO", 1)
+        config1.write_config_header(header_path)
+        content1 = header_path.read_text()
+        mtime1 = header_path.stat().st_mtime_ns
+
+        # Second, independent "run" that produces byte-identical output.
+        config2 = Configure(build_dir=tmp_path)
+        config2.define("FOO", 1)
+        config2.write_config_header(header_path)
+        content2 = header_path.read_text()
+        mtime2 = header_path.stat().st_mtime_ns
+
+        assert content1 == content2
+        assert mtime1 == mtime2  # file was not touched, so mtime is unchanged
+
+    def test_write_happens_when_content_changes(self, tmp_path: Path) -> None:
+        """Sanity check: a real content change still gets written."""
+        header_path = tmp_path / "config.h"
+
+        config1 = Configure(build_dir=tmp_path)
+        config1.define("FOO", 1)
+        config1.write_config_header(header_path)
+
+        config2 = Configure(build_dir=tmp_path)
+        config2.define("FOO", 2)
+        config2.write_config_header(header_path)
+
+        assert "#define FOO 2" in header_path.read_text()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,12 @@
 # SPDX-License-Identifier: MIT
 """Pytest configuration and shared fixtures."""
 
+from typing import Any
+
 import pytest
 
+from pcons.core.builder_registry import BuilderRegistry
+from pcons.core.preset import _PRESET_REGISTRY
 from pcons.core.project import Project
 from pcons.generators.generator import BaseGenerator
 from pcons.toolchains.gcc import (
@@ -59,12 +63,38 @@ int main(void) {
     return src_file
 
 
+def _snapshot_registries() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Snapshot the mutable dicts backing the global BuilderRegistry and the
+    contributed-preset registry, so registrations made during a test can be
+    undone afterwards. Copies the containers (not just rebinding names) so
+    later mutation of the live dicts doesn't affect the snapshot.
+    """
+    return dict(BuilderRegistry._builders), dict(_PRESET_REGISTRY)
+
+
+def _restore_registries(snapshot: tuple[dict[str, Any], dict[str, Any]]) -> None:
+    """Restore the global registries to a prior `_snapshot_registries()` result."""
+    builders, presets = snapshot
+    BuilderRegistry._builders.clear()
+    BuilderRegistry._builders.update(builders)
+    _PRESET_REGISTRY.clear()
+    _PRESET_REGISTRY.update(presets)
+
+
 @pytest.fixture(autouse=True)
 def clear_project_tree():
-    """Ensure global Project and generator state is cleared for each test."""
+    """Ensure global Project/generator/registry state is isolated per test.
+
+    Snapshots the BuilderRegistry and the contributed-preset registry before
+    each test and restores them afterwards, so a test that registers a
+    builder or preset (directly, or as a side effect of a non-hermetic module
+    load) can't leak state into later tests.
+    """
     Project._clear_tree()
     BaseGenerator._clear_pending()
+    registries = _snapshot_registries()
     yield
+    _restore_registries(registries)
     Project._clear_tree()
     BaseGenerator._clear_pending()
 

--- a/tests/contrib/test_bundle_plist.py
+++ b/tests/contrib/test_bundle_plist.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: MIT
+"""Tests for pcons.contrib.bundle: Info.plist generation and installation.
+
+Covers two fixes:
+- generate_info_plist() must XML-escape interpolated values so the result
+  is well-formed XML even when names/versions contain &, <, >, or ".
+- create_macos_bundle() must actually write and install an Info.plist when
+  given a string (the documented usage), not silently drop it.
+"""
+
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from pcons import Project
+from pcons.contrib import bundle
+
+
+class TestGenerateInfoPlistEscaping:
+    """generate_info_plist() must produce well-formed, parseable XML."""
+
+    def test_special_characters_produce_well_formed_xml(self) -> None:
+        plist = bundle.generate_info_plist(
+            name='Foo & Bar <"Baz">',
+            version="1.0 & 2",
+            identifier="com.example.foo&bar",
+            executable='Foo & "Bar"',
+            extra_keys={"MyKey & <Weird>": 'Value with "quotes" & <tags>'},
+        )
+
+        # Must parse without raising ET.ParseError.
+        root = ET.fromstring(plist)
+        assert root.tag == "plist"
+
+        # The raw (unescaped) special characters must not appear verbatim.
+        assert "Foo & Bar" not in plist
+        assert "<Weird>" not in plist
+
+        # And the escaped values must round-trip through parsing intact.
+        strings = [el.text for el in root.iter("string")]
+        assert 'Foo & Bar <"Baz">' in strings
+        assert 'Foo & "Bar"' in strings
+        assert 'Value with "quotes" & <tags>' in strings
+
+    def test_plain_values_unaffected(self) -> None:
+        plist = bundle.generate_info_plist("MyPlugin", "1.0.0", bundle_type="BNDL")
+        root = ET.fromstring(plist)
+        strings = [el.text for el in root.iter("string")]
+        assert "MyPlugin" in strings
+        assert "1.0.0" in strings
+        assert "BNDL" in strings
+
+
+class TestCreateMacosBundleStringPlist:
+    """create_macos_bundle() with a string info_plist must install it."""
+
+    def _make_plugin(self, project: Project, env):
+        # A trivial Target standing in for a compiled plugin binary; the
+        # bundle graph only cares that it's a Target with an output node.
+        return env.Command(
+            target="myplugin.so",
+            source=None,
+            command="true",
+            name="plugin",
+        )
+
+    def test_string_info_plist_creates_info_plist_install_target(
+        self, tmp_path: Path
+    ) -> None:
+        project = Project("test_bundle", build_dir=tmp_path / "build")
+        env = project.Environment()
+        plugin = self._make_plugin(project, env)
+
+        plist_content = bundle.generate_info_plist("MyPlugin", "1.0.0")
+
+        bundle.create_macos_bundle(
+            project,
+            env,
+            plugin,
+            bundle_dir="MyPlugin.bundle",
+            info_plist=plist_content,
+        )
+
+        project.resolve()
+
+        # Find every output node produced by any target and confirm an
+        # Info.plist ends up somewhere under the bundle's Contents dir.
+        plist_nodes = [
+            node
+            for target in project.targets
+            for node in target.output_nodes
+            if node.path.name == "Info.plist"
+        ]
+        assert plist_nodes, "expected an Info.plist output node in the bundle graph"
+        assert any(node.path.parent.name == "Contents" for node in plist_nodes), (
+            f"Info.plist not installed under Contents/: {[n.path for n in plist_nodes]}"
+        )
+
+    def test_path_info_plist_still_installs(self, tmp_path: Path) -> None:
+        """Regression guard: the pre-existing Path branch keeps working."""
+        project = Project("test_bundle_path", build_dir=tmp_path / "build")
+        env = project.Environment()
+        plugin = self._make_plugin(project, env)
+
+        existing_plist = tmp_path / "Info.plist"
+        existing_plist.write_text(bundle.generate_info_plist("MyPlugin", "1.0.0"))
+
+        bundle.create_macos_bundle(
+            project,
+            env,
+            plugin,
+            bundle_dir="MyPlugin.bundle",
+            info_plist=existing_plist,
+        )
+
+        project.resolve()
+
+        plist_nodes = [
+            node
+            for target in project.targets
+            for node in target.output_nodes
+            if node.path.name == "Info.plist"
+        ]
+        assert plist_nodes

--- a/tests/contrib/test_installers.py
+++ b/tests/contrib/test_installers.py
@@ -313,6 +313,287 @@ class TestWindowsInstallers:
             assert "MakeAppx" in path
 
 
+class TestMsixSigning:
+    """Tests for MSIX signing target correctness (platform-independent).
+
+    These only exercise the build-graph construction in windows.create_msix,
+    not the real MakeAppx.exe/SignTool.exe tools, so they run on any OS.
+    """
+
+    @staticmethod
+    def _mock_find_sdk_tool(tool_name: str) -> str:
+        if tool_name == "MakeAppx.exe":
+            return "/fake/MakeAppx.exe"
+        if tool_name == "SignTool.exe":
+            return "/fake/SignTool.exe"
+        raise AssertionError(f"unexpected tool lookup: {tool_name}")
+
+    def test_signed_target_output_matches_produced_file(self, monkeypatch) -> None:
+        """The declared ninja target must be the file the command actually writes.
+
+        Regression test: previously the signed target was declared as
+        output.with_suffix(".signed.msix") while the sign command modified
+        the unsigned output in place, so the declared target was never
+        produced (a perpetually-dirty, phantom output).
+        """
+        from pcons.contrib.installers import windows
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", self._mock_find_sdk_tool)
+
+        project = Project("test_msix_sign_target")
+        env = project.Environment()
+
+        signed = windows.create_msix(
+            project=project,
+            env=env,
+            name="TestApp",
+            version="1.0.0",
+            publisher="CN=Test Publisher",
+            sources=[],
+            sign_cert=Path("dummy_cert.pfx"),
+        )
+
+        assert len(signed.output_nodes) == 1
+        declared_path = signed.output_nodes[0].path
+        assert declared_path == Path("TestApp-1.0.0.signed.msix")
+
+        # The command's own output file (the last --output value) must be
+        # the same path as the declared ninja target.
+        command = signed.output_nodes[0]._build_info["command"]
+        assert command[command.index("--output") + 1] == str(declared_path)
+
+    def test_signed_target_input_is_unsigned_output(self, monkeypatch) -> None:
+        """The sign step must consume the unsigned .msix, not itself."""
+        from pcons.contrib.installers import windows
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", self._mock_find_sdk_tool)
+
+        project = Project("test_msix_sign_input")
+        env = project.Environment()
+
+        signed = windows.create_msix(
+            project=project,
+            env=env,
+            name="TestApp",
+            version="1.0.0",
+            publisher="CN=Test Publisher",
+            sources=[],
+            sign_cert=Path("dummy_cert.pfx"),
+        )
+
+        command = signed.output_nodes[0]._build_info["command"]
+        assert command[command.index("--input") + 1] == "TestApp-1.0.0.msix"
+
+    def test_signing_password_not_embedded_literally(self, monkeypatch) -> None:
+        """The certificate password must never appear literally in the command.
+
+        Only the *name* of an environment variable may appear; the value is
+        resolved from the environment when the signing step actually runs.
+        """
+        from pcons.contrib.installers import windows
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", self._mock_find_sdk_tool)
+
+        project = Project("test_msix_sign_password")
+        env = project.Environment()
+
+        secret = "hunter2-super-secret-password"  # noqa: S105 - test value
+        signed = windows.create_msix(
+            project=project,
+            env=env,
+            name="TestApp",
+            version="1.0.0",
+            publisher="CN=Test Publisher",
+            sources=[],
+            sign_cert=Path("dummy_cert.pfx"),
+            sign_password_env="PCONS_TEST_MSIX_PASSWORD",
+        )
+
+        command = signed.output_nodes[0]._build_info["command"]
+        assert secret not in command
+        assert "PCONS_TEST_MSIX_PASSWORD" in command
+        assert command[command.index("--password-env") + 1] == (
+            "PCONS_TEST_MSIX_PASSWORD"
+        )
+
+    def test_signing_without_password_env_omits_flag(self, monkeypatch) -> None:
+        """No --password-env token should appear when no password is needed."""
+        from pcons.contrib.installers import windows
+
+        monkeypatch.setattr(windows, "_find_sdk_tool", self._mock_find_sdk_tool)
+
+        project = Project("test_msix_sign_no_password")
+        env = project.Environment()
+
+        signed = windows.create_msix(
+            project=project,
+            env=env,
+            name="TestApp",
+            version="1.0.0",
+            publisher="CN=Test Publisher",
+            sources=[],
+            sign_cert=Path("dummy_cert.pfx"),
+        )
+
+        command = signed.output_nodes[0]._build_info["command"]
+        assert "--password-env" not in command
+
+
+class TestSignMsixHelper:
+    """Tests for the sign_msix _helpers function that performs the copy+sign."""
+
+    def test_copies_and_signs(self, tmp_path: Path, monkeypatch) -> None:
+        from pcons.contrib.installers import _helpers
+
+        input_path = tmp_path / "unsigned.msix"
+        output_path = tmp_path / "signed.msix"
+        input_path.write_text("fake msix contents")
+
+        calls: list[list[str]] = []
+
+        def fake_run(args: list[str], check: bool) -> None:  # noqa: ARG001
+            calls.append(args)
+
+        monkeypatch.setattr(_helpers.subprocess, "run", fake_run)
+
+        _helpers.sign_msix(
+            input_path,
+            output_path,
+            signtool="/fake/SignTool.exe",
+            cert=tmp_path / "cert.pfx",
+        )
+
+        # Original left untouched; copy created at the declared output path.
+        assert input_path.exists()
+        assert output_path.read_text() == "fake msix contents"
+        assert len(calls) == 1
+        assert calls[0][0] == "/fake/SignTool.exe"
+        assert str(output_path) in calls[0]
+
+    def test_password_env_resolved_at_runtime(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        from pcons.contrib.installers import _helpers
+
+        input_path = tmp_path / "unsigned.msix"
+        output_path = tmp_path / "signed.msix"
+        input_path.write_text("fake msix contents")
+
+        monkeypatch.setenv("PCONS_TEST_SIGN_PW", "hunter2-super-secret-password")
+
+        calls: list[list[str]] = []
+        monkeypatch.setattr(
+            _helpers.subprocess,
+            "run",
+            lambda args, check: calls.append(args),  # noqa: ARG005
+        )
+
+        _helpers.sign_msix(
+            input_path,
+            output_path,
+            signtool="/fake/SignTool.exe",
+            cert=tmp_path / "cert.pfx",
+            password_env="PCONS_TEST_SIGN_PW",
+        )
+
+        assert "hunter2-super-secret-password" in calls[0]
+
+    def test_missing_password_env_raises(self, tmp_path: Path, monkeypatch) -> None:
+        from pcons.contrib.installers import _helpers
+
+        input_path = tmp_path / "unsigned.msix"
+        input_path.write_text("fake msix contents")
+        monkeypatch.delenv("PCONS_TEST_SIGN_PW_UNSET", raising=False)
+
+        with pytest.raises(_helpers.InstallerError, match="PCONS_TEST_SIGN_PW_UNSET"):
+            _helpers.sign_msix(
+                input_path,
+                tmp_path / "signed.msix",
+                signtool="/fake/SignTool.exe",
+                cert=tmp_path / "cert.pfx",
+                password_env="PCONS_TEST_SIGN_PW_UNSET",
+            )
+
+
+class TestValidateStagingPath:
+    """Tests for macos._validate_staging_path conflict detection.
+
+    Platform-independent: this only walks in-memory project/target state,
+    it never shells out to pkgbuild/hdiutil.
+    """
+
+    def test_raises_on_target_output_conflict(self, tmp_path: Path) -> None:
+        from pcons.contrib.installers import macos
+
+        project = Project("test_staging_conflict", build_dir=tmp_path / "build")
+        env = project.Environment()
+
+        # A target whose output lives under the staging directory. Normal
+        # builder outputs (Program/Library/...) carry the build_dir prefix
+        # on their node path, so model that here rather than a bare
+        # build_dir-relative path.
+        env.Command(
+            target=project.build_dir
+            / ".pkg_staging"
+            / "MyApp"
+            / "payload"
+            / "leftover.txt",
+            source=None,
+            command="",
+            name="conflicting_target",
+        )
+
+        with pytest.raises(ValueError, match="conflicts with"):
+            macos._validate_staging_path(project, ".pkg_staging")
+
+    def test_raises_on_raw_node_conflict(self, tmp_path: Path) -> None:
+        from pcons.contrib.installers import macos
+
+        project = Project("test_staging_node_conflict", build_dir=tmp_path / "build")
+
+        # A raw node (not attached to any Target) directly under staging.
+        project.node(project.build_dir / ".pkg_staging" / "stray_file.txt")
+
+        with pytest.raises(ValueError, match="conflicts with"):
+            macos._validate_staging_path(project, ".pkg_staging")
+
+    def test_no_conflict_for_unrelated_outputs(self, tmp_path: Path) -> None:
+        from pcons.contrib.installers import macos
+
+        project = Project("test_staging_no_conflict", build_dir=tmp_path / "build")
+        env = project.Environment()
+
+        # Unrelated output, not under the staging directory.
+        env.Command(
+            target=Path("dist") / "output.txt",
+            source=None,
+            command="",
+            name="unrelated_target",
+        )
+        project.node(project.build_dir / "other" / "file.txt")
+
+        # Should not raise.
+        macos._validate_staging_path(project, ".pkg_staging")
+
+    def test_no_conflict_for_sibling_prefix(self, tmp_path: Path) -> None:
+        """A staging dir with a matching prefix but different name isn't a conflict."""
+        from pcons.contrib.installers import macos
+
+        project = Project("test_staging_prefix", build_dir=tmp_path / "build")
+        env = project.Environment()
+
+        # ".pkg_staging_extra" is not under ".pkg_staging" despite the string
+        # prefix match, so this must not raise.
+        env.Command(
+            target=project.build_dir / ".pkg_staging_extra" / "file.txt",
+            source=None,
+            command="",
+            name="sibling_target",
+        )
+
+        macos._validate_staging_path(project, ".pkg_staging")
+
+
 class TestWindowsInstallersErrors:
     """Tests for error handling in Windows installer creation."""
 

--- a/tests/contrib/test_msvcup.py
+++ b/tests/contrib/test_msvcup.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import os
 import sys
 from pathlib import Path
@@ -263,6 +264,125 @@ class TestEnsureMsvc:
             )
             assert result == Path(r"C:\msvcup\autoenv-x64")
             mock_ensure.assert_called_once()
+
+
+class TestChecksumVerification:
+    """Tests for SHA-256 verification of downloaded msvcup archives."""
+
+    def test_verify_checksum_success(self, tmp_path: Path):
+        """A matching digest passes and leaves the file in place."""
+        zip_path = tmp_path / "msvcup.zip"
+        data = b"totally-legit-msvcup-zip-bytes"
+        zip_path.write_bytes(data)
+        digest = hashlib.sha256(data).hexdigest()
+
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v_test")
+        with patch(
+            "pcons.contrib.windows.msvcup._RELEASE_SHA256",
+            {("v_test", "x86_64"): digest},
+        ):
+            up._verify_checksum(zip_path, "x86_64")  # should not raise
+
+        assert zip_path.exists()
+
+    def test_verify_checksum_mismatch_raises_and_deletes(self, tmp_path: Path):
+        """A mismatching digest raises and removes the downloaded file."""
+        zip_path = tmp_path / "msvcup.zip"
+        zip_path.write_bytes(b"possibly-tampered-bytes")
+
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v_test")
+        with patch(
+            "pcons.contrib.windows.msvcup._RELEASE_SHA256",
+            {("v_test", "x86_64"): "0" * 64},
+        ):
+            with pytest.raises(RuntimeError, match="checksum mismatch"):
+                up._verify_checksum(zip_path, "x86_64")
+
+        assert not zip_path.exists()
+
+    def test_verify_checksum_missing_pin_raises_and_deletes(self, tmp_path: Path):
+        """An unpinned version/arch fails closed rather than skipping."""
+        zip_path = tmp_path / "msvcup.zip"
+        zip_path.write_bytes(b"some-bytes")
+
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v_unpinned")
+        with patch("pcons.contrib.windows.msvcup._RELEASE_SHA256", {}):
+            with pytest.raises(RuntimeError, match="No pinned SHA-256"):
+                up._verify_checksum(zip_path, "x86_64")
+
+        assert not zip_path.exists()
+
+    def test_bootstrap_checksum_match_extracts_and_installs(self, tmp_path: Path):
+        """End-to-end: a good download proceeds to install/autoenv."""
+        import io
+        import zipfile
+
+        exe_bytes = b"fake-msvcup-exe-contents"
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w") as zf:
+            zf.writestr("msvcup.exe", exe_bytes)
+        zip_bytes = buf.getvalue()
+        digest = hashlib.sha256(zip_bytes).hexdigest()
+
+        def fake_urlretrieve(url: str, filename: Path) -> None:
+            Path(filename).write_bytes(zip_bytes)
+
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v_test")
+        mock_platform = MagicMock(arch="x86_64")
+        with (
+            patch.object(MsvcUp, "MSVCUP_DIR", str(tmp_path)),
+            patch(
+                "pcons.contrib.windows.msvcup._RELEASE_SHA256",
+                {("v_test", "x86_64"): digest},
+            ),
+            patch(
+                "pcons.contrib.windows.msvcup.get_platform",
+                return_value=mock_platform,
+            ),
+            patch(
+                "pcons.contrib.windows.msvcup.urllib.request.urlretrieve",
+                side_effect=fake_urlretrieve,
+            ),
+            patch("pcons.contrib.windows.msvcup.subprocess.run") as mock_run,
+        ):
+            msvcup_exe = up._bootstrap_msvcup()
+
+        assert msvcup_exe.read_bytes() == exe_bytes
+        mock_run.assert_not_called()  # bootstrap alone doesn't execute msvcup
+
+    def test_bootstrap_checksum_mismatch_never_executes(self, tmp_path: Path):
+        """A bad download is deleted and never reaches install/autoenv."""
+        zip_bytes = b"attacker-controlled-payload"
+
+        def fake_urlretrieve(url: str, filename: Path) -> None:
+            Path(filename).write_bytes(zip_bytes)
+
+        up = MsvcUp("14.44.17.14", "10.0.22621.7", msvcup_version="v_test")
+        mock_platform = MagicMock(arch="x86_64")
+        with (
+            patch.object(MsvcUp, "MSVCUP_DIR", str(tmp_path)),
+            patch(
+                "pcons.contrib.windows.msvcup._RELEASE_SHA256",
+                {("v_test", "x86_64"): "0" * 64},
+            ),
+            patch(
+                "pcons.contrib.windows.msvcup.get_platform",
+                return_value=mock_platform,
+            ),
+            patch(
+                "pcons.contrib.windows.msvcup.urllib.request.urlretrieve",
+                side_effect=fake_urlretrieve,
+            ),
+            patch("pcons.contrib.windows.msvcup.subprocess.run") as mock_run,
+        ):
+            with pytest.raises(RuntimeError, match="checksum mismatch"):
+                up.ensure_installed()
+
+        mock_run.assert_not_called()
+        msvcup_exe = Path(tmp_path) / "bin" / "msvcup.exe"
+        assert not msvcup_exe.exists()
+        cache_zip = Path(tmp_path) / "cache" / "msvcup-v_test.zip"
+        assert not cache_zip.exists()
 
 
 class TestModuleImport:

--- a/tests/core/test_build_context.py
+++ b/tests/core/test_build_context.py
@@ -142,6 +142,50 @@ class TestCompileLinkContext:
             assert flags.count("-fsanitize=address") == 1
             assert "-pthread" in flags
 
+    def test_link_overrides_separated_arg_flags_not_split(self) -> None:
+        """Verify separated-arg flags like -isystem/-framework aren't split.
+
+        Regression test for the same bug class as the -framework fix (#49):
+        naive per-token dedup treats a repeated "-isystem" as already-seen
+        and drops it, orphaning the following directory as a bare
+        positional argument on the command line.
+        """
+        import tempfile
+        from pathlib import Path
+
+        from pcons.core.project import Project
+        from pcons.toolchains.gcc import GccToolchain
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+            toolchain = GccToolchain()
+            toolchain._configured = True
+            env = project.Environment(toolchain=toolchain)
+            env.add_tool("link")
+            env.link.flags = ["-isystem", "/usr/local/include", "-framework", "Cocoa"]
+
+            ctx = CompileLinkContext(
+                link_flags=["-isystem", "/opt/include", "-framework", "CoreFoundation"],
+                mode="link",
+                _env=env,
+            )
+            overrides = ctx.get_env_overrides()
+
+            # Each -isystem/-framework pair must stay intact: the second
+            # occurrence of the flag is a different pair (different
+            # argument) and must not be dropped or orphaned.
+            assert overrides["flags"] == [
+                "-isystem",
+                "/usr/local/include",
+                "-framework",
+                "Cocoa",
+                "-isystem",
+                "/opt/include",
+                "-framework",
+                "CoreFoundation",
+            ]
+
     def test_toolchain_injected_flag_deduplicated(self) -> None:
         """Toolchain-injected link flags already present are not duplicated."""
         from pcons.tools.requirements import EffectiveRequirements
@@ -168,6 +212,61 @@ class TestCompileLinkContext:
 
         assert ctx.link_flags.count("-Wl,-soname,libfoo.so") == 1
         assert "-Wl,-z" in ctx.link_flags
+
+    def test_from_effective_requirements_objcxx_uses_cxx_linker(
+        self, gcc_toolchain, tmp_project
+    ) -> None:
+        """.mm sources (link_language "objcxx") must link with the C++ driver.
+
+        Regression test: objcxx has priority 3 (higher than cxx's 2, see
+        BaseToolchain.DEFAULT_LANGUAGE_PRIORITY), so a target that mixes
+        .mm and .cpp sources picks "objcxx" as its link_language. Before
+        this fix, only "cxx" (and "fortran") triggered the C++ linker-driver
+        override, so objcxx fell through to the default C linker (gcc) and
+        libstdc++/libc++ was never linked in, breaking STL usage in .mm
+        files.
+        """
+        from pcons.core.project import Project
+        from pcons.tools.requirements import EffectiveRequirements
+
+        project = Project("test", root_dir=tmp_project, build_dir=tmp_project / "build")
+        env = project.Environment(toolchain=gcc_toolchain)
+
+        ctx = CompileLinkContext.from_effective_requirements(
+            EffectiveRequirements(),
+            mode="link",
+            language="objcxx",
+            env=env,
+        )
+
+        assert ctx.linker_cmd == env.cxx.cmd
+        assert ctx.linker_cmd != env.cc.cmd
+
+    def test_from_effective_requirements_cuda_uses_cxx_linker(
+        self, gcc_toolchain, tmp_project
+    ) -> None:
+        """CUDA-linked targets (link_language "cuda") use the host C++ linker.
+
+        CudaToolchain is designed to be used alongside a C/C++ toolchain for
+        linking (nvcc only compiles .cu files); when cuda is the
+        highest-priority language in a mixed build, the C++ driver must
+        still be selected, just as for plain C++.
+        """
+        from pcons.core.project import Project
+        from pcons.tools.requirements import EffectiveRequirements
+
+        project = Project("test", root_dir=tmp_project, build_dir=tmp_project / "build")
+        env = project.Environment(toolchain=gcc_toolchain)
+
+        ctx = CompileLinkContext.from_effective_requirements(
+            EffectiveRequirements(),
+            mode="link",
+            language="cuda",
+            env=env,
+        )
+
+        assert ctx.linker_cmd == env.cxx.cmd
+        assert ctx.linker_cmd != env.cc.cmd
 
     def test_compile_overrides_merge_with_env_flags(self) -> None:
         """Verify compile flags are merged with env.{tool}.flags.

--- a/tests/core/test_build_context.py
+++ b/tests/core/test_build_context.py
@@ -562,22 +562,21 @@ class TestNinjaQuoting:
 class TestMakefileQuoting:
     """Test that Makefile generator properly quotes values."""
 
-    def test_quote_tokens_for_make(self) -> None:
-        """Test the _quote_tokens_for_make helper directly."""
+    def test_escape_dollar_for_recipe(self) -> None:
+        """Test the _escape_dollar_for_recipe helper directly."""
         from pcons.generators.makefile import MakefileGenerator
 
         gen = MakefileGenerator()
 
-        # Simple tokens - no quoting needed
-        assert gen._quote_tokens_for_make(["-Wall", "-O2"]) == "-Wall -O2"
+        # No dollar signs - unchanged
+        assert gen._escape_dollar_for_recipe("-Wall -O2") == "-Wall -O2"
 
-        # Paths with spaces need quoting
-        result = gen._quote_tokens_for_make(["-I/path with spaces"])
-        assert "'" in result or '"' in result
-
-        # Dollar signs get escaped for Make
-        result = gen._quote_tokens_for_make(["-DVAR=$HOME"])
-        assert "$$HOME" in result
+        # Dollar signs get escaped for Make, regardless of shell quoting
+        assert gen._escape_dollar_for_recipe("-DVAR=$HOME") == "-DVAR=$$HOME"
+        assert (
+            gen._escape_dollar_for_recipe("'-Wl,-rpath,$ORIGIN/../lib'")
+            == "'-Wl,-rpath,$$ORIGIN/../lib'"
+        )
 
 
 class TestCompileCommandsQuoting:

--- a/tests/core/test_graph.py
+++ b/tests/core/test_graph.py
@@ -12,6 +12,7 @@ from pcons.core.graph import (
     topological_sort_targets,
 )
 from pcons.core.node import FileNode
+from pcons.core.project import Project
 from pcons.core.target import Target
 
 
@@ -85,8 +86,8 @@ class TestDetectCycles:
 
         cycles = detect_cycles_in_targets([a, b])
         assert len(cycles) == 1
-        assert "A" in cycles[0]
-        assert "B" in cycles[0]
+        assert a.qualified_name in cycles[0]
+        assert b.qualified_name in cycles[0]
 
     def test_self_cycle(self, test_project):  # noqa: F811
         a = Target("A")
@@ -211,3 +212,60 @@ class TestCollectBuildOrder:
         # left and right should come before top
         assert order.index(left) < order.index(top)
         assert order.index(right) < order.index(top)
+
+
+class TestSameShortNameAcrossSubprojects:
+    """Two subprojects may each define a target with the same short name.
+
+    Target identity is qualified_name, so graph algorithms keyed on the
+    bare .name incorrectly collapse two same-named targets from different
+    (sub)projects into one map entry: dropping targets from the result
+    (spurious DependencyCycleError from topological_sort_targets) or
+    silently skipping one of them during traversal.
+    """
+
+    def _make_sub_utils(self, root):
+        with root._enter_subdir("sub1"):
+            Project("sub1", root_dir=root.root_dir / "sub1")
+            util1 = Target("util")
+        with root._enter_subdir("sub2"):
+            Project("sub2", root_dir=root.root_dir / "sub2")
+            util2 = Target("util")
+        return util1, util2
+
+    def test_topological_sort_no_spurious_cycle(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        app = Target("app")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        result = topological_sort_targets([util1, util2, app])
+
+        assert set(result) == {util1, util2, app}
+        assert result.index(util1) < result.index(app)
+        assert result.index(util2) < result.index(app)
+
+    def test_detect_cycles_no_false_positive(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        app = Target("app")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        cycles = detect_cycles_in_targets([util1, util2, app])
+        assert cycles == []
+
+    def test_collect_all_nodes_includes_both(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        util1_out = FileNode("util1.o")
+        util2_out = FileNode("util2.o")
+        util1.output_nodes.append(util1_out)
+        util2.output_nodes.append(util2_out)
+
+        app = Target("app")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        nodes = collect_all_nodes([app])
+
+        assert util1_out in nodes
+        assert util2_out in nodes

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -297,6 +297,12 @@ class TestProjectDefaults:
         with pytest.raises(KeyError, match="not a known alias or target"):
             project.Default("nonexistent")
 
+    def test_default_wrong_type_raises_type_error(self):
+        project = Project("myproject")
+
+        with pytest.raises(TypeError):
+            project.Default(42)  # type: ignore[arg-type]
+
 
 class TestProjectValidation:
     def test_valid_project(self, tmp_path):

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -264,6 +264,39 @@ class TestProjectDefaults:
 
         assert project.default_targets.count(target) == 1
 
+    def test_default_with_node(self):
+        project = Project("myproject")
+        target = Target("app")
+        node = FileNode(Path("app.out"))
+        target.output_nodes.append(node)
+
+        project.Default(node)
+
+        assert target in project.default_targets
+
+    def test_default_with_node_not_owned_by_any_target_raises(self):
+        project = Project("myproject")
+        Target("app")
+        orphan_node = FileNode(Path("orphan.out"))
+
+        with pytest.raises(ValueError, match="not an output of any target"):
+            project.Default(orphan_node)
+
+    def test_default_with_alias(self):
+        project = Project("myproject")
+        target = Target("app")
+        project.Alias("myalias", target)
+
+        project.Default("myalias")
+
+        assert target in project.default_targets
+
+    def test_default_unknown_name_raises_clear_error(self):
+        project = Project("myproject")
+
+        with pytest.raises(KeyError, match="not a known alias or target"):
+            project.Default("nonexistent")
+
 
 class TestProjectValidation:
     def test_valid_project(self, tmp_path):

--- a/tests/core/test_project.py
+++ b/tests/core/test_project.py
@@ -434,15 +434,19 @@ class TestGeneratePcFile:
         target = Target("foo")
 
         pc = project.generate_pc_file(target, version="1.0")
-        mtime1 = pc.stat().st_mtime
+        content1 = pc.read_text()
+        mtime_ns1 = pc.stat().st_mtime_ns
 
-        # Call again — should not rewrite
-        import time
-
-        time.sleep(0.01)
+        # Call again with identical content — should not rewrite the file.
+        # Comparing st_mtime_ns (not st_mtime) and not sleeping avoids relying
+        # on filesystem mtime granularity, which can be coarser than a
+        # wrongly-rewritten file's actual write latency and mask a bug.
         project.generate_pc_file(target, version="1.0")
-        mtime2 = pc.stat().st_mtime
-        assert mtime1 == mtime2
+        content2 = pc.read_text()
+        mtime_ns2 = pc.stat().st_mtime_ns
+
+        assert content2 == content1
+        assert mtime_ns2 == mtime_ns1
 
     def test_pc_file_requires_from_pkgconfig_deps(self, tmp_path):
         """Dependencies found via pkg-config become Requires: entries."""

--- a/tests/core/test_registry_isolation.py
+++ b/tests/core/test_registry_isolation.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: MIT
+"""Tests proving the autouse test-isolation fixture cleans up global registry
+state (see `tests/conftest.py::clear_project_tree`).
+
+Without this cleanup, a test that registers a builder or a contributed preset
+(directly, or as the side effect of a non-hermetic module load) leaks that
+registration into every later test in the process — a latent, hard-to-debug
+source of intermittent CI failures.
+
+These tests exercise the exact snapshot/restore helpers the autouse fixture
+uses, so they demonstrate the real fixture behavior deterministically, rather
+than relying on pytest's item ordering across separate test functions (which
+is not guaranteed under `pytest -n auto`).
+"""
+
+from __future__ import annotations
+
+from pcons.core.builder_registry import BuilderRegistry
+from pcons.core.preset import _PRESET_REGISTRY
+from tests.conftest import _restore_registries, _snapshot_registries
+
+
+def _dummy_create_target(project: object) -> None:
+    return None
+
+
+def test_snapshot_restore_removes_builder_registered_during_test() -> None:
+    """A builder registered after the snapshot is gone once restored."""
+    assert BuilderRegistry.get("__leak_test_builder__") is None
+
+    snapshot = _snapshot_registries()
+    BuilderRegistry.register(
+        "__leak_test_builder__",
+        create_target=_dummy_create_target,
+        target_type="interface",
+    )
+    assert BuilderRegistry.get("__leak_test_builder__") is not None
+
+    _restore_registries(snapshot)
+
+    assert BuilderRegistry.get("__leak_test_builder__") is None
+
+
+def test_snapshot_restore_removes_preset_registered_during_test() -> None:
+    """A preset registered after the snapshot is gone once restored."""
+    assert "__leak_test__/preset" not in _PRESET_REGISTRY
+
+    snapshot = _snapshot_registries()
+    from pcons.core.preset import register_preset
+
+    register_preset("__leak_test__/preset", lambda toolchain: None)
+    assert "__leak_test__/preset" in _PRESET_REGISTRY
+
+    _restore_registries(snapshot)
+
+    assert "__leak_test__/preset" not in _PRESET_REGISTRY
+
+
+def test_snapshot_restore_preserves_builtin_builders() -> None:
+    """Restoring must bring back the pre-test snapshot, not wipe to empty —
+    built-in builders like Program must still be registered afterwards."""
+    snapshot = _snapshot_registries()
+    BuilderRegistry.register(
+        "__leak_test_builder_2__",
+        create_target=_dummy_create_target,
+        target_type="interface",
+    )
+    _restore_registries(snapshot)
+
+    assert BuilderRegistry.get("Program") is not None

--- a/tests/core/test_resolver.py
+++ b/tests/core/test_resolver.py
@@ -3,8 +3,12 @@
 
 from pathlib import Path
 
+import pytest
+
+from pcons.core.errors import DependencyCycleError
 from pcons.core.project import Project
 from pcons.core.resolver import Resolver
+from pcons.core.target import Target
 
 
 class TestResolverCreation:
@@ -14,6 +18,36 @@ class TestResolverCreation:
         resolver = Resolver(project)
 
         assert resolver.project is project
+
+
+class TestResolverImplicitDependsCycle:
+    """A cycle formed purely via target.depends() (implicit target deps).
+
+    target.dependencies (used for topological sort / cycle detection)
+    excludes _implicit_target_deps, so a depends()-only cycle isn't caught
+    by validate() before resolve() runs. Without a guard, _resolve_target's
+    eager recursion into depends() targets recurses forever. It must raise
+    a clean DependencyCycleError instead.
+    """
+
+    def test_depends_only_cycle_raises_cleanly(self, test_project):  # noqa: F811
+        a = Target("A")
+        b = Target("B")
+        a.depends(b)
+        b.depends(a)
+
+        with pytest.raises(DependencyCycleError):
+            test_project.resolve()
+
+    def test_depends_only_cycle_via_resolver_directly(self, test_project):  # noqa: F811
+        a = Target("A")
+        b = Target("B")
+        a.depends(b)
+        b.depends(a)
+
+        resolver = Resolver(test_project)
+        with pytest.raises(DependencyCycleError):
+            resolver.resolve()
 
 
 class TestResolverSingleTarget:

--- a/tests/core/test_subst.py
+++ b/tests/core/test_subst.py
@@ -5,6 +5,8 @@ The substitution system returns structured token lists, not strings.
 Shell quoting happens only at the final step via to_shell_command().
 """
 
+import platform
+
 import pytest
 
 from pcons.core.errors import (
@@ -515,9 +517,15 @@ class TestToShellCommand:
     def test_ninja_quotes_backtick_command_substitution(self):
         tokens = ["gcc", "-c", "`id`.c", "-o", "$out"]
         result = to_shell_command(tokens, shell="ninja")
-        # The backtick must be escaped so it can't run as a command substitution
-        assert "`id`.c" not in result
-        assert "\\`id\\`.c" in result
+        if platform.system() == "Windows":
+            # ninja runs cmd.exe, which has no backtick command substitution,
+            # so double-quoting the token is enough to keep it a literal.
+            assert '"`id`.c"' in result
+        else:
+            # ninja runs /bin/sh: the backtick must be escaped so it can't run
+            # as a command substitution.
+            assert "`id`.c" not in result
+            assert "\\`id\\`.c" in result
 
     def test_ninja_quotes_dollar_paren_command_substitution(self):
         tokens = ["gcc", "-c", "$(id).c", "-o", "$out"]

--- a/tests/core/test_subst.py
+++ b/tests/core/test_subst.py
@@ -294,6 +294,34 @@ class TestSubstFunctions:
             subst(["${prefix(a)}"], {"a": "-I"})
         assert "2 args" in str(exc_info.value)
 
+    def test_function_call_with_space_after_comma_in_string_template(self):
+        """A space after the comma in ${func(a, b)} must not break tokenization
+        when the function call appears in a *string* template (not a list)."""
+        ns = {"sep": ",", "items": ["a", "b", "c"]}
+        result = subst("${join(sep, items)}", ns)
+        assert result == ["a,b,c"]
+
+    def test_function_call_with_space_mixed_with_other_tokens(self):
+        ns = {"iprefix": "-I", "includes": ["/usr/include", "/opt/include"]}
+        result = subst("gcc ${prefix(iprefix, includes)} -c file.c", ns)
+        assert result == ["gcc", "-I/usr/include", "-I/opt/include", "-c", "file.c"]
+
+    def test_prefix_expands_variable_references_in_list_items(self):
+        """List items that are themselves $var references must be recursively
+        expanded, not passed through as literal '$var' text."""
+        ns = {
+            "iprefix": "-I",
+            "includes": ["$abs_include", "relative/inc"],
+            "abs_include": "/opt/local/include",
+        }
+        result = subst(["${prefix(iprefix, includes)}"], ns)
+        assert result == ["-I/opt/local/include", "-Irelative/inc"]
+
+    def test_join_expands_variable_references_in_list_items(self):
+        ns = {"sep": ",", "items": ["$x", "y"], "x": "X"}
+        result = subst(["${join(sep, items)}"], ns)
+        assert result == ["X,y"]
+
 
 class TestSubstErrors:
     """Test error handling."""
@@ -339,6 +367,18 @@ class TestSubstErrors:
         }
         with pytest.raises(CircularReferenceError):
             subst("$a", ns)
+
+    def test_self_referential_list_variable(self):
+        """A list variable whose item refers back to itself must raise
+        CircularReferenceError, not RecursionError."""
+        ns = {"x": ["$x"]}
+        with pytest.raises(CircularReferenceError):
+            subst(["$x"], ns)
+
+    def test_mutually_referential_list_variables(self):
+        ns = {"a": ["$b"], "b": ["$a"]}
+        with pytest.raises(CircularReferenceError):
+            subst(["$a"], ns)
 
 
 class TestSubstEdgeCases:
@@ -466,6 +506,53 @@ class TestToShellCommand:
         result = to_shell_command(tokens, shell="ninja")
         assert "\\$$HOME" in result
         assert "$in" in result
+
+    # --- Security: space-free tokens with shell metacharacters must be
+    # neutralized, not passed through bare (a token could be an
+    # attacker-influenced filename from a glob, or a flag pulled from a
+    # malicious Conan/pkg-config .pc file). ---
+
+    def test_ninja_quotes_backtick_command_substitution(self):
+        tokens = ["gcc", "-c", "`id`.c", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        # The backtick must be escaped so it can't run as a command substitution
+        assert "`id`.c" not in result
+        assert "\\`id\\`.c" in result
+
+    def test_ninja_quotes_dollar_paren_command_substitution(self):
+        tokens = ["gcc", "-c", "$(id).c", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        # The token must be quoted, and its leading '$' backslash-escaped, so
+        # that after ninja's own $$ -> $ pass the shell sees `\$(id).c`
+        # (a literal, escaped $) rather than an executable `$(id)` command
+        # substitution.
+        assert '"\\$$(id).c"' in result
+
+    def test_ninja_quotes_semicolon(self):
+        tokens = ["gcc", "-c", "x;touch_pwned.c", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        # The semicolon-bearing token must be quoted, not passed through bare
+        assert result.count('"x;touch_pwned.c"') == 1
+
+    def test_ninja_quotes_pipe_and_ampersand(self):
+        tokens = ["gcc", "-c", "a|b&c.c", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        assert '"a|b&c.c"' in result
+
+    def test_ninja_still_expands_topdir_when_quoted(self):
+        """$topdir must still be present (unescaped) for ninja to expand,
+        even when the surrounding token needs quoting for other reasons."""
+        tokens = ["gcc", "-c", "$topdir/src/x;y.c", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        assert "$topdir/src/x;y.c" in result
+        assert result.count('"') >= 2
+
+    def test_ninja_bare_in_out_still_unquoted(self):
+        """$in/$out must remain bare (unquoted) so multi-file expansion works."""
+        tokens = ["gcc", "-c", "$in", "-o", "$out"]
+        result = to_shell_command(tokens, shell="ninja")
+        assert " $in " in f" {result} "
+        assert result.endswith("$out")
 
 
 class TestGeneratorVariables:

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -366,6 +366,63 @@ class TestTarget:
             Target("orphan")
 
 
+class TestSameShortNameAcrossSubprojects:
+    """Two subprojects may each define a target with the same short name.
+
+    Target identity is qualified_name (project::target), so graph
+    algorithms that key on the bare .name incorrectly collapse these into
+    one entry, silently dropping the second target's usage requirements.
+    """
+
+    def _make_sub_utils(self, root):
+        """Create two subprojects, each with a target named 'util'."""
+        with root._enter_subdir("sub1"):
+            Project("sub1", root_dir=root.root_dir / "sub1")
+            util1 = Target("util")
+        with root._enter_subdir("sub2"):
+            Project("sub2", root_dir=root.root_dir / "sub2")
+            util2 = Target("util")
+        return util1, util2
+
+    def test_transitive_dependencies_includes_both(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        assert util1.name == util2.name == "util"
+        assert util1.qualified_name != util2.qualified_name
+
+        app = Target("app")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        deps = app.transitive_dependencies()
+        assert set(deps) == {util1, util2}
+
+    def test_collect_usage_requirements_from_both(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        util1.public.defines.append("FROM_SUB1")
+        util2.public.defines.append("FROM_SUB2")
+
+        app = Target("app")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        requirements = app.collect_usage_requirements()
+        assert "FROM_SUB1" in requirements.defines
+        assert "FROM_SUB2" in requirements.defines
+
+    def test_get_all_languages_union(self, test_project):  # noqa: F811
+        util1, util2 = self._make_sub_utils(test_project)
+        util1.required_languages.add("c")
+        util2.required_languages.add("cxx")
+
+        app = Target("app")
+        app.required_languages.add("fortran")
+        app.private.link_libs.append(util1)
+        app.private.link_libs.append(util2)
+
+        langs = app.get_all_languages()
+        assert langs == {"fortran", "c", "cxx"}
+
+
 class TestImportedTarget:
     def test_creation(self, test_project):  # noqa: F811
         target = ImportedTarget("zlib", version="1.2.11")

--- a/tests/generators/test_compile_commands.py
+++ b/tests/generators/test_compile_commands.py
@@ -3,6 +3,7 @@
 
 import json
 import os
+import shlex
 from pathlib import Path
 
 from pcons.core.builder import CommandBuilder
@@ -242,7 +243,10 @@ class TestCompileCommandsEntries:
 
         content = json.loads((tmp_path / "compile_commands.json").read_text())
         assert len(content) == 1
-        command_parts = normalize_path(content[0]["command"]).split()
+        # Parse with shlex so shell-quoting (bash quotes tokens containing a
+        # backslash, e.g. a Windows-style output path) is undone before we
+        # compare individual arguments.
+        command_parts = [normalize_path(p) for p in shlex.split(content[0]["command"])]
         assert "cl.exe" in command_parts
         assert "/c" in command_parts
         assert "/Fobuild/main.obj" in command_parts

--- a/tests/generators/test_compile_commands.py
+++ b/tests/generators/test_compile_commands.py
@@ -197,6 +197,60 @@ class TestCompileCommandsEntries:
         # Normalize path separators for cross-platform comparison
         assert "src/main.c" in normalize_path(content[0]["command"])
 
+    def test_msvc_style_command_uses_real_tokens(self, tmp_path):
+        """When build_info["command"] holds the resolver's real,
+        fully-expanded tokens (as it does for a real build via
+        Resolver._expand_single_node_command), compile_commands.json must
+        render the actual toolchain invocation -- e.g. MSVC's "/c /Fo<out>"
+        -- rather than hardcoded GCC "-c -o <out>" flags.
+        """
+        from pcons.core.subst import SourcePath, TargetPath
+
+        project = Project("test", root_dir=tmp_path, build_dir=".")
+
+        target = Target("app")
+        output_node = FileNode("build/main.obj")
+        source_node = FileNode("src/main.c")
+        output_node._build_info = {
+            "tool": "cc",
+            "command_var": "objcmd",
+            "language": "c",
+            "sources": [source_node],
+            "command": [
+                "cl.exe",
+                "/nologo",
+                "/showIncludes",
+                "/c",
+                TargetPath(prefix="/Fo"),
+                SourcePath(),
+            ],
+        }
+        output_node.builder = CommandBuilder(
+            "Object",
+            "cc",
+            "objcmd",
+            src_suffixes=[".c"],
+            target_suffixes=[".obj"],
+            language="c",
+        )
+
+        target.intermediate_nodes.append(output_node)
+
+        gen = CompileCommandsGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = json.loads((tmp_path / "compile_commands.json").read_text())
+        assert len(content) == 1
+        command_parts = normalize_path(content[0]["command"]).split()
+        assert "cl.exe" in command_parts
+        assert "/c" in command_parts
+        assert "/Fobuild/main.obj" in command_parts
+        assert any(p.endswith("src/main.c") for p in command_parts)
+        # Should not fall back to hardcoded GCC-style flags
+        assert "-c" not in command_parts
+        assert "-o" not in command_parts
+
 
 class TestCompileCommandsSymlink:
     def test_creates_symlink_at_project_root(self, tmp_path):

--- a/tests/generators/test_compile_commands.py
+++ b/tests/generators/test_compile_commands.py
@@ -255,6 +255,48 @@ class TestCompileCommandsEntries:
         assert "-c" not in command_parts
         assert "-o" not in command_parts
 
+    def test_build_typed_path_token_gets_build_dir_prepended(self, tmp_path):
+        """A PathToken with path_type="build" in the command is emitted with
+        the project build_dir prepended (compile_commands entries run from the
+        project root, not the build dir)."""
+        from pcons.core.subst import PathToken, SourcePath, TargetPath
+
+        project = Project("test", root_dir=tmp_path, build_dir="out")
+
+        target = Target("app")
+        output_node = FileNode("out/main.o")
+        source_node = FileNode("src/main.c")
+        output_node._build_info = {
+            "tool": "cc",
+            "command_var": "objcmd",
+            "language": "c",
+            "sources": [source_node],
+            "command": [
+                "gcc",
+                "-c",
+                PathToken(prefix="-I", path="generated_inc", path_type="build"),
+                TargetPath(prefix="-o"),
+                SourcePath(),
+            ],
+        }
+        output_node.builder = CommandBuilder(
+            "Object",
+            "cc",
+            "objcmd",
+            src_suffixes=[".c"],
+            target_suffixes=[".o"],
+            language="c",
+        )
+        target.intermediate_nodes.append(output_node)
+
+        gen = CompileCommandsGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = json.loads((tmp_path / "compile_commands.json").read_text())
+        command = normalize_path(content[0]["command"])
+        assert "-Iout/generated_inc" in command
+
 
 class TestCompileCommandsSymlink:
     def test_creates_symlink_at_project_root(self, tmp_path):

--- a/tests/generators/test_makefile.py
+++ b/tests/generators/test_makefile.py
@@ -323,6 +323,58 @@ class TestMakefilePostBuild:
         assert "echo" in content
 
 
+class TestMakefileRecipeDollarEscaping:
+    def test_rpath_origin_survives_make(self, tmp_path):
+        """A literal $ORIGIN rpath flag must be doubled ($$ORIGIN) so Make's
+        own $-expansion pass doesn't mangle it before the shell ever runs
+        the recipe (Make would otherwise read $O as variable O, an empty
+        variable, turning $ORIGIN/../lib into RIGIN/../lib).
+
+        ``build_info["command"]`` here mirrors exactly what the resolver
+        stores for a real build (see Resolver._expand_single_node_command):
+        a token list where the user's ``$$ORIGIN`` has already been
+        collapsed by subst() to a literal single-dollar ``$ORIGIN``,
+        protected from the *shell* by quoting but not yet from Make.
+        """
+        from pcons.core.subst import SourcePath, TargetPath
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+
+        target = Target("app", target_type="program")
+        output_node = FileNode(tmp_path / "build" / "app")
+        source_node = FileNode(tmp_path / "build" / "main.o")
+
+        output_node._build_info = {
+            "tool": "link",
+            "command_var": "linkcmd",
+            "sources": [source_node],
+            "command": [
+                "gcc",
+                "-o",
+                TargetPath(),
+                SourcePath(),
+                "-Wl,-rpath,$ORIGIN/../lib",
+            ],
+        }
+        output_node.builder = CommandBuilder(
+            "Program", "link", "linkcmd", src_suffixes=[".o"], target_suffixes=[""]
+        )
+
+        target.intermediate_nodes.append(output_node)
+        target.output_nodes.append(output_node)
+        project._resolved = True  # Skip auto-resolve since nodes are hand-built
+
+        gen = MakefileGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "build" / "Makefile").read_text()
+        assert "$$ORIGIN/../lib" in content
+        # A bare single-dollar $ORIGIN would mean Make's own pass wasn't
+        # escaped away; make sure it doesn't appear un-doubled.
+        assert "$ORIGIN" not in content.replace("$$ORIGIN", "")
+
+
 class TestMakefileSrcDir:
     def test_srcdir_replaced_with_project_root(self, tmp_path):
         """$SRCDIR in Command() commands is replaced with project root for make."""
@@ -347,3 +399,37 @@ class TestMakefileSrcDir:
         assert f"{project_root}/scripts/generate.py" in content
         # Original $SRCDIR should not appear
         assert "$SRCDIR" not in content
+
+
+class TestMakefileTestRecipe:
+    def test_test_recipe_quotes_and_escapes_python_exe(
+        self, tmp_path, gcc_toolchain, monkeypatch
+    ):
+        """sys.executable is quoted for the shell and $-escaped for Make, so
+        an interpreter path containing a space or $ survives both a shell
+        argument split and Make's own $-expansion pass over the recipe.
+        """
+        import sys
+
+        fake_python = "/opt/my tools/py$thon/bin/python3"
+        monkeypatch.setattr(sys, "executable", fake_python)
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        env = project.Environment(toolchain=gcc_toolchain)
+        src = tmp_path / "main.c"
+        src.write_text("int main(void){return 0;}\n")
+        prog = project.Program("prog", env, sources=[str(src)])
+        project.Test("prog.smoke", prog)
+
+        project.resolve()
+
+        gen = MakefileGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "build" / "Makefile").read_text()
+        # Shell-quoted (single quotes, so the embedded space is part of one
+        # argument) and $-escaped ($$ so Make doesn't consume $t as a
+        # variable reference before the shell ever sees the line).
+        assert "'/opt/my tools/py$$thon/bin/python3'" in content
+        assert "test-build" in content

--- a/tests/generators/test_ninja.py
+++ b/tests/generators/test_ninja.py
@@ -446,6 +446,11 @@ class TestNinjaDepsDirectives:
         assert "deps = msvc" in content
         # MSVC doesn't use depfile
         assert "depfile" not in content
+        # The prefix must be pinned explicitly rather than relying on
+        # ninja's built-in default, which is the English cl.exe string and
+        # silently matches nothing (dropping header deps) on a localized
+        # (e.g. German/Japanese) cl.exe.
+        assert "msvc_deps_prefix = Note: including file: " in content
 
     def test_no_deps_style_emits_no_deps_directive(self, tmp_path):
         project = Project("test", root_dir=tmp_path, build_dir=".")
@@ -700,3 +705,37 @@ class TestNinjaSrcDir:
         after_pipe = link_line.split("| ", 1)[1]
         assert "generated.h" not in before_pipe, "generated.h should not be in $in"
         assert "generated.h" in after_pipe
+
+
+class TestNinjaTestRule:
+    def test_test_rule_quotes_spaced_python_exe(
+        self, tmp_path, gcc_toolchain, monkeypatch
+    ):
+        """sys.executable must survive as a single argument even with a
+        space in the path. _escape_path's "$ " (dollar-space) is unescaped
+        by ninja to a bare space before the shell sees it, which would
+        otherwise split the interpreter path into two arguments.
+        """
+        import sys
+
+        fake_python = "/opt/my tools/bin/python3"
+        monkeypatch.setattr(sys, "executable", fake_python)
+
+        project = Project("test", root_dir=tmp_path, build_dir=tmp_path / "build")
+        env = project.Environment(toolchain=gcc_toolchain)
+        src = tmp_path / "main.c"
+        src.write_text("int main(void){return 0;}\n")
+        prog = project.Program("prog", env, sources=[str(src)])
+        project.Test("prog.smoke", prog)
+
+        project.resolve()
+
+        gen = NinjaGenerator()
+        gen.generate(project)
+        BaseGenerator._generate_pending(project)
+
+        content = (tmp_path / "build" / "build.ninja").read_text()
+        assert '"/opt/my tools/bin/python3"' in content
+        # The old "$ "-escaped form (unquoted, ninja un-escapes to a bare
+        # space) must not appear.
+        assert "/opt/my$ tools/bin/python3" not in content

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -242,6 +242,57 @@ Cflags: -I${includedir}
             assert "PkgConfigDeps" in call_args
             assert "--build=missing" in call_args
 
+    def test_install_passes_custom_conanfile_path_not_parent_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """A custom conanfile name must reach `conan install` as the file
+        itself, not its containing directory — otherwise Conan silently
+        falls back to resolving the default conanfile.txt in that dir.
+        """
+        conanfile = tmp_path / "conanfile-ci.txt"
+        conanfile.write_text("[requires]\nzlib/1.3\n")
+        # A default conanfile.txt also exists alongside it, with different
+        # requirements, to prove the wrong (default) one isn't picked up.
+        (tmp_path / "conanfile.txt").write_text("[requires]\nopenssl/3.0\n")
+
+        output_folder = tmp_path / "deps"
+        output_folder.mkdir()
+
+        finder = ConanFinder(
+            conanfile=conanfile,
+            output_folder=output_folder,
+        )
+        finder.sync_profile()
+
+        pc_file = output_folder / "zlib.pc"
+        pc_file.write_text(
+            "prefix=/usr/local\nName: zlib\nVersion: 1.3\nLibs:\nCflags:\n"
+        )
+
+        captured_calls: list = []
+
+        def mock_run(cmd, **kwargs):
+            captured_calls.append(cmd)
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with (
+            patch.object(finder, "is_available", return_value=True),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            finder.install()
+
+        conan_calls = [c for c in captured_calls if "install" in c]
+        assert len(conan_calls) == 1
+        call_args = conan_calls[0]
+        assert str(conanfile) in call_args
+        # The bare parent directory must not be passed instead of the file —
+        # that would make conan silently resolve the default conanfile.txt.
+        assert str(tmp_path) not in call_args
+
     def test_install_parses_pc_files(self, tmp_path: Path) -> None:
         """Test that install parses generated .pc files."""
         conanfile = tmp_path / "conanfile.txt"
@@ -316,6 +367,46 @@ Cflags: -I${includedir}
             pytest.raises(RuntimeError, match=re.escape(str(output_folder))),
         ):
             finder.install()
+
+    def test_install_reinstalls_when_cache_valid_but_pc_files_missing(
+        self, tmp_path: Path
+    ) -> None:
+        """A valid cache key with no .pc files (e.g. the output folder was
+        cleaned but the cache key file survived) must not be treated as a
+        cache hit returning {} — it must fall through to a real install.
+        """
+        conanfile = tmp_path / "conanfile.txt"
+        conanfile.write_text("[requires]\nzlib/1.3\n")
+
+        output_folder = tmp_path / "deps"
+        output_folder.mkdir()
+
+        finder = ConanFinder(
+            conanfile=conanfile,
+            output_folder=output_folder,
+        )
+        finder.sync_profile()
+        finder._save_cache_key()
+        assert finder._is_cache_valid() is True
+
+        def mock_run(cmd, **kwargs):
+            if "install" in cmd:
+                (output_folder / "zlib.pc").write_text(
+                    "prefix=/usr/local\nName: zlib\nVersion: 1.3\nLibs:\nCflags:\n"
+                )
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = ""
+            result.stderr = ""
+            return result
+
+        with (
+            patch.object(finder, "is_available", return_value=True),
+            patch("subprocess.run", side_effect=mock_run),
+        ):
+            packages = finder.install()
+
+        assert "zlib" in packages
 
 
 class TestConanFinderCaching:
@@ -643,23 +734,80 @@ Cflags: -I/opt/pcons_test/include
         assert result is None
 
 
+class _FakeCompilerTool:
+    """Stand-in for a Tool: only ``default_vars()['cmd']`` is read by
+    ``ConanFinder._get_toolchain_compiler_cmd``.
+    """
+
+    def __init__(self, cmd: str) -> None:
+        self._cmd = cmd
+
+    def default_vars(self) -> dict[str, str]:
+        return {"cmd": self._cmd}
+
+
+class _FakeToolchain:
+    """Stand-in for a Toolchain exposing only ``.name`` and ``.tools`` —
+    the attributes ConanFinder's compiler detection reads. Real toolchains
+    never expose a ``.version`` attribute, so tests must go through the
+    same cc/cxx command path the real code uses, not a shortcut.
+    """
+
+    def __init__(self, name: str, cc_cmd: str, cxx_cmd: str | None = None) -> None:
+        self.name = name
+        self.tools = {
+            "cc": _FakeCompilerTool(cc_cmd),
+            "cxx": _FakeCompilerTool(cxx_cmd or cc_cmd),
+        }
+
+
 class TestConanFinderWithToolchain:
     """Tests for toolchain integration."""
 
     def test_detect_compiler_settings_with_gcc_toolchain(self, tmp_path: Path) -> None:
-        """Test compiler detection with GCC toolchain."""
+        """Compiler version must be detected by running the toolchain's
+        actual compiler command, not a bare "gcc" resolved from PATH.
+        """
         finder = ConanFinder(output_folder=tmp_path)
+        toolchain = _FakeToolchain("gcc", cc_cmd="/opt/gcc-13/bin/gcc-13")
 
-        # Mock toolchain
-        toolchain = MagicMock()
-        toolchain.name = "gcc"
-        toolchain.version = "12.3.0"
+        def mock_run(cmd, **kwargs):
+            assert cmd[0] == "/opt/gcc-13/bin/gcc-13"
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "gcc (Ubuntu 13.2.0-4ubuntu3) 13.2.0\n"
+            result.stderr = ""
+            return result
 
-        settings = finder._detect_compiler_settings(toolchain)
+        with patch("subprocess.run", side_effect=mock_run):
+            settings = finder._detect_compiler_settings(toolchain)
 
         assert settings["compiler"] == "gcc"
-        assert settings["compiler.version"] == "12"
+        assert settings["compiler.version"] == "13"
         assert settings["compiler.libcxx"] == "libstdc++11"
+
+    def test_detect_compiler_version_uses_toolchain_cmd_not_path(
+        self, tmp_path: Path
+    ) -> None:
+        """A gcc-13 toolchain must not be reported using whatever "gcc"
+        happens to resolve first on PATH (e.g. an unrelated gcc-11).
+        """
+        finder = ConanFinder(output_folder=tmp_path)
+        toolchain = _FakeToolchain("gcc", cc_cmd="/opt/gcc-13/bin/gcc-13")
+
+        def mock_run(cmd, **kwargs):
+            if cmd[0] in ("gcc", "clang"):
+                raise AssertionError(f"looked up bare {cmd[0]!r} on PATH")
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "gcc (Ubuntu 13.2.0-4ubuntu3) 13.2.0\n"
+            result.stderr = ""
+            return result
+
+        with patch("subprocess.run", side_effect=mock_run):
+            settings = finder._detect_compiler_settings(toolchain)
+
+        assert settings["compiler.version"] == "13"
 
     def test_detect_compiler_settings_with_clang_toolchain(
         self, tmp_path: Path
@@ -668,10 +816,7 @@ class TestConanFinderWithToolchain:
         from pcons.configure.platform import Platform
 
         finder = ConanFinder(output_folder=tmp_path)
-
-        toolchain = MagicMock()
-        toolchain.name = "clang"
-        toolchain.version = "15.0.0"
+        toolchain = _FakeToolchain("clang", cc_cmd="/usr/lib/llvm-15/bin/clang")
 
         # Create a mock platform that's not macOS
         mock_platform = MagicMock(spec=Platform)
@@ -680,23 +825,73 @@ class TestConanFinderWithToolchain:
         mock_platform.is_windows = False
         mock_platform.arch = "x86_64"
 
+        def mock_run(cmd, **kwargs):
+            assert cmd[0] == "/usr/lib/llvm-15/bin/clang"
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "Ubuntu clang version 15.0.7\n"
+            result.stderr = ""
+            return result
+
         original_platform = finder._platform
         finder._platform = mock_platform
         try:
-            settings = finder._detect_compiler_settings(toolchain)
+            with patch("subprocess.run", side_effect=mock_run):
+                settings = finder._detect_compiler_settings(toolchain)
         finally:
             finder._platform = original_platform
 
         assert settings["compiler"] == "clang"
         assert settings["compiler.version"] == "15"
 
+    def test_detect_compiler_settings_with_msvc_toolchain(self, tmp_path: Path) -> None:
+        """MSVC settings must include compiler.version and compiler.runtime
+        (both mandatory in Conan 2 msvc profiles) so `conan install`
+        doesn't fail on Windows.
+        """
+        finder = ConanFinder(output_folder=tmp_path)
+        toolchain = _FakeToolchain("msvc", cc_cmd="cl.exe")
+
+        def mock_run(cmd, **kwargs):
+            assert cmd == ["cl.exe"]
+            result = MagicMock()
+            result.returncode = 2
+            result.stdout = ""
+            result.stderr = (
+                "Microsoft (R) C/C++ Optimizing Compiler Version "
+                "19.38.33130 for x64\n"
+                "Copyright (C) Microsoft Corporation.  All rights reserved.\n"
+            )
+            return result
+
+        with patch("subprocess.run", side_effect=mock_run):
+            settings = finder._detect_compiler_settings(toolchain, build_type="Debug")
+
+        assert settings["compiler"] == "msvc"
+        assert settings["compiler.version"] == "193"
+        assert settings["compiler.runtime"] == "dynamic"
+        assert settings["compiler.runtime_type"] == "Debug"
+
+    @pytest.mark.parametrize(
+        ("cl_version", "expected"),
+        [
+            ("17.0", "170"),
+            ("18.0", "180"),
+            ("19.0", "190"),
+            ("19.16", "191"),
+            ("19.29", "192"),
+            ("19.38", "193"),
+            ("19.40", "194"),
+        ],
+    )
+    def test_msvc_conan_version_mapping(self, cl_version: str, expected: str) -> None:
+        """cl.exe's raw version must map to Conan's msvc version buckets."""
+        assert ConanFinder._msvc_conan_version(cl_version) == expected
+
     def test_sync_profile_with_toolchain(self, tmp_path: Path) -> None:
         """Test profile generation with toolchain."""
         finder = ConanFinder(output_folder=tmp_path)
-
-        toolchain = MagicMock()
-        toolchain.name = "gcc"
-        toolchain.version = "11"
+        toolchain = _FakeToolchain("gcc", cc_cmd="gcc")
 
         finder.sync_profile(toolchain=toolchain)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -792,6 +792,55 @@ class TestCLIArgumentParsing:
         assert result.returncode == 0
         assert "demo" in result.stdout
 
+    def test_test_dispatch_not_confused_by_option_value(self, tmp_path: Path) -> None:
+        """An option VALUE equal to 'test' must not be mistaken for the subcommand.
+
+        `pcons --build-dir test test ...` has "test" appearing twice: once
+        as the value of --build-dir, once as the actual subcommand. Locating
+        the dispatch point by scanning raw argv for the literal string
+        "test" (sys.argv.index("test")) finds the option value first and
+        hands the runner a bogus leading "test" positional, which its
+        argparse rejects. Dispatch must instead reuse the same
+        skip-options-and-their-values logic as find_command_in_argv.
+        """
+        import json as _json
+
+        manifest = tmp_path / "tests.json"
+        manifest.write_text(
+            _json.dumps(
+                {
+                    "version": 1,
+                    "project": "cli_dispatch",
+                    "build_dir": str(tmp_path),
+                    "tests": [
+                        {
+                            "name": "demo",
+                            "command": ["/bin/true"],
+                            "labels": ["unit"],
+                        }
+                    ],
+                }
+            )
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "pcons.cli",
+                "--build-dir",
+                "test",
+                "test",
+                "--manifest",
+                str(manifest),
+                "--list",
+                "--no-color",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "demo" in result.stdout
+
     def test_generate_with_variable(self, tmp_path: Path) -> None:
         """Test pcons generate VAR=value works."""
         # Create a minimal pcons-build.py that just prints the variable

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,7 @@ from pcons import (
     NinjaGenerator,
 )
 from pcons.cli import (
+    _find_command_index,
     find_command_in_argv,
     find_script,
     parse_variables,
@@ -276,6 +277,31 @@ class TestFindCommandInArgv:
         """Test that invalid commands return None."""
         assert find_command_in_argv(["notacommand"]) is None
         assert find_command_in_argv(["BUILD"]) is None  # case sensitive
+
+
+class TestFindCommandIndex:
+    """Tests for _find_command_index (returns the position, not the name)."""
+
+    def test_index_of_first_positional_command(self) -> None:
+        assert _find_command_index(["build"]) == 0
+        assert _find_command_index(["-v", "generate"]) == 1
+
+    def test_option_value_equal_to_command_is_not_the_command(self) -> None:
+        # The motivating bug: an option value that equals a command name
+        # must not be reported as the subcommand.
+        assert _find_command_index(["--build-dir", "test", "test"]) == 2
+        assert _find_command_index(["-B", "build", "build"]) == 2
+
+    def test_equals_option_then_command(self) -> None:
+        assert _find_command_index(["--build-dir=out", "test"]) == 1
+
+    def test_boolean_flag_then_command(self) -> None:
+        assert _find_command_index(["--unknown-flag", "clean"]) == 1
+
+    def test_no_command_returns_none(self) -> None:
+        assert _find_command_index([]) is None
+        assert _find_command_index(["notacommand"]) is None
+        assert _find_command_index(["--build-dir", "out"]) is None
 
 
 class TestRunScriptEnvironment:

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -257,14 +257,114 @@ def discover_examples() -> list[Path]:
     return examples
 
 
+# Keys recognized at the top level of test.toml.
+_TOP_LEVEL_KEYS = {"test", "skip", "toolchains", "verify", "rebuild"}
+
+# Keys recognized one level down, inside each known top-level table. Some
+# support a platform-specific `<key>_<platform>` override (see
+# get_platform_value()); those are listed separately so the suffixed form is
+# accepted too.
+_TEST_SECTION_KEYS = {
+    "description",
+    "build_command",
+    "variants",
+    "timeout",
+    "generator",
+}
+_TEST_SECTION_PLATFORM_KEYS = {
+    "expected_outputs",
+    "expected_install_outputs",
+    "build_targets",
+    "toolchains",
+    "toolchain",
+}
+_SKIP_SECTION_KEYS = {
+    "platforms",
+    "requires",
+    "require_commands",
+    "requires_any",
+    "require_env",
+    "requires_cxx_modules",
+    "requires_cxx_std_module",
+    "generators",
+    "rebuild_on_windows",
+}
+_VERIFY_SECTION_PLATFORM_KEYS = {"commands"}
+_TOOLCHAINS_SECTION_KEYS = {"linux", "darwin", "windows"}
+
+_PLATFORM_SUFFIXES = ("windows", "darwin", "linux")
+
+
+def _validate_known_keys(
+    test_toml: Path,
+    section: str,
+    table: dict[str, Any],
+    allowed: set[str],
+    platform_aware: set[str] = frozenset(),
+) -> None:
+    """Raise if `table` has keys outside `allowed`/`platform_aware` (+ its
+    `_<platform>` suffixed forms).
+
+    A misnamed key (e.g. `test.expected_output` instead of the recognized
+    `test.expected_outputs`) otherwise silently disables the check it was
+    meant to enable — the build still passes, just with less coverage than
+    the author intended. Failing loudly on an unknown key catches the typo
+    instead.
+    """
+    unknown = [
+        key
+        for key in table
+        if key not in allowed
+        and key not in platform_aware
+        and not any(
+            key == f"{base}_{p}" for base in platform_aware for p in _PLATFORM_SUFFIXES
+        )
+    ]
+    if unknown:
+        raise ValueError(
+            f"{test_toml}: unknown key(s) in [{section}]: {', '.join(sorted(unknown))}"
+        )
+
+
 def load_test_config(example_dir: Path) -> dict[str, Any]:
-    """Load test.toml configuration."""
+    """Load test.toml configuration.
+
+    Validates that only recognized keys are present (see `_validate_known_keys`)
+    so a misnamed key fails the test run loudly instead of silently disabling
+    the verification it was meant to enable.
+    """
     if tomllib is None:
         pytest.skip("tomllib/tomli not available")
 
     config_file = example_dir / "test.toml"
     with open(config_file, "rb") as f:
-        return tomllib.load(f)
+        config = tomllib.load(f)
+
+    _validate_known_keys(config_file, "top level", config, _TOP_LEVEL_KEYS)
+    if "test" in config:
+        _validate_known_keys(
+            config_file,
+            "test",
+            config["test"],
+            _TEST_SECTION_KEYS,
+            _TEST_SECTION_PLATFORM_KEYS,
+        )
+    if "skip" in config:
+        _validate_known_keys(config_file, "skip", config["skip"], _SKIP_SECTION_KEYS)
+    if "verify" in config:
+        _validate_known_keys(
+            config_file,
+            "verify",
+            config["verify"],
+            set(),
+            _VERIFY_SECTION_PLATFORM_KEYS,
+        )
+    if "toolchains" in config:
+        _validate_known_keys(
+            config_file, "toolchains", config["toolchains"], _TOOLCHAINS_SECTION_KEYS
+        )
+
+    return config
 
 
 def should_skip(config: dict[str, Any]) -> str | None:

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -175,6 +175,43 @@ def was_registered() -> bool:
         assert "valid" in loaded
         assert "invalid" not in loaded
 
+    def test_handles_non_import_exception_at_module_scope(
+        self, module_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A module raising e.g. NameError/ValueError at import time is
+        logged and skipped, not fatal, and other modules still load."""
+        from pcons import modules  # type: ignore[attr-defined]
+
+        (module_dir / "good.py").write_text("x = 1")
+        # Raises NameError (undefined_name) when executed, not an
+        # import/syntax error.
+        (module_dir / "bad.py").write_text("undefined_name + 1\n")
+
+        with caplog.at_level("WARNING"):
+            loaded = modules.load_modules([module_dir])
+
+        assert "good" in loaded
+        assert "bad" not in loaded
+        assert any("bad" in record.message for record in caplog.records)
+
+    def test_handles_register_exception_gracefully(
+        self, module_dir: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A module whose register() raises is logged and skipped, not
+        fatal, and other modules still load."""
+        from pcons import modules  # type: ignore[attr-defined]
+
+        (module_dir / "good2.py").write_text("y = 2")
+        (module_dir / "badreg.py").write_text(
+            "def register() -> None:\n    raise RuntimeError('boom')\n"
+        )
+
+        with caplog.at_level("WARNING"):
+            loaded = modules.load_modules([module_dir])
+
+        assert "good2" in loaded
+        assert any("badreg" in record.message for record in caplog.records)
+
 
 class TestModuleNamespace:
     """Tests for the pcons.modules namespace."""

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -277,6 +277,32 @@ class TestJUnitOutput:
         assert cases[1].find("failure") is not None
         assert cases[2].find("skipped") is not None
 
+    def test_control_chars_in_output_produce_valid_xml(self, tmp_path):
+        # XML 1.0 forbids most C0 control chars (only tab/LF/CR survive
+        # below 0x20). A test that dumps binary-ish output to stdout/stderr
+        # used to get embedded raw, producing a file ET couldn't parse.
+        illegal = "boom\x00\x01\x07 core dumped"
+        results = [
+            TestResult(
+                name="bad",
+                status=FAIL,
+                duration=0.01,
+                stderr=illegal,
+                message="crashed\x0b",
+            ),
+        ]
+        out = tmp_path / "junit.xml"
+        write_junit(out, "demo", results)
+
+        # This raises ET.ParseError if the control chars weren't stripped.
+        root = ET.fromstring(out.read_text())
+        failure = root.find("testsuite/testcase/failure")
+        assert failure is not None
+        assert "\x00" not in (failure.text or "")
+        assert "boom" in (failure.text or "")
+        assert "core dumped" in (failure.text or "")
+        assert "\x0b" not in failure.attrib["message"]
+
 
 # ----- main() CLI integration ----------------------------------------------
 
@@ -321,6 +347,73 @@ class TestCLIMain:
         assert rc == 0
         captured = capsys.readouterr()
         assert "alpha" in captured.out
+
+    def test_list_mode_does_not_execute_discovery_binary(self, tmp_path, capsys):
+        # A discover-enabled entry's "list test cases" flag used to be
+        # invoked even for --list. It should now be listed at the
+        # manifest level (annotated) without ever being spawned.
+        marker = tmp_path / "invoked.marker"
+        lister = _make_exit_script(
+            tmp_path,
+            "lister.py",
+            f"import pathlib; pathlib.Path(r'{marker}').write_text('yes')\n"
+            "print('Suite.')\nprint('  Case')\n",
+        )
+        _make_manifest(
+            tmp_path,
+            [
+                {
+                    "name": "gtest_bin",
+                    "command": [str(lister)],
+                    "discover": "gtest",
+                    "labels": [],
+                }
+            ],
+        )
+        rc = main(["--manifest", str(tmp_path / "tests.json"), "--list", "--no-color"])
+        assert rc == 0
+        assert not marker.exists()
+        out = capsys.readouterr().out
+        assert "gtest_bin" in out
+        assert "discover: gtest" in out
+
+    def test_label_excluded_discovery_binary_is_never_invoked(self, tmp_path):
+        # Filtering must happen before discovery: a binary excluded by
+        # label should never have its listing flag run, in a real
+        # (non --list) invocation too.
+        marker = tmp_path / "invoked.marker"
+        lister = _make_exit_script(
+            tmp_path,
+            "lister.py",
+            f"import pathlib; pathlib.Path(r'{marker}').write_text('yes')\n"
+            "print('Suite.')\nprint('  Case')\n",
+        )
+        ok = _make_exit_script(tmp_path, "ok.py", "import sys; sys.exit(0)")
+        _make_manifest(
+            tmp_path,
+            [
+                {
+                    "name": "gtest_bin",
+                    "command": [str(lister)],
+                    "discover": "gtest",
+                    "labels": ["slow"],
+                },
+                {"name": "fast", "command": [str(ok)], "labels": ["fast"]},
+            ],
+        )
+        rc = main(
+            [
+                "--manifest",
+                str(tmp_path / "tests.json"),
+                "-LE",
+                "slow",
+                "-j",
+                "1",
+                "--no-color",
+            ]
+        )
+        assert rc == 0
+        assert not marker.exists()
 
     def test_label_filter(self, tmp_path, capsys):
         ok = _make_exit_script(tmp_path, "ok.py", "import sys; sys.exit(0)")
@@ -703,6 +796,46 @@ class TestSerialExclusivity:
         )
         assert {r.name for r in results} == {"p1", "s1", "p2"}
         assert all(r.status == PASS for r in results)
+
+
+class TestJobsZeroMeansUnlimited:
+    def test_jobs_zero_runs_all_non_serial_tests(self, tmp_path):
+        # Regression test: run_all used to size the worker pool off
+        # max(1, jobs) but gate launches on the raw `jobs` value, so
+        # `jobs=0` (ninja's "-j0 == unlimited" convention) made
+        # `len(running) >= 0` always true. No non-serial test was ever
+        # submitted; they all came back as SKIP "not run", which is a
+        # false green (main() would report 0 failures with nothing run).
+        ok = _make_exit_script(tmp_path, "ok.py", "import sys; sys.exit(0)")
+        tests = [
+            {"name": "a", "command": [str(ok)], "labels": []},
+            {"name": "b", "command": [str(ok)], "labels": []},
+            {"name": "c", "command": [str(ok)], "labels": []},
+        ]
+        results = run_all(
+            tests,
+            tmp_path,
+            jobs=0,
+            stop_on_fail=False,
+            on_start=lambda _t: None,
+            on_finish=lambda _t, _r: None,
+        )
+        by_name = {r.name: r for r in results}
+        assert all(r.status == PASS for r in by_name.values())
+        assert all(r.message != "not run" for r in by_name.values())
+
+    def test_negative_jobs_also_means_unlimited(self, tmp_path):
+        ok = _make_exit_script(tmp_path, "ok.py", "import sys; sys.exit(0)")
+        tests = [{"name": "a", "command": [str(ok)], "labels": []}]
+        results = run_all(
+            tests,
+            tmp_path,
+            jobs=-1,
+            stop_on_fail=False,
+            on_start=lambda _t: None,
+            on_finish=lambda _t, _r: None,
+        )
+        assert results[0].status == PASS
 
 
 # ----- Discovery warnings (non-fatal paths) -------------------------------

--- a/tests/toolchains/test_cross_presets.py
+++ b/tests/toolchains/test_cross_presets.py
@@ -221,6 +221,23 @@ class TestCrossPresetApplication:
         assert "--target=aarch64-linux-gnu" in env.cc.flags
         assert "--target=aarch64-linux-gnu" in env.cxx.flags
 
+    def test_gcc_apply_triple_no_target_flag(self, test_project):  # noqa: F811
+        """GCC rejects --target=; the cross preset must not add it for gcc."""
+        from pcons.toolchains.gcc import GccToolchain
+
+        env = _make_unix_env()
+        toolchain = GccToolchain()
+
+        preset = CrossPreset(
+            name="test",
+            arch="arm64",
+            triple="aarch64-linux-gnu",
+        )
+        toolchain.apply_cross_preset(env, preset)
+
+        assert not any("--target=" in str(f) for f in env.cc.flags)
+        assert not any("--target=" in str(f) for f in env.cxx.flags)
+
     def test_unix_apply_sysroot(self, test_project):  # noqa: F811
         """UnixToolchain should apply --sysroot flag."""
         from pcons.toolchains.llvm import LlvmToolchain

--- a/tests/toolchains/test_cuda.py
+++ b/tests/toolchains/test_cuda.py
@@ -1,8 +1,33 @@
 # SPDX-License-Identifier: MIT
 """Tests for CUDA toolchain."""
 
+from pcons.configure.platform import Platform, get_platform
 from pcons.toolchains import CudaCompiler, CudaToolchain, find_cuda_toolchain
 from pcons.tools.toolchain import SourceHandler
+
+_WINDOWS_PLATFORM = Platform(
+    os="windows",
+    arch="x86_64",
+    is_64bit=True,
+    exe_suffix=".exe",
+    shared_lib_suffix=".dll",
+    shared_lib_prefix="",
+    static_lib_suffix=".lib",
+    static_lib_prefix="",
+    object_suffix=".obj",
+)
+
+_LINUX_PLATFORM = Platform(
+    os="linux",
+    arch="x86_64",
+    is_64bit=True,
+    exe_suffix="",
+    shared_lib_suffix=".so",
+    shared_lib_prefix="lib",
+    static_lib_suffix=".a",
+    static_lib_prefix="lib",
+    object_suffix=".o",
+)
 
 
 class TestCudaCompiler:
@@ -58,7 +83,7 @@ class TestCudaToolchain:
         assert isinstance(handler, SourceHandler)
         assert handler.tool_name == "cuda"
         assert handler.language == "cuda"
-        assert handler.object_suffix == ".o"
+        assert handler.object_suffix == get_platform().object_suffix
 
     def test_source_handler_unknown(self):
         """CudaToolchain returns None for unknown suffixes."""
@@ -68,9 +93,31 @@ class TestCudaToolchain:
         assert toolchain.get_source_handler(".txt") is None
 
     def test_object_suffix(self):
-        """CudaToolchain produces .o files."""
+        """CudaToolchain matches the host platform's object suffix."""
+        toolchain = CudaToolchain()
+        assert toolchain.get_object_suffix() == get_platform().object_suffix
+
+    def test_object_suffix_windows(self, monkeypatch):
+        """On Windows, nvcc objects pair with MSVC's .obj convention."""
+        monkeypatch.setattr(
+            "pcons.toolchains.cuda.get_platform", lambda: _WINDOWS_PLATFORM
+        )
+        toolchain = CudaToolchain()
+        assert toolchain.get_object_suffix() == ".obj"
+        handler = toolchain.get_source_handler(".cu")
+        assert handler is not None
+        assert handler.object_suffix == ".obj"
+
+    def test_object_suffix_linux(self, monkeypatch):
+        """On Linux, nvcc objects pair with GCC/Clang's .o convention."""
+        monkeypatch.setattr(
+            "pcons.toolchains.cuda.get_platform", lambda: _LINUX_PLATFORM
+        )
         toolchain = CudaToolchain()
         assert toolchain.get_object_suffix() == ".o"
+        handler = toolchain.get_source_handler(".cu")
+        assert handler is not None
+        assert handler.object_suffix == ".o"
 
 
 class TestCudaVariants:

--- a/tests/toolchains/test_emscripten.py
+++ b/tests/toolchains/test_emscripten.py
@@ -11,6 +11,7 @@ from pcons.toolchains.emscripten import (
     EmccCxxCompiler,
     EmccLinker,
     EmscriptenToolchain,
+    find_emscripten_toolchain,
     find_emsdk,
     is_emcc_available,
 )
@@ -291,6 +292,43 @@ class TestEmscriptenRegistration:
         entry = toolchain_registry.get("emcc")
         assert entry is not None
         assert entry.toolchain_class is EmscriptenToolchain
+
+    def test_is_available_wired_to_real_probe(self):
+        """The registry entry must gate on is_emcc_available, not just
+        ``shutil.which("emcc")`` directly — this is what lets
+        find_available() correctly skip Emscripten when emcc is absent
+        even though another wasm-category toolchain's check_command
+        (e.g. WASI's "clang") happens to be on PATH."""
+        from pcons.tools.toolchain import toolchain_registry
+
+        entry = toolchain_registry.get("emscripten")
+        assert entry is not None
+        assert entry.is_available is is_emcc_available
+
+
+class TestFindEmscriptenToolchain:
+    """find_emscripten_toolchain() must not return a WASI toolchain when
+    emcc is absent — a bare ``clang`` on PATH (WASI's check_command) is
+    not Emscripten, and must not be silently substituted."""
+
+    def test_raises_when_no_emcc(self, monkeypatch):
+        monkeypatch.delenv("EMSDK", raising=False)
+        monkeypatch.setattr("shutil.which", lambda _cmd: None)
+        with pytest.raises(RuntimeError, match="Emscripten not found"):
+            find_emscripten_toolchain()
+
+    def test_does_not_silently_return_wasi(self, monkeypatch, tmp_path):
+        """Even if a real wasi-sdk happens to be installed (category-wide
+        fallback), find_emscripten_toolchain must raise rather than
+        silently return a WasiToolchain — which would produce a bare
+        .wasm instead of the expected .js + .wasm pair."""
+        from pcons.toolchains import wasi
+
+        monkeypatch.delenv("EMSDK", raising=False)
+        monkeypatch.setattr("shutil.which", lambda _cmd: None)
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: tmp_path)
+        with pytest.raises(RuntimeError, match="Emscripten not found"):
+            find_emscripten_toolchain()
 
 
 class TestEmsdkHints:

--- a/tests/toolchains/test_msvc.py
+++ b/tests/toolchains/test_msvc.py
@@ -17,6 +17,10 @@ from pcons.toolchains.msvc import (
     MsvcLinker,
     MsvcResourceCompiler,
     MsvcToolchain,
+    _find_msvc_bin_dir,
+    _host_arch_dirs,
+    _sorted_version_dirs,
+    _version_sort_key,
 )
 
 
@@ -633,3 +637,124 @@ class TestMsvcAuxiliaryInputHandler:
         handler = tc.get_auxiliary_input_handler(".MANIFEST")
         assert handler is not None
         assert handler.suffix == ".manifest"
+
+
+class TestVersionSortKey:
+    """_version_sort_key parses MSVC/SDK version directory names for
+    numeric (not lexicographic) comparison."""
+
+    def test_parses_msvc_tool_version(self):
+        assert _version_sort_key("14.38.33130") == (14, 38, 33130)
+
+    def test_parses_sdk_version(self):
+        assert _version_sort_key("10.0.22621.0") == (10, 0, 22621, 0)
+
+    def test_rejects_non_numeric_component(self):
+        assert _version_sort_key("14.38.33130-preview") is None
+
+    def test_rejects_empty_string(self):
+        assert _version_sort_key("") is None
+
+
+class TestSortedVersionDirs:
+    """_sorted_version_dirs must sort numerically, not lexicographically,
+    so e.g. 14.10 (newer) beats 14.9, which a plain string sort gets wrong."""
+
+    def test_numeric_ordering_beats_lexicographic(self, tmp_path):
+        for name in ("14.9.0", "14.10.0", "14.2.0"):
+            (tmp_path / name).mkdir()
+
+        dirs = _sorted_version_dirs(tmp_path)
+
+        assert [d.name for d in dirs] == ["14.10.0", "14.9.0", "14.2.0"]
+
+    def test_realistic_sdk_versions_sort_numerically(self, tmp_path):
+        # Lexicographically "10.0.9200.0" > "10.0.22621.0" (character '9' >
+        # '2'), but 22621 is the newer SDK build.
+        for name in ("10.0.9200.0", "10.0.22621.0", "10.0.19041.0"):
+            (tmp_path / name).mkdir()
+
+        dirs = _sorted_version_dirs(tmp_path)
+
+        assert dirs[0].name == "10.0.22621.0"
+
+    def test_garbage_directories_are_skipped_not_crashed(self, tmp_path):
+        (tmp_path / "14.38.33130").mkdir()
+        (tmp_path / "not-a-version").mkdir()
+        (tmp_path / "some_file.txt").write_text("not a dir")
+
+        dirs = _sorted_version_dirs(tmp_path)
+
+        assert [d.name for d in dirs] == ["14.38.33130"]
+
+
+class TestHostArchDirs:
+    """_host_arch_dirs must reflect the detected host, not hardcode x64,
+    so ARM64 (and other) hosts get the right Host<ARCH>/<arch> bin dir."""
+
+    @pytest.mark.parametrize(
+        "machine,expected",
+        [
+            ("AMD64", ("Hostx64", "x64")),
+            ("x86_64", ("Hostx64", "x64")),
+            ("ARM64", ("HostARM64", "arm64")),
+            ("aarch64", ("HostARM64", "arm64")),
+        ],
+    )
+    def test_detected_host(self, monkeypatch, machine, expected):
+        monkeypatch.setattr("platform.machine", lambda: machine)
+        assert _host_arch_dirs() == expected
+
+
+class TestFindMsvcBinDirHostAware:
+    """_find_msvc_bin_dir (and the vswhere fallbacks in MsvcCompiler.configure
+    / MsvcAssembler.configure that delegate to it) must pick the bin dir
+    matching the running host's architecture, not a hardcoded Hostx64/x64."""
+
+    def test_picks_arm64_host_dir_on_arm64_host(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pcons.toolchains.msvc._find_msvc_install", lambda: tmp_path
+        )
+        monkeypatch.setattr("platform.machine", lambda: "ARM64")
+
+        vc_tools = tmp_path / "VC" / "Tools" / "MSVC" / "14.40.12345"
+        arm_bin = vc_tools / "bin" / "HostARM64" / "arm64"
+        arm_bin.mkdir(parents=True)
+        (arm_bin / "cl.exe").touch()
+        # An x64 host dir also exists (e.g. a shared VS install) — it must
+        # NOT be picked when the running host is ARM64.
+        x64_bin = vc_tools / "bin" / "Hostx64" / "x64"
+        x64_bin.mkdir(parents=True)
+        (x64_bin / "cl.exe").touch()
+
+        assert _find_msvc_bin_dir() == arm_bin
+
+    def test_picks_x64_host_dir_on_x64_host(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pcons.toolchains.msvc._find_msvc_install", lambda: tmp_path
+        )
+        monkeypatch.setattr("platform.machine", lambda: "AMD64")
+
+        vc_tools = tmp_path / "VC" / "Tools" / "MSVC" / "14.40.12345"
+        x64_bin = vc_tools / "bin" / "Hostx64" / "x64"
+        x64_bin.mkdir(parents=True)
+        (x64_bin / "cl.exe").touch()
+
+        assert _find_msvc_bin_dir() == x64_bin
+
+    def test_picks_newest_version_numerically(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "pcons.toolchains.msvc._find_msvc_install", lambda: tmp_path
+        )
+        monkeypatch.setattr("platform.machine", lambda: "AMD64")
+
+        vc_tools = tmp_path / "VC" / "Tools" / "MSVC"
+        for version in ("14.9.0", "14.10.0"):
+            bin_dir = vc_tools / version / "bin" / "Hostx64" / "x64"
+            bin_dir.mkdir(parents=True)
+            (bin_dir / "cl.exe").touch()
+
+        result = _find_msvc_bin_dir()
+
+        assert result is not None
+        assert result.parent.parent.parent.name == "14.10.0"

--- a/tests/toolchains/test_wasi.py
+++ b/tests/toolchains/test_wasi.py
@@ -11,6 +11,8 @@ from pcons.toolchains.wasi import (
     WasiLinker,
     WasiToolchain,
     find_wasi_sdk,
+    find_wasi_toolchain,
+    is_wasi_sdk_available,
 )
 
 # =============================================================================
@@ -257,6 +259,56 @@ class TestWasiRegistration:
         entry = toolchain_registry.get("wasi-sdk")
         assert entry is not None
         assert entry.toolchain_class is WasiToolchain
+
+    def test_is_available_wired_to_real_sdk_probe(self):
+        """The registry entry must gate on a real wasi-sdk probe, not just
+        ``shutil.which("clang")`` — otherwise any system clang would make
+        the toolchain look available (see find_available)."""
+        from pcons.tools.toolchain import toolchain_registry
+
+        entry = toolchain_registry.get("wasi")
+        assert entry is not None
+        assert entry.is_available is is_wasi_sdk_available
+
+
+class TestIsWasiSdkAvailable:
+    def test_false_when_no_sdk(self, monkeypatch):
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: None)
+        assert is_wasi_sdk_available() is False
+
+    def test_true_when_sdk_found(self, monkeypatch, tmp_path):
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: tmp_path)
+        assert is_wasi_sdk_available() is True
+
+
+class TestFindWasiToolchain:
+    """find_wasi_toolchain() must not return a toolchain whose wasi-sdk
+    isn't actually installed — plain ``clang`` on PATH is not enough."""
+
+    def test_raises_when_no_wasi_sdk(self, monkeypatch):
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: None)
+        with pytest.raises(RuntimeError, match="wasi-sdk not found"):
+            find_wasi_toolchain()
+
+    def test_does_not_silently_return_emscripten(self, monkeypatch):
+        """Even if Emscripten happens to be available (category-wide
+        fallback), find_wasi_toolchain must raise rather than silently
+        return an EmscriptenToolchain mislabeled as WASI."""
+        from pcons.toolchains import wasi
+
+        monkeypatch.setattr(wasi, "find_wasi_sdk", lambda: None)
+        monkeypatch.delenv("EMSDK", raising=False)
+        monkeypatch.setattr(
+            "shutil.which", lambda cmd: "/usr/bin/emcc" if cmd == "emcc" else None
+        )
+        with pytest.raises(RuntimeError, match="wasi-sdk not found"):
+            find_wasi_toolchain()
 
 
 class TestWasiHints:

--- a/tests/tools/test_toolchain.py
+++ b/tests/tools/test_toolchain.py
@@ -122,26 +122,3 @@ class TestLanguagePriority:
         priority = tc.language_priority
         assert priority["c"] < priority["cxx"]
         assert priority["cxx"] < priority["cuda"]
-
-    def test_get_linker_for_languages_c_only(self):
-        tc = MockToolchain()
-        linker = tc.get_linker_for_languages({"c"})
-        assert linker == "cc"
-
-    def test_get_linker_for_languages_cxx(self):
-        tc = MockToolchain()
-        linker = tc.get_linker_for_languages({"c", "cxx"})
-        # C++ should win (higher priority)
-        assert linker == "cxx"
-
-    def test_get_linker_for_languages_empty(self):
-        tc = MockToolchain()
-        linker = tc.get_linker_for_languages(set())
-        assert linker == "link"
-
-    def test_get_linker_for_fortran(self):
-        tc = MockToolchain()
-        linker = tc.get_linker_for_languages({"c", "fortran"})
-        # Base toolchains don't know about Fortran priority, so C wins.
-        # GfortranToolchain overrides language_priority to add "fortran": 3.
-        assert linker == "cc"

--- a/tests/util/test_commands.py
+++ b/tests/util/test_commands.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 from pcons.util.commands import concat, copy, copytree
@@ -128,3 +129,36 @@ class TestCopytree:
         copytree(str(src), str(dest), stamp=str(stamp))
 
         assert stamp.exists()
+
+    def test_copytree_depfile_escapes_spaces(self, tmp_path: Path) -> None:
+        """Test that source paths with spaces are escaped in the depfile.
+
+        Ninja depfiles treat unescaped spaces as dependency separators, so a
+        path containing a space must be written as ``my\\ file.txt`` (a single
+        escaped dependency), not ``my file.txt`` (which ninja would parse as
+        two separate dependencies).
+        """
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "my file.txt").write_text("has a space")
+
+        dest = tmp_path / "dest"
+        depfile = tmp_path / "deps.d"
+
+        copytree(str(src), str(dest), depfile=str(depfile))
+
+        content = depfile.read_text()
+        assert "my\\ file.txt" in content
+
+        # Verify the depfile parses to exactly one dependency for this file:
+        # join line continuations, then split on spaces that are NOT
+        # backslash-escaped (mimicking ninja's depfile tokenizer), and
+        # finally unescape "\ " back to a plain space.
+        _, deps_part = content.split(":", 1)
+        deps_part = deps_part.replace("\\\n", " ")
+        tokens = re.split(r"(?<!\\) ", deps_part)
+        deps = [t.strip().replace("\\ ", " ") for t in tokens if t.strip()]
+        expected = str(src / "my file.txt").replace("\\", "/")
+        assert deps.count(expected) == 1
+        assert not any(d.endswith("/my") for d in deps)
+        assert "file.txt" not in deps


### PR DESCRIPTION
Fixes from a full-repo code review, one commit per issue. Every fix includes tests; the whole branch is green on macOS (2108 unit tests) and Windows/tower1 (2033 unit tests, 64 ninja example tests — the 2 remaining example failures there are missing-tool environmental, Rust and an old `uv`).

## Correctness bugs
- **Objective-C++/CUDA link driver** — `.mm`/`.cu` targets linked with the C driver, so libc++/libstdc++ was never linked. Now use the C++ linker for `objcxx`/`cuda` link languages.
- **Target-identity collapse** — graph algorithms keyed on the unqualified `.name`, so two subproject targets sharing a short name collapsed (silent missing deps / spurious `DependencyCycleError`). Keyed on `qualified_name`; `depends()`-only cycles now raise cleanly instead of `RecursionError`.
- **Configure cache correctness** — hints now override the cache; removed the always-False `check_header`/`check_symbol` placeholders; `_defines` rebuilt per run; `write_config_header` is write-if-changed; check keys fold in headers/libs; MSVC/clang-cl flag dispatch.
- **Conan finder** — honor a custom conanfile name; MSVC profile sets the mandatory `compiler.version`/`runtime`; version detected from the real toolchain; word-boundary `.pc` var substitution; multi-word `PCONS_CONAN`.
- **Generators** — Makefile recipes escape `$`→`$$` (fixes `$ORIGIN` rpath); ninja emits `msvc_deps_prefix` (localized-MSVC header deps); `compile_commands.json` renders the real toolchain command (correct for clang-cl).
- **Test runner** — `-j0` no longer reports a false green; JUnit strips XML-illegal control chars; `--list` doesn't execute discovery binaries; robust `test` subcommand dispatch.
- **Others** — module loader no longer crashes on one bad plugin; copytree depfile escapes spaces; wasm detection requires the real SDK; `Default()` handles nodes/aliases; macOS bundle string-plist + XML escaping; MSVC version-dir numeric sort + host-arch fallback; GCC no longer gets `--target=`; CUDA obj suffix from platform.

## Security
- **Ninja command-injection quoting** — the ninja branch didn't neutralize shell metacharacters in space-free tokens (attacker-controlled filename or dependency flag → command execution under `sh -c`). Now escaped, **platform-aware**: full escaping for POSIX `sh`, quote-only for Windows `cmd.exe` (backslash isn't an escape there — escaping it corrupted `python -c` manifest commands, caught on tower1).
- **MSIX signing** — real `.signed.msix` output (no phantom target); signing password passed as an env-var name, not baked into `build.ninja`.
- **msvcup** — verify a pinned SHA-256 before executing the downloaded binary; fail closed.

## Tests, docs, hygiene
- Autouse fixture now snapshots/restores the global BuilderRegistry + preset registry (closes the latent Linux-CI leak); example harness rejects unknown `test.toml` keys (fixed 3 examples whose verification was silently dead).
- User-guide `Generator().generate()` calls, mkdocs nav, README (`build.ninja`, `ty`), example docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)