### PR TITLE
Fix Conan compiler.version detection when sync_profile() has no toolchain

### DIFF
--- a/pcons/packages/finders/conan.py
+++ b/pcons/packages/finders/conan.py
@@ -324,10 +324,14 @@ class ConanFinder(BaseFinder):
                 ``_get_toolchain_compiler_cmd`` — this must match what
                 [buildenv] CC/CXX use, so profile detection doesn't run a
                 bare "gcc"/"clang" off PATH while the build itself uses a
-                different, toolchain-selected compiler. Falls back to the
-                bare compiler name when no toolchain is available.
+                different, toolchain-selected compiler. Falls back to a
+                real compiler binary on PATH when no toolchain is available.
         """
-        cmd = compiler_cmd or compiler
+        # Without a toolchain command, map the Conan compiler name to an
+        # actual executable: "apple-clang" is a Conan setting value, not a
+        # runnable binary (the binary is "clang").
+        _name_to_binary = {"apple-clang": "clang", "clang": "clang", "gcc": "gcc"}
+        cmd = compiler_cmd or _name_to_binary.get(compiler, compiler)
         try:
             if compiler in ("apple-clang", "clang"):
                 result = subprocess.run(

--- a/tests/packages/test_conan.py
+++ b/tests/packages/test_conan.py
@@ -809,6 +809,30 @@ class TestConanFinderWithToolchain:
 
         assert settings["compiler.version"] == "13"
 
+    def test_detect_compiler_version_no_toolchain_maps_apple_clang_to_binary(
+        self, tmp_path: Path
+    ) -> None:
+        """With no toolchain (sync_profile() called bare), the Conan compiler
+        name "apple-clang" must be mapped to the real "clang" binary — it is
+        not itself an executable — so version detection still works on macOS.
+        """
+        finder = ConanFinder(output_folder=tmp_path)
+        invoked: list[str] = []
+
+        def mock_run(cmd, **kwargs):
+            invoked.append(cmd[0])
+            result = MagicMock()
+            result.returncode = 0
+            result.stdout = "Apple clang version 15.0.0 (clang-1500.0.40.1)\n"
+            result.stderr = ""
+            return result
+
+        with patch("subprocess.run", side_effect=mock_run):
+            version = finder._detect_compiler_version("apple-clang", None)
+
+        assert version == "15"
+        assert invoked == ["clang"]  # not the non-existent "apple-clang"
+
     def test_detect_compiler_settings_with_clang_toolchain(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes a regression introduced in the recent code-review batch (finding #17). When `ConanFinder.sync_profile()` is called **without a toolchain**, Conan compiler-version detection failed on macOS, aborting with:

```
ERROR: ... Invalid: 'settings.compiler.version' value not defined
```

## Root cause

Finding #17 changed `_detect_compiler_version` to resolve the compiler command from the toolchain (so profile detection matches the compiler the build actually uses). Its no-toolchain fallback used the Conan compiler *name* as the command:

```python
cmd = compiler_cmd or compiler   # compiler == "apple-clang"
```

But `"apple-clang"` is a Conan **setting value**, not a runnable binary — the executable is `clang`. So `subprocess.run(["apple-clang", "--version"])` raised, version detection returned `None`, and Conan got no version. The old code sidestepped this by hardcoding `["clang", ...]`.

## Fix

Map the Conan compiler name to a real binary in the no-toolchain fallback (`apple-clang`/`clang` → `clang`, `gcc` → `gcc`), while keeping the toolchain-command behavior when a toolchain is present.

## How it was found

Running the external real-world projects in `~/src/pcons-tests` against the merged pcons. The `reflect` project calls `sync_profile(build_type=..., cppstd="20")` without a toolchain (deliberately, so Conan doesn't use its reflection compiler) and hit this. After the fix it generates `build.ninja` cleanly.

## Tests

Added `test_detect_compiler_version_no_toolchain_maps_apple_clang_to_binary` (asserts `clang` is invoked, not the non-existent `apple-clang`). Full unit suite green (2116 passed); ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)