### PR TITLE
Make link() first-class again; add link_private(); fix private-dep header leak

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1449,16 +1449,16 @@ httplib = ImportedTarget.from_package(PackageDescription(
     include_dirs=['/opt/homebrew/include'],
     defines=['CPPHTTPLIB_OPENSSL_SUPPORT'],
 ))
-httplib.public.link_libs.append(openssl)  # transitive: consumers get openssl too
+httplib.link(openssl)  # transitive: consumers get openssl too
 
 # Build library
 libcore = project.StaticLibrary('core', env, sources=['src/core.cpp'])
 libcore.public.include_dirs.append(Path('include'))
-libcore.private.link_libs.append(zlib)  # private dep: not re-exported to consumers
+libcore.link_private(zlib)  # private dep: not re-exported to consumers
 
 # Build executable — gets zlib transitively through libcore's link deps
 app = project.Program('myapp', env, sources=['src/main.cpp'])
-app.private.link_libs.extend([libcore, openssl, httplib])
+app.link_private(libcore, openssl, httplib)
 
 project.Default(app)
 Generator().generate(project)
@@ -1565,7 +1565,7 @@ An ImportedTarget represents an external dependency. It has usage requirements b
 ```python
 # Preferred: use project.find_package()
 zlib = project.find_package("zlib")
-app.private.link_libs.append(zlib)  # public requirements propagate automatically
+app.link_private(zlib)  # public requirements propagate automatically
 
 # Manual: for header-only libs or packages without .pc files
 httplib = ImportedTarget.from_package(PackageDescription(
@@ -1573,7 +1573,7 @@ httplib = ImportedTarget.from_package(PackageDescription(
     include_dirs=["/usr/include"],
     defines=["CPPHTTPLIB_OPENSSL_SUPPORT"],
 ))
-httplib.public.link_libs.append(openssl)  # re-exported to consumers
+httplib.link(openssl)  # re-exported to consumers
 ```
 
 ### Package Finders
@@ -1606,13 +1606,13 @@ from pcons import Generator, Project, find_c_toolchain
 project = Project('myapp', build_dir='build')
 env = project.Environment(toolchain=find_c_toolchain())
 
-# find_package returns ImportedTarget — link_libs propagates requirements
+# find_package returns ImportedTarget — link_private propagates requirements
 zlib = project.find_package('zlib')
 openssl = project.find_package('openssl')
 boost = project.find_package('boost', components=['filesystem'])
 
 app = project.Program('myapp', env, sources=['main.cpp'])
-app.private.link_libs.extend([zlib, openssl, boost])
+app.link_private(zlib, openssl, boost)
 # Automatically gets all include dirs, library dirs, libraries, flags
 
 Generator().generate(project)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`target.link_private(*libs)`** adds PRIVATE link dependencies: the target gets the dependency's headers and usage requirements (or, for a string like `"m"`, just the raw link token) without re-exporting anything to its own consumers. The counterpart of `target.link()`, and the recommended replacement for `target.private.link_libs.append(...)`.
+
+### Changed
+
+- **`target.link(*libs)` is un-deprecated and is again the recommended way to add PUBLIC link dependencies** (it re-exports them to consumers, like CMake's plain `target_link_libraries`). It now also accepts raw library-name strings (`app.link(mylib, "m")`). The `target.public.link_libs` / `target.private.link_libs` lists remain fully supported as the low-level form.
+
 ## [0.20.1] - 2026-06-18
 
 ### Fixed

--- a/docs/porting-from-cmake.md
+++ b/docs/porting-from-cmake.md
@@ -18,9 +18,9 @@ This guide maps common CMake patterns to their pcons equivalents. It's designed 
 | `add_executable(name src...)` | `project.Program("name", env, sources=[...])` |
 | `add_library(name STATIC src...)` | `project.StaticLibrary("name", env, sources=[...])` |
 | `add_library(name SHARED src...)` | `project.SharedLibrary("name", env, sources=[...])` |
-| `target_link_libraries(t PUBLIC lib)` | `t.public.link_libs.append(lib)` |
-| `target_link_libraries(t PRIVATE lib)` | `t.private.link_libs.append(lib)` |
-| `target_link_libraries(t -lm)` | `t.public.link_libs.append("m")` |
+| `target_link_libraries(t PUBLIC lib)` | `t.link(lib)` |
+| `target_link_libraries(t PRIVATE lib)` | `t.link_private(lib)` |
+| `target_link_libraries(t -lm)` | `t.link("m")` |
 | `target_include_directories(t PUBLIC dir)` | `t.public.include_dirs.append(dir)` |
 | `target_compile_definitions(t PRIVATE DEF)` | `t.private.defines.append("DEF")` |
 | `set_target_properties(t PROPERTIES OUTPUT_NAME n)` | `t.output_name = "n"` |
@@ -144,10 +144,10 @@ target_link_libraries(app PRIVATE mylib)
 
 ```python
 # pcons
-app.private.link_libs.append(mylib)
+app.link_private(mylib)
 ```
 
-Appending to `link_libs` applies the dependency's public usage requirements (include dirs, defines, link flags) — just like CMake. Use `public.link_libs` to re-export them to consumers (CMake's `PUBLIC`) or `private.link_libs` to keep them local (CMake's `PRIVATE`).
+`link()` / `link_private()` apply the dependency's public usage requirements (include dirs, defines, link flags) — just like CMake. Use `link()` to re-export them to consumers (CMake's `PUBLIC`) or `link_private()` to keep them local (CMake's `PRIVATE`). The `target.public.link_libs` / `target.private.link_libs` lists are the equivalent low-level form.
 
 ### PUBLIC vs PRIVATE
 
@@ -169,8 +169,8 @@ mylib.private.defines.append("INTERNAL_FLAG")
 
 ### System libraries (`-l` flags)
 
-!!! warning "Use `link_libs`, not `link_flags`"
-    On Linux, link order matters. Libraries specified with `link_libs` are placed **after** object files on the link line (correct for `-l` resolution). `link_flags` are placed **before** objects.
+!!! warning "Use `link()`, not `link_flags`"
+    On Linux, link order matters. Libraries linked with `link()`/`link_private()` are placed **after** object files on the link line (correct for `-l` resolution). `link_flags` are placed **before** objects.
 
 ```cmake
 # CMake
@@ -179,8 +179,7 @@ target_link_libraries(mylib PUBLIC m pthread)
 
 ```python
 # pcons
-mylib.public.link_libs.append("m")
-mylib.public.link_libs.append("pthread")
+mylib.link("m", "pthread")
 ```
 
 ### INTERFACE-only libraries
@@ -475,7 +474,7 @@ target_link_libraries(app PRIVATE ZLIB::ZLIB)
 ```python
 # pcons
 zlib = project.find_package("zlib")
-app.private.link_libs.append(zlib)
+app.link_private(zlib)
 ```
 
 `find_package()` searches using pkg-config first, then system paths. For optional dependencies:
@@ -483,7 +482,7 @@ app.private.link_libs.append(zlib)
 ```python
 optional_dep = project.find_package("libfoo", required=False)
 if optional_dep:
-    app.private.link_libs.append(optional_dep)
+    app.link_private(optional_dep)
 ```
 
 ### Conan integration
@@ -695,7 +694,7 @@ Print statements work during generation — they run at configure/generate time,
 
 ## Gotchas and Tips
 
-1. **`link_libs` vs `link_flags`**: Use `link_libs` for `-l` libraries (e.g., `"m"`, `"pthread"`). These are placed **after** objects on the link line, which matters on Linux where the linker resolves symbols left-to-right. `link_flags` are placed **before** objects and are for flags like `-Wl,-rpath`.
+1. **`link()` vs `link_flags`**: Use `link()`/`link_private()` for `-l` libraries (e.g., `"m"`, `"pthread"`). These are placed **after** objects on the link line, which matters on Linux where the linker resolves symbols left-to-right. `link_flags` are placed **before** objects and are for flags like `-Wl,-rpath`.
 
 2. **Pre-compiled objects and `-fPIC`**: If you compile objects with `env.cc.Object()` and add them to both a static and shared library, compile them separately. Pcons auto-adds `-fPIC` for `SharedLibrary` sources, but not for pre-compiled objects.
 
@@ -711,7 +710,7 @@ Print statements work during generation — they run at configure/generate time,
 
 8. **Removing flags from a cloned environment**: CMake's per-target flags are additive. In pcons, if you clone an environment and need to *remove* a flag (e.g., `-fno-rtti` for a consumer library that needs RTTI), you modify the list directly on the cloned env using plain python. Plan for this when a project has libraries with different flag requirements.
 
-9. **Transitive dependencies work automatically**: Like CMake, when A links B and B links C, A automatically gets C's public requirements. You don't need to repeat `link_libs` entries — just link your direct dependencies and public include dirs, defines, and link libs propagate transitively.
+9. **Transitive dependencies work automatically**: Like CMake, when A links B and B links C, A automatically gets C's public requirements. You don't need to repeat `link()` calls — just link your direct dependencies and public include dirs, defines, and link libs propagate transitively.
 
 10. **Configure-time vs build-time code generation**: If you generate files with plain Python at configure time (e.g., embedding assets into headers), pcons won't track changes to the input files across builds. For inputs that may change, either use `env.Command()` (runs at build time with dependency tracking) or add `target.depends()` on the generated file's inputs so rebuilds are triggered correctly.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -380,7 +380,7 @@ lib.add_sources(["lib.cpp"])
 lib.public.include_dirs.append(Path("include"))
 
 # Link the program against the library
-app.private.link_libs.append(lib)
+app.link_private(lib)
 ```
 
 #### Target Types
@@ -654,14 +654,14 @@ libmath.add_sources([src_dir / "math_utils.c"])
 libmath.public.include_dirs.append(include_dir)
 
 # Public link libs (e.g., math library on Linux).
-# Use link_libs for -l libraries (placed after objects on the link line).
-# Use link_flags for other linker flags (placed before objects).
-libmath.public.link_libs.append("m")
+# link("m") adds a raw -l library (placed after objects on the link line);
+# use link_flags for other linker flags (placed before objects).
+libmath.link("m")
 
 # Create program that uses the library
 app = project.Program("myapp", env)
 app.add_sources([src_dir / "main.c"])
-app.private.link_libs.append(libmath)  # Gets libmath's public includes automatically!
+app.link_private(libmath)  # Gets libmath's public includes automatically!
 
 project.Default(app)
 Generator().generate(project)
@@ -669,10 +669,10 @@ Generator().generate(project)
 
 Key points:
 - `public.include_dirs` propagates to targets that link against this library
-- Appending to `app.private.link_libs` adds libmath as a dependency and applies its public requirements. Use `private.link_libs` to keep the dependency local (as here, since `app` is the final program) or `public.link_libs` to re-export it to consumers of this target.
+- `app.link_private(libmath)` adds libmath as a dependency and applies its public requirements. Use `link_private()` to keep the dependency local (as here, since `app` is the final program) or `link()` to re-export it to consumers of this target.
 
-!!! note "Deprecated `target.link()`"
-    Earlier versions used `app.link(libmath)`. That method is deprecated; it is equivalent to `app.public.link_libs.append(libmath)`. Prefer appending to `public.link_libs` or `private.link_libs` directly, which lets you control propagation.
+!!! note "`link()` / `link_private()` vs. the `link_libs` lists"
+    `target.link(...)` and `target.link_private(...)` are the recommended high-level forms. They are exactly equivalent to appending to `target.public.link_libs` and `target.private.link_libs` respectively — those lists remain fully supported as the low-level form, and accept the same `Target` objects and library-name strings.
 
 ### Shared/Dynamic Library
 
@@ -714,7 +714,7 @@ libplugin.output_name = "myplugin.so"  # Override default libplugin.so
 # Create program that uses the library
 app = project.Program("host", env)
 app.add_sources([src_dir / "main.c"])
-app.private.link_libs.append(libplugin)
+app.link_private(libplugin)
 
 project.Default(app, libplugin)
 Generator().generate(project)
@@ -756,17 +756,17 @@ env = project.Environment(toolchain=toolchain)
 libmath = project.StaticLibrary("math", env)
 libmath.add_sources([src_dir / "math_utils.c"])
 libmath.public.include_dirs.append(include_dir)
-libmath.public.link_libs.append("m")  # Link math library
+libmath.link("m")  # Link math library
 
 # Library: libphysics - depends on libmath
 libphysics = project.StaticLibrary("physics", env)
 libphysics.add_sources([src_dir / "physics.c"])
-libphysics.public.link_libs.append(libmath)  # Re-exports libmath's includes to consumers
+libphysics.link(libmath)  # Re-exports libmath's includes to consumers
 
 # Program: simulator - main application
 simulator = project.Program("simulator", env)
 simulator.add_sources([src_dir / "main.c"])
-simulator.private.link_libs.append(libphysics)  # Gets BOTH physics and math includes!
+simulator.link_private(libphysics)  # Gets BOTH physics and math includes!
 
 # Set defaults and generate
 project.Default(simulator)
@@ -889,7 +889,7 @@ optional = project.find_package("optional-dep", required=False)
 
 # Use as a dependency (public requirements auto-propagate)
 app = project.Program("myapp", env, sources=["main.cpp"])
-app.private.link_libs.append(zlib)
+app.link_private(zlib)
 
 # Or apply directly to an environment
 env.use(openssl)
@@ -924,17 +924,17 @@ httplib = ImportedTarget.from_package(PackageDescription(
 ))
 ```
 
-If the manual package depends on another package, append it to `public.link_libs` to wire up transitive dependencies — don't copy public requirements manually:
+If the manual package depends on another package, `link()` it to wire up transitive dependencies — don't copy public requirements manually:
 
 ```python
 openssl = project.find_package("openssl")
 
 httplib = # ... see above
-httplib.public.link_libs.append(openssl)  # openssl requirements propagate to anything linking httplib
+httplib.link(openssl)  # openssl requirements propagate to anything linking httplib
 
 # Now any target that links httplib automatically gets openssl too
 app = project.Program("myapp", env, sources=["main.cpp"])
-app.private.link_libs.append(httplib)  # gets httplib AND openssl includes, libs, flags
+app.link_private(httplib)  # gets httplib AND openssl includes, libs, flags
 ```
 
 ### Using pkg-config
@@ -2355,7 +2355,7 @@ lib.add_sources(["src/mylib.c"])
 
 prog = project.Program("myapp", env)
 prog.add_sources(["src/main.c"])
-prog.private.link_libs.append(lib)
+prog.link_private(lib)
 
 # Force-load all symbols from the static library (macOS)
 prog.private.link_flags.append(
@@ -2901,10 +2901,12 @@ This is especially useful when porting CMake projects to pcons, since the templa
 |--------|-------------|
 | `target.add_source(path)` | Add a source file |
 | `target.add_sources(paths)` | Add multiple source files |
-| `target.public.link_libs.append(t)` | Link a dependency and re-export its public requirements |
-| `target.private.link_libs.append(t)` | Link a dependency, keeping its requirements local |
+| `target.link(t, "m")` | Link a dependency (or raw lib name) and re-export it to consumers |
+| `target.link_private(t, "m")` | Link a dependency (or raw lib name), keeping it local |
 | `target.add_dependency(t)` | Add a non-link build dependency |
 | `target.public.include_dirs` | Include dirs for consumers |
+| `target.public.link_libs.append(t)` | Low-level form of `link()` (append a `Target` or `-l` name) |
+| `target.private.link_libs.append(t)` | Low-level form of `link_private()` |
 | `target.public.link_libs` | Libraries to link (`-l`; placed after objects) |
 | `target.public.link_flags` | Linker flags (placed before objects; use `link_libs` for `-l` libraries). Use `PathToken` for flags containing paths. |
 | `target.public.defines` | Defines for consumers |

--- a/examples/05_multi_library/pcons-build.py
+++ b/examples/05_multi_library/pcons-build.py
@@ -33,7 +33,7 @@ libmath.add_sources(["src/math_utils.c"])
 libmath.public.include_dirs.append("include")
 # Link against libm for math functions (required on Linux, not needed on Windows)
 if sys.platform != "win32":
-    libmath.public.link_libs.append("m")
+    libmath.link("m")
 
 # -----------------------------------------------------------------------------
 # Library: libphysics - physics simulation, depends on libmath
@@ -43,18 +43,14 @@ libphysics.add_sources(["src/physics.c"])
 if sys.platform == "win32":
     # export symbols on Windows
     libphysics.private.defines.append("PHYSICS_BUILDING_DLL")
-libphysics.public.link_libs.append(
-    libmath
-)  # Gets libmath's public includes transitively
+libphysics.link(libmath)  # Gets libmath's public includes transitively
 
 # -----------------------------------------------------------------------------
 # Program: simulator - main application
 # -----------------------------------------------------------------------------
 simulator = project.Program("simulator", env)
 simulator.add_sources(["src/main.c"])
-simulator.private.link_libs.append(
-    libphysics
-)  # Gets both libphysics and libmath includes
+simulator.link_private(libphysics)  # Gets both libphysics and libmath includes
 
 # Generate dependency diagrams (after generate, which auto-resolves)
 mermaid_gen = MermaidGenerator(direction="LR")

--- a/examples/13_subdirs/app/pcons-build.py
+++ b/examples/13_subdirs/app/pcons-build.py
@@ -18,4 +18,4 @@ assert libfoo is not None, (
 
 app = project.Program("app", env)
 app.add_sources(["src/main.c"])
-app.public.link_libs.append(libfoo)
+app.link(libfoo)

--- a/examples/18_static_into_shared/pcons-build.py
+++ b/examples/18_static_into_shared/pcons-build.py
@@ -29,6 +29,8 @@ core_lib.public.include_dirs.append(src_dir)  # So dependents can #include "core
 
 # 2. Create shared library from wrapper.c, linking the static library
 #    wrapper.c includes "core.h" which should be found via core_lib's public includes
+# This example deliberately uses the low-level link_libs lists (the power form)
+# instead of link()/link_private(), to keep that API exercised in CI.
 wrapper_lib = project.SharedLibrary("wrapper", env, sources=[src_dir / "wrapper.c"])
 wrapper_lib.public.link_libs.append(core_lib)
 

--- a/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/a/pcons-build.py
@@ -8,4 +8,4 @@ a = project.StaticLibrary("a", env, sources=["a.cppm"])
 (aa,) = add_subdirectory("aa", pick=["aa"])
 
 a_app = project.Program("a_app", env, sources=["a_main.cpp"])
-a_app.private.link_libs.extend([a, aa])
+a_app.link_private(a, aa)

--- a/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/app/pcons-build.py
@@ -11,4 +11,4 @@ from pcons import context
 project = context.current_project
 env = project.default_environment
 app = project.Program("app", env, sources=["main.cpp"])
-app.private.link_libs.extend(context.get_targets("a", "aa", "b", "bb"))
+app.link_private(*context.get_targets("a", "aa", "b", "bb"))

--- a/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
+++ b/examples/36_cxx_modules_multi_level_subdirs/b/pcons-build.py
@@ -8,4 +8,4 @@ b = project.StaticLibrary("b", env, sources=["b.cppm"])
 s = add_subdirectory("bb")
 
 b_app = project.Program("b_app", env, sources=["b_main.cpp"])
-b_app.private.link_libs.extend([b, s.bb])
+b_app.link_private(b, s.bb)

--- a/examples/39_bmi_compat/pcons-build.py
+++ b/examples/39_bmi_compat/pcons-build.py
@@ -60,6 +60,6 @@ lib3.private.compile_flags.extend(breaker_dialect)
 # A program to prove the shared interface links and runs end to end.
 app = project.Program("app", env, sources=["main.cpp"])
 app.private.compile_flags.extend(shared_dialect)
-app.private.link_libs.append(lib1)
+app.link_private(lib1)
 
 project.generate()

--- a/examples/50_pyproject/pcons-build.py
+++ b/examples/50_pyproject/pcons-build.py
@@ -130,6 +130,9 @@ hello_lib.private.defines.append("HELLO_LIB_EXPORTS")
 # e.g. pcons_hello_ext.cpython-314-x86_64-linux-gnu.so
 pcons_hello_ext.output_prefix = ""
 pcons_hello_ext.output_suffix = sysconfig.get_config_var("EXT_SUFFIX")
+# Uses the low-level link_libs list rather than link_private(): this example
+# builds under PEP 517 isolation against the *released* pcons (see the note at
+# the top of this file), so it sticks to APIs available in the released version.
 pcons_hello_ext.private.link_libs.extend([python, nanobind, hello_lib])
 
 subgen = Path(nanobind.package.prefix) / "nanobind" / "stubgen.py"

--- a/pcons/_gen_stubs.py
+++ b/pcons/_gen_stubs.py
@@ -428,7 +428,7 @@ _USAGE_REQUIREMENT_TYPES: tuple[tuple[str, str, str | None], ...] = (
     (
         "link_libs",
         "MutableSequence[str | Target]",
-        "libraries propagated to dependents (names or Target objects)",
+        "link deps: a Target brings its public usage requirements (headers etc.); a str is a raw link token; public re-exports, private does not",
     ),
 )
 

--- a/pcons/core/_usage_requirements_stubs.py
+++ b/pcons/core/_usage_requirements_stubs.py
@@ -28,4 +28,4 @@ if TYPE_CHECKING:
         compile_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings, or PathToken for embedded paths)
         link_flags: MutableSequence[str | PathToken]  # flags propagated to dependents (strings, or PathToken for embedded paths)
         defines: MutableSequence[str]  # preprocessor defines propagated to dependents
-        link_libs: MutableSequence[str | Target]  # libraries propagated to dependents (names or Target objects)
+        link_libs: MutableSequence[str | Target]  # link deps: a Target brings its public usage requirements (headers etc.); a str is a raw link token; public re-exports, private does not

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -7,35 +7,12 @@ and carries "usage requirements" that propagate to consumers (CMake-style).
 
 from __future__ import annotations
 
-import functools
 import logging
 import re
-import sys
-import warnings
 from collections import UserList
-from collections.abc import Callable, Iterable, Sequence
+from collections.abc import Callable, Iterable, MutableSequence, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
-
-if sys.version_info >= (3, 13):
-    from warnings import deprecated
-else:
-
-    def deprecated(msg: str):  # type: ignore[no-redef]
-        def decorator(func):
-            @functools.wraps(func)
-            def wrapper(*args, **kwargs):
-                warnings.warn(
-                    f"{func.__name__} is deprecated: {msg}",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-                return func(*args, **kwargs)
-
-            return wrapper
-
-        return decorator
-
 
 from pcons.core.flags import merge_flags
 
@@ -104,6 +81,14 @@ class UsageRequirements(_UsageRequirementsStubs):
     define its own requirement names. C/C++ toolchains use include_dirs,
     defines, compile_flags, link_flags, link_libs. Other toolchains can
     use any names they need (e.g., python_packages, data_schemas).
+
+    The ``link_libs`` list is special: appending a ``Target`` creates a full
+    dependency (the owner inherits that target's public usage requirements —
+    headers, defines, transitive link libs — and links its output), while
+    appending a ``str`` adds only a raw link token (``"m"`` → ``-lm``) with
+    no usage requirements. As with all requirements, the ``public`` scope
+    re-exports to consumers; ``private`` does not. ``target.link(...)`` and
+    ``target.link_private(...)`` are the recommended high-level equivalents.
 
     A field may use a special list type (``UniqueList`` dedup, or
     ``ValidatedUniqueList`` whose ``on_append`` hook enforces invariants and
@@ -277,6 +262,16 @@ def _make_default_requirements(
     # usage requirements are merged. Direct appends are preserved verbatim.
     reqs.compile_flags = []
     reqs.link_flags = []
+    # link_libs is the link-dependency list. Entries are either:
+    #   - a Target: a full dependency — the owner inherits its PUBLIC usage
+    #     requirements (include_dirs/headers, defines, flags, transitive
+    #     link_libs) and links its output. NOT just a link-line entry.
+    #   - a str (e.g. "m"): a raw link token, formatted by the toolchain
+    #     (-lm / m.lib) and placed after objects. No usage requirements.
+    # Scope controls propagation: entries on target.public re-export to the
+    # target's consumers; entries on target.private stay local.
+    # target.link(...) / target.link_private(...) are the equivalent
+    # high-level API; this list is the low-level/power form.
     reqs.link_libs = ValidatedUniqueList([], on_append=link_libs_validator)
     return reqs
 
@@ -525,54 +520,134 @@ class Target:
         """All build nodes for this target (intermediate + output)."""
         return self.intermediate_nodes + self.output_nodes
 
-    def __link_libs_validator(self, target: Target):
+    def __link_libs_validator(self, item: Target | str):
         if self._resolved:
             raise RuntimeError(f"Cannot modify target '{self.name}' after resolve(). ")
-        if target is self:
+        if item is self:
             raise ValueError(f"Target '{self.name}' cannot link itself.")
         # Invalidate cached requirements
         self._collected_requirements = None
 
-    @deprecated("Use target.{public,private}.link_libs instead")
-    def link(self, *targets: Target) -> Target:
-        """Add targets as dependencies (fluent API).
+    def link(self, *libs: Target | str) -> Target:
+        """Add PUBLIC link dependencies (fluent API).
 
-        The dependencies' public usage requirements will be applied
-        when building this target.
+        Each ``Target`` argument becomes a full dependency, not just a link
+        line entry: when this target is built it inherits the dependency's
+        PUBLIC usage requirements — include_dirs (headers), defines, flags,
+        and transitive link_libs — and links against the dependency's
+        output. Because the dependency is added PUBLICLY, it is also
+        re-exported: anything that later links *this* target inherits it
+        too (like CMake's ``target_link_libraries(... PUBLIC ...)``). Use
+        :meth:`link_private` for implementation-only dependencies that
+        consumers should not see.
+
+        Each ``str`` argument is a raw library name (e.g. ``"m"``,
+        ``"pthread"``), formatted by the toolchain (``-lm``, ``m.lib``) and
+        placed after object files on the link line. A string brings no
+        usage requirements — no headers, no defines — it is just a link
+        token. Being public, it too propagates to consumers' link lines.
+
+        Equivalent to appending each argument to ``self.public.link_libs``;
+        the methods and the lists are interchangeable, the lists being the
+        low-level form. Duplicates are silently ignored; argument order is
+        preserved (link order can matter for static libraries).
 
         Args:
-            *targets: Targets to depend on.
+            *libs: Targets to depend on, and/or raw library-name strings.
 
         Returns:
-            self for method chaining.
+            self, for method chaining.
 
         Raises:
-            TypeError: If a non-Target argument is passed.
-            ValueError: If a target tries to link itself.
+            TypeError: If an argument is not a Target or str. Pass lists
+                unpacked: ``target.link(*libs)``, not ``target.link(libs)``.
+            ValueError: If a target links itself, or a library name is empty.
             RuntimeError: If called after the target has been resolved.
+
+        Example:
+            libmath = project.StaticLibrary("math", env, sources=["math.c"])
+            libmath.public.include_dirs.append("include")
+            libmath.link("m")  # consumers of libmath also get -lm
+
+            libphysics = project.SharedLibrary("physics", env, sources=["physics.c"])
+            libphysics.link(libmath)  # re-exports libmath (headers and all)
+
+            app = project.Program("app", env, sources=["main.c"])
+            app.link_private(libphysics)  # app gets physics + math + -lm
         """
+        return self._link_into(self.public.link_libs, libs, "link")
+
+    def link_private(self, *libs: Target | str) -> Target:
+        """Add PRIVATE link dependencies (fluent API).
+
+        Exactly like :meth:`link`, but the dependencies are NOT re-exported
+        to this target's consumers (like CMake's ``target_link_libraries(...
+        PRIVATE ...)``): a ``Target`` argument still brings its PUBLIC usage
+        requirements (headers, defines, transitive link_libs) into *this*
+        target's build, and a ``str`` argument is still a raw link token —
+        but targets that link this one inherit none of it. Use this for
+        implementation details; it is the right choice for programs, which
+        have no consumers.
+
+        Equivalent to appending each argument to ``self.private.link_libs``.
+
+        Note: a private dependency of a *static* library still reaches the
+        final program's link line (an archive does not contain its
+        dependencies), without propagating headers or defines.
+
+        Args:
+            *libs: Targets to depend on, and/or raw library-name strings.
+
+        Returns:
+            self, for method chaining.
+
+        Raises:
+            TypeError: If an argument is not a Target or str. Pass lists
+                unpacked: ``target.link_private(*libs)``.
+            ValueError: If a target links itself, or a library name is empty.
+            RuntimeError: If called after the target has been resolved.
+
+        Example:
+            core = project.StaticLibrary("core", env, sources=["core.c"])
+            core.link_private(zlib)  # core uses zlib; consumers never see zlib headers
+
+            app = project.Program("app", env, sources=["main.c"])
+            app.link_private(core, "pthread")
+        """
+        return self._link_into(self.private.link_libs, libs, "link_private")
+
+    def _link_into(
+        self,
+        link_libs: MutableSequence[Target | str],
+        libs: tuple[Target | str, ...],
+        method: str,
+    ) -> Target:
+        """Validate and append link dependencies; shared by link()/link_private()."""
         if self._resolved:
             raise RuntimeError(
                 f"Cannot modify target '{self.name}' after resolve(). "
-                f"Add link_libs before project.resolve() or project.generate()."
+                f"Add link dependencies before project.resolve() or project.generate()."
             )
-        for target in targets:
-            if isinstance(target, (list, tuple)):
+        for lib in libs:
+            if isinstance(lib, (list, tuple)):
                 raise TypeError(
-                    "link() takes Target arguments, not a list. "
-                    "Use target.link(a, b) instead of target.link([a, b])."
+                    f"{method}() takes individual arguments, not a list. "
+                    f"Use target.{method}(a, b) or target.{method}(*libs)."
                 )
-            if not isinstance(target, Target):
+            if not isinstance(lib, (Target, str)):
                 raise TypeError(
-                    f"link() requires Target objects, got {type(target).__name__}. "
-                    f"Use project.get_target(name) to look up a target by name."
+                    f"{method}() requires Target objects or library-name strings, "
+                    f"got {type(lib).__name__}. Pass a Target to depend on it "
+                    f"(bringing its headers and usage requirements), or a string "
+                    f"like 'm' for a raw system library."
                 )
-            if target is self:
+            if isinstance(lib, str) and not lib.strip():
+                raise ValueError(f"{method}() got an empty library name.")
+            if lib is self:
                 raise ValueError(f"Target '{self.name}' cannot link itself.")
-            if target not in self.public.link_libs:
-                self.public.link_libs.append(target)
-        # Invalidate cached requirements
-        self._collected_requirements = None
+            link_libs.append(
+                lib
+            )  # ValidatedUniqueList: validates, de-dupes, invalidates cache
         return self
 
     def add_dependency(self, *targets: Target) -> Target:
@@ -581,8 +656,8 @@ class Target:
         Each becomes a full dependency: it is included in
         ``transitive_dependencies()`` and ``dependencies``, so its public
         usage requirements propagate here. Unlike ``link_libs``, this does not
-        treat the targets as libraries to link, use ``target.{public,private}
-        .link_libs`` for that. Duplicates are ignored.
+        treat the targets as libraries to link, use ``target.link()`` /
+        ``target.link_private()`` for that. Duplicates are ignored.
 
         Args:
             *targets: Targets to depend on.

--- a/pcons/core/target.py
+++ b/pcons/core/target.py
@@ -957,17 +957,20 @@ class Target:
         return result
 
     def _collect_from_deps(self, result: UsageRequirements, visited: set[str]) -> None:
-        """Recursively collect public requirements from dependencies."""
+        """Merge public requirements from all transitive dependencies.
+
+        ``transitive_dependencies()`` already returns the full public-edge
+        closure (a private dep of a dependency is not re-exported), so we
+        simply merge each one's public requirements. We must NOT recurse via
+        ``dep._collect_from_deps`` here: that re-enters each dependency at its
+        own top level, where its *private* link_libs are followed, which would
+        leak private dependencies' headers up to consumers.
+        """
         for dep in self.transitive_dependencies():
             if dep.qualified_name in visited:
                 continue
             visited.add(dep.qualified_name)
-
-            # Merge this dependency's public requirements
             result.merge(dep.public)
-
-            # Recursively get transitive requirements
-            dep._collect_from_deps(result, visited)
 
     def get_all_languages(self) -> set[str]:
         """Get all languages required by this target and its dependencies.

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -619,13 +619,40 @@ class TestFluentAPI:
     def test_link_private_not_reexported(self, test_project):  # noqa: F811
         """A private link dependency is not re-exported (mirrors line 233)."""
         leaf = Target("leaf")
+        leaf.public.include_dirs.append(Path("leaf_inc"))
         mid = Target("mid")
         mid.link_private(leaf)  # private
         app = Target("app")
         app.link_private(mid)
 
-        # Usage-requirement propagation must not pull leaf in through mid.
+        # Neither the dependency graph nor the propagated usage requirements
+        # may pull leaf in through mid's private edge.
         assert leaf not in app.transitive_dependencies()
+        assert Path("leaf_inc") not in app.collect_usage_requirements().include_dirs
+
+    def test_private_deps_do_not_leak_headers_up_the_chain(self, test_project):  # noqa: F811
+        """A private dependency's public headers must not propagate to a
+        consumer at any distance.
+
+        Regression test: usage-requirement collection used to re-enter each
+        dependency at its own top level (following that dep's *private*
+        link_libs), leaking a private dependency's public include dirs
+        unboundedly up the consumer chain.
+        """
+        leaf = Target("leaf")
+        leaf.public.include_dirs.append(Path("leaf_inc"))
+        mid = Target("mid")
+        mid.link_private(leaf)  # leaf is mid's private implementation detail
+        app = Target("app")
+        app.link(mid)  # public
+        top = Target("top")
+        top.link(app)  # public, two levels above the private edge
+
+        # mid uses leaf, so mid itself sees leaf's headers...
+        assert Path("leaf_inc") in mid.collect_usage_requirements().include_dirs
+        # ...but no consumer of mid does, at any distance.
+        assert Path("leaf_inc") not in app.collect_usage_requirements().include_dirs
+        assert Path("leaf_inc") not in top.collect_usage_requirements().include_dirs
 
     def test_add_source_returns_self(self, tmp_path, test_project):  # noqa: F811
         """add_source() returns self for chaining."""

--- a/tests/core/test_target.py
+++ b/tests/core/test_target.py
@@ -458,9 +458,7 @@ class TestFluentAPI:
         lib = Target("lib")
         app = Target("app")
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            result = app.link(lib)
+        result = app.link(lib)
 
         assert result is app
         assert lib in app.dependencies
@@ -470,12 +468,164 @@ class TestFluentAPI:
         lib = Target("lib")
         app = Target("app")
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            app.link(lib)
-            app.link(lib)  # same lib again — must be ignored
+        app.link(lib)
+        app.link(lib)  # same lib again — must be ignored
 
         assert app.public.link_libs.count(lib) == 1
+
+    def test_link_emits_no_warning(self, test_project):  # noqa: F811
+        """link() is no longer deprecated: no warning on call."""
+        lib = Target("lib")
+        app = Target("app")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            app.link(lib)
+
+        assert lib in app.public.link_libs
+
+    def test_link_private_appends_to_private_not_public(self, test_project):  # noqa: F811
+        """link_private() targets go to private.link_libs only."""
+        lib = Target("lib")
+        app = Target("app")
+
+        app.link_private(lib)
+
+        assert lib in app.private.link_libs
+        assert lib not in app.public.link_libs
+
+    def test_link_accepts_string(self, test_project):  # noqa: F811
+        """link() accepts raw library-name strings."""
+        app = Target("app")
+
+        app.link("m")
+
+        assert "m" in app.public.link_libs
+
+    def test_link_private_accepts_string(self, test_project):  # noqa: F811
+        """link_private() accepts raw library-name strings."""
+        app = Target("app")
+
+        app.link_private("m")
+
+        assert "m" in app.private.link_libs
+
+    def test_link_mixed_targets_and_strings(self, test_project):  # noqa: F811
+        """link() preserves argument order for mixed targets/strings."""
+        lib = Target("lib")
+        lib2 = Target("lib2")
+        app = Target("app")
+
+        app.link(lib, "m", lib2)
+
+        assert list(app.public.link_libs) == [lib, "m", lib2]
+
+    def test_link_private_returns_self_and_chains(self, test_project):  # noqa: F811
+        """link()/link_private() chain, both returning self."""
+        a = Target("a")
+        b = Target("b")
+        app = Target("app")
+
+        assert app.link(a).link_private(b) is app
+
+    def test_link_string_dedup(self, test_project):  # noqa: F811
+        """A repeated string library name is de-duped."""
+        app = Target("app")
+
+        app.link("m")
+        app.link("m")
+
+        assert app.public.link_libs.count("m") == 1
+
+    def test_link_private_rejects_list(self, test_project):  # noqa: F811
+        """link_private() rejects a list argument with TypeError."""
+        lib = Target("lib")
+        app = Target("app")
+
+        with pytest.raises(TypeError):
+            app.link_private([lib])
+
+    def test_link_rejects_bad_type(self, test_project):  # noqa: F811
+        """link() rejects non-Target, non-str arguments."""
+        app = Target("app")
+
+        with pytest.raises(TypeError):
+            app.link(42)
+        with pytest.raises(TypeError):
+            app.link(Path("libfoo.a"))
+
+    def test_link_rejects_empty_string(self, test_project):  # noqa: F811
+        """link() rejects empty/whitespace-only library names."""
+        app = Target("app")
+
+        with pytest.raises(ValueError):
+            app.link("")
+        with pytest.raises(ValueError):
+            app.link("  ")
+
+    def test_link_rejects_self(self, test_project):  # noqa: F811
+        """link() rejects linking a target against itself."""
+        app = Target("app")
+
+        with pytest.raises(ValueError):
+            app.link(app)
+
+    def test_link_private_rejects_self(self, test_project):  # noqa: F811
+        """link_private() rejects linking a target against itself."""
+        app = Target("app")
+
+        with pytest.raises(ValueError):
+            app.link_private(app)
+
+    def test_link_after_resolve_raises(self, test_project):  # noqa: F811
+        """link() after resolve() raises RuntimeError."""
+        lib = Target("lib")
+        app = Target("app")
+        app._resolved = True
+
+        with pytest.raises(RuntimeError):
+            app.link(lib)
+
+    def test_link_private_after_resolve_raises(self, test_project):  # noqa: F811
+        """link_private() after resolve() raises RuntimeError."""
+        lib = Target("lib")
+        app = Target("app")
+        app._resolved = True
+
+        with pytest.raises(RuntimeError):
+            app.link_private(lib)
+
+    def test_link_target_brings_usage_requirements(self, test_project):  # noqa: F811
+        """A linked Target brings its public usage requirements."""
+        lib = Target("lib")
+        lib.public.include_dirs.append(Path("include"))
+        app = Target("app")
+
+        app.link_private(lib)
+
+        assert Path("include") in app.collect_usage_requirements().include_dirs
+
+    def test_link_public_reexports_to_consumers(self, test_project):  # noqa: F811
+        """A public link dependency propagates to consumers (mirrors line 219)."""
+        leaf = Target("leaf")
+        mid = Target("mid")
+        mid.link(leaf)  # public
+        app = Target("app")
+        app.link_private(mid)
+
+        # leaf is re-exported through mid's public scope.
+        assert leaf in app.transitive_dependencies()
+
+    def test_link_private_not_reexported(self, test_project):  # noqa: F811
+        """A private link dependency is not re-exported (mirrors line 233)."""
+        leaf = Target("leaf")
+        mid = Target("mid")
+        mid.link_private(leaf)  # private
+        app = Target("app")
+        app.link_private(mid)
+
+        # Usage-requirement propagation must not pull leaf in through mid.
+        assert leaf not in app.transitive_dependencies()
 
     def test_add_source_returns_self(self, tmp_path, test_project):  # noqa: F811
         """add_source() returns self for chaining."""
@@ -540,9 +690,7 @@ class TestFluentAPI:
         src = tmp_path / "main.c"
         src.touch()
 
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", category=DeprecationWarning)
-            result = app.add_source(src).link(lib)
+        result = app.add_source(src).link(lib)
 
         assert result is app
         assert len(app.sources) == 1

--- a/tests/packages/test_imported.py
+++ b/tests/packages/test_imported.py
@@ -217,11 +217,12 @@ class TestImportedTarget:
                 defines=["CPPHTTPLIB_OPENSSL_SUPPORT"],
             )
         )
-        httplib.public.link_libs.append(openssl)
+        # ImportedTarget inherits link(); exercise it directly.
+        httplib.link(openssl)
 
         # A target that links httplib should get openssl transitively
         app = Target("app")
-        app.private.link_libs.append(httplib)
+        app.link_private(httplib)
 
         reqs = app.collect_usage_requirements()
         # httplib's own requirements

--- a/tests/test_user_errors.py
+++ b/tests/test_user_errors.py
@@ -10,6 +10,7 @@ These serve as both regression tests for existing good errors and a
 roadmap for future error handling improvements.
 """
 
+import warnings
 from pathlib import Path
 
 import pytest
@@ -65,22 +66,28 @@ class TestWrongArgumentTypes:
         with pytest.raises(TypeError, match="name"):
             project.Program(123, env, sources=["src/main.c"])
 
-    def test_link_string_instead_of_target(self, project_env):
-        """User passes a string library name instead of a Target object."""
+    def test_link_accepts_string_library(self, project_env):
+        """A string library name is a valid link() argument (raw link token)."""
         project, env = project_env
         app = project.Program("app", env, sources=["src/main.c"])
-        with (
-            pytest.raises(TypeError, match="[Tt]arget"),
-            pytest.warns(DeprecationWarning, match="link"),
-        ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             app.link("mylib")
+        assert "mylib" in app.public.link_libs
+
+    def test_link_non_target_non_string(self, project_env):
+        """A non-Target, non-str argument to link() is a TypeError."""
+        project, env = project_env
+        app = project.Program("app", env, sources=["src/main.c"])
+        with pytest.raises(TypeError):
+            app.link(42)
 
     def test_link_list_instead_of_varargs(self, project_env):
         """User passes a list instead of unpacking: link([a, b]) vs link(a, b)."""
         project, env = project_env
         lib = project.StaticLibrary("mylib", env, sources=["src/lib.c"])
         app = project.Program("app", env, sources=["src/main.c"])
-        with pytest.raises(TypeError), pytest.warns(DeprecationWarning, match="link"):
+        with pytest.raises(TypeError):
             app.link([lib])
 
     def test_add_sources_string_not_list(self, project_env):
@@ -372,13 +379,15 @@ class TestDependencyMistakes:
         # Should not crash and lib should appear only once
         assert app.dependencies.count(lib) == 1
 
-    def test_link_now_deprecated(self, project_env):
-        """Using the old link() method should raise a DeprecationWarning."""
+    def test_link_not_deprecated(self, project_env):
+        """link() is a first-class API and must not emit any warning."""
         project, env = project_env
         lib = project.StaticLibrary("mylib", env, sources=["src/lib.c"])
         app = project.Program("app", env, sources=["src/main.c"])
-        with pytest.warns(DeprecationWarning, match="link"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             app.link(lib)
+        assert lib in app.public.link_libs
 
 
 # =============================================================================


### PR DESCRIPTION
Reworks the target-linking API for ergonomics and clarity, and fixes a pre-existing usage-requirement propagation bug that this work surfaced. Two commits.

## 1. Un-deprecate `link()`, add `link_private()`

`target.link()` was deprecated (PR #41) in favor of `target.public.link_libs.append(...)`. But `link()` is short, memorable, and matches CMake's plain `target_link_libraries` (public/transitive by default), whereas `x.private.link_libs.append(lib)` *looks like* an inert list mutation while actually wiring a full dependency (headers, defines, transitive link libs). So:

- **`link(*libs)` is un-deprecated** — the recommended way to add a PUBLIC link dependency (re-exported to consumers).
- **`link_private(*libs)` is new** — the private counterpart (this target compiles/links against the dependency; consumers inherit nothing). Replaces the awkward `private.link_libs.append(...)` idiom.
- **Both accept Targets *and* raw strings**: `app.link(mylib, "m")`. A Target brings usage requirements; a string is a raw link token (`-lm`).
- The `public.link_libs` / `private.link_libs` lists remain fully supported as the low-level form, now **documented in-code** so it's clear that appending a Target pulls in usage requirements.

Deletes the orphaned `deprecated` shim + unused imports. Updates CHANGELOG, user-guide, porting-from-cmake, ARCHITECTURE, and examples (scope-preserving); `examples/18` deliberately stays on the low-level list form for continued CI coverage. 20 new/updated tests.

## 2. Fix unbounded leak of private deps' headers to consumers

Writing an honest `link_private()` docstring surfaced that the guarantee wasn't true for headers: `mid.link_private(leaf)` re-exported `leaf`'s public include dirs to **everything that linked `mid`**, unbounded up the chain.

Root cause: `_collect_from_deps` did a redundant double-traversal — iterating the already-transitive `transitive_dependencies()` *and* recursing per-dependency, which re-entered each dep at its own top level where its *private* link_libs get followed. The link *graph* was always correct; only usage-requirement propagation leaked. `transitive_dependencies()` is already the complete public-edge closure, so the extra recursion is dropped. Includes a multi-level regression test.

## Testing

- 2134 unit tests pass; stubs verified in sync.
- 57 example integration tests pass. The 2 `50_pyproject` failures on macOS are a pre-existing environmental dyld error (`libpython3.12.dylib` when `uv` builds the example's isolated venv, before pcons runs) — reproduces on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)